### PR TITLE
add script to download and extract node-obs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,14 @@ Node OBS is our (deprecated) C++ Node module that provides a javascript
 interface to OBS.  For SLOBS to start properly, it needs to
 find a built version of node OBS at `./node-obs`.
 
-You will have to clone and do the compilation yourself.
-Instructions can be found here:
+The easiest way to get this is to simply run the command:
+```
+yarn install-node-obs
+```
 
+This will download the current release and extract it.
+
+If you wish to compile it yourself, instructions can be found here:
 https://github.com/stream-labs/node-obs
 
 ### Yarn

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   - git submodule update --init --recursive
-  - git clone https://github.com/stream-labs/node-obs-prebuild.git node-obs
+  - yarn install-node-obs
   - yarn install
   - yarn ci:compile
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ environment:
 
 install:
   - git submodule update --init --recursive
-  - yarn install-node-obs
   - yarn install
+  - yarn install-node-obs
   - yarn ci:compile
 
 test_script:

--- a/bin/install-node-obs.js
+++ b/bin/install-node-obs.js
@@ -1,0 +1,49 @@
+/**
+ * This script downloads and exctracts the specified release of node-obs
+ */
+
+const NODE_OBS_VERSION = '0.1.22';
+
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const childProcess = require('child_process');
+const rimraf = require('rimraf');
+
+const archivePath = path.join(os.tmpdir(), `node-obs-${NODE_OBS_VERSION}.zip`);
+const archive = fs.createWriteStream(archivePath);
+
+const zipExe = path.resolve(__dirname, '..', 'node_modules', '7zip-bin-win', 'x64', '7za.exe');
+const slobsDir = path.resolve(__dirname, '..');
+
+const continuePromise = new Promise(resolve => {
+  const nodeObsPath = path.join(slobsDir, 'node-obs');
+
+  if (fs.existsSync(nodeObsPath)) {
+    rimraf(nodeObsPath, resolve);
+  } else {
+    resolve();
+  }
+});
+
+continuePromise.then(() => {
+  const releaseUrl = `https://github.com/stream-labs/node-obs/releases/download/v${NODE_OBS_VERSION}/node-obs.zip`;
+
+  archive.on('finish', () => {
+    childProcess.exec(`${zipExe} x "${archivePath}" -o"${slobsDir}"`, (error, stdout, stderr) => {
+        if (error) {
+          console.error(`Extraction error: ${error}`);
+          return;
+        }
+
+        console.log(stdout);
+        console.log(stderr);
+    });
+  });
+
+  https.get(releaseUrl, response => {
+    // Follow redirect
+    https.get(response.headers.location, response => response.pipe(archive));
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ci:compile": "yarn clear && webpack",
     "watch": "yarn clear && webpack --watch --progress",
     "start": "electron .",
+    "install-node-obs": "node bin/install-node-obs.js && yarn install-plugins",
     "rebuild-node-obs": "cd ../node-obs/ && cmake-js build --runtime electron --runtime-version 1.7.7 && rm -rf ../streamlabs-obs/node-obs/ && cp -r ./build/distribute/node-obs/ ../streamlabs-obs/ && cd ../streamlabs-obs && node_modules/7zip-bin-win/x64/7za.exe x plugins/obs-browser-2987-old.7z -onode-obs/",
     "install-plugins": "node_modules/7zip-bin-win/x64/7za.exe x plugins/obs-browser-2987-old.7z -onode-obs/",
     "package": "rm -rf dist && build -w --x64 --em.env=production",


### PR DESCRIPTION
This will allow us to get rid of the node-obs-prebuild repo.  This simple command can be used to download and extract the currently pegged release of node-obs.  This should be the standard way people (and CI) consume node-obs for the time being.  The few people who need to compile node-obs can continue with their current workflow.

This also means that starting now, no code should hit staging that relies on unreleased functionality in node-obs.  On staging and master, the version specified in the install script is expected to work properly.