### PR TITLE
avoid a possible exit crash

### DIFF
--- a/main.js
+++ b/main.js
@@ -327,7 +327,7 @@ ipcMain.on('vuex-mutation', (event, mutation) => {
     const windowId = senderWindow.id;
 
     _.each(_.omit(registeredStores, [windowId]), win => {
-      win.webContents.send('vuex-mutation', mutation);
+      if (!win.isDestroyed()) win.webContents.send('vuex-mutation', mutation);
     });
   }
 });

--- a/main.js
+++ b/main.js
@@ -321,13 +321,16 @@ ipcMain.on('vuex-register', event => {
 
 // Proxy vuex-mutation events to all other subscribed windows
 ipcMain.on('vuex-mutation', (event, mutation) => {
-  let windowId = BrowserWindow.fromWebContents(event.sender).id;
+  const senderWindow = BrowserWindow.fromWebContents(event.sender);
 
-  _.each(_.omit(registeredStores, [windowId]), win => {
-    win.webContents.send('vuex-mutation', mutation);
-  });
+  if (senderWindow && !senderWindow.isDestroyed()) {
+    const windowId = senderWindow.id;
+
+    _.each(_.omit(registeredStores, [windowId]), win => {
+      win.webContents.send('vuex-mutation', mutation);
+    });
+  }
 });
-
 
 
 // Handle service initialization


### PR DESCRIPTION
Just hit this exit crash.  It's due to a race condition where a vuex mutation comes through as the browser windows are being destroy.  I think we may eventually want to write a small ipc wrapper for use in the main process that checks if a window still exists before sending an event to it.  It seems like there are all sorts of race conditions surrounding IPC and destroyed windows, all of which cause unhandled JS exceptions.