### PR TITLE
use app urls for module resolution, move sources into directory

### DIFF
--- a/app/services/sources/index.ts
+++ b/app/services/sources/index.ts
@@ -6,16 +6,16 @@ import {
   getPropertiesFormData,
   setPropertiesFormData,
   setupSourceDefaults
-} from '../components/shared/forms/Input';
-import { StatefulService, mutation, ServiceHelper } from './stateful-service';
-import * as obs from '../../obs-api';
+} from 'components/shared/forms/Input';
+import { StatefulService, mutation, ServiceHelper } from 'services/stateful-service';
+import * as obs from '../../../obs-api';
 import electron from 'electron';
-import Utils from './utils';
-import { ScenesService, ISceneItem } from './scenes';
-import { Inject } from '../util/injector';
-import namingHelpers from '../util/NamingHelpers';
-import { WindowsService } from './windows';
-import { WidgetType } from './widgets';
+import Utils from 'services/utils';
+import { ScenesService, ISceneItem } from 'services/scenes';
+import { Inject } from 'util/injector';
+import namingHelpers from 'util/NamingHelpers';
+import { WindowsService } from 'services/windows';
+import { WidgetType } from 'services/widgets';
 
 const { ipcRenderer } = electron;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": [
       "dom",
       "es7",
-      "ES2017"
+      "es2017"
     ],
     "module": "es2015",
     "moduleResolution": "node",
@@ -21,7 +21,8 @@
     "sourceMap": true,
     "allowJs": false,
     "strictNullChecks": false,
-    "emitDecoratorMetadata": true
+    "emitDecoratorMetadata": true,
+    "baseUrl": "./app"
   },
   "exclude": [
     "node_modules"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const CircularDependencyPlugin = require('circular-dependency-plugin');
+const path = require('path');
 
 const plugins = [];
 
@@ -28,7 +29,8 @@ module.exports = {
   target: 'electron-renderer',
 
   resolve: {
-    extensions: ['.js', '.ts']
+    extensions: ['.js', '.ts'],
+    modules: [path.resolve(__dirname, 'app'), 'node_modules']
   },
 
   // We want to dynamically require native addons


### PR DESCRIPTION
This PR started because I wanted to move the sources service from a single file to a directory.  I realized that our use of relative paths for everything makes this very annoying.  So I changed our webpack and tsconfig to allow us to load files relative to the `app` directory instead.  This means we can move files around in the directory structure without breaking imports.  We should do this from now on instead of using relative paths.

There are a number of ways to achieve this effect.  The way I have it set up here seems to preserve all intellisense, click-to-definition etc in VSCode.  @holiber Can you please check in your IDE to make sure this change doesn't impact your workflow?