### PR TITLE
distribute updates via AWS Cloudfront

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,8 @@
             ],
             "cwd": "${workspaceRoot}",
             "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-            "envFile": "${workspaceRoot}/.env"
+            "envFile": "${workspaceRoot}/.env",
+            "outputCapture": "std"
         }
     ]
 }

--- a/bin/deploy.js
+++ b/bin/deploy.js
@@ -37,7 +37,7 @@ const channelFileName = `${channel}.yml`;
 const channelFilePath = path.join(distDir, channelFileName);
 
 if (!fs.existsSync(channelFilePath)) {
-  err(`Could not find ${path.resolve(chanelFilePath)}`);
+  err(`Could not find ${path.resolve(channelFilePath)}`);
   exitErr();
 }
 

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,2 +1,2 @@
 provider: generic
-url: 'https://s3-us-west-2.amazonaws.com/streamlabs-obs'
+url: 'https://d1g6eog1uhe0xm.cloudfront.net'

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     ],
     "publish": {
       "provider": "generic",
-      "url": "https://s3-us-west-2.amazonaws.com/streamlabs-obs"
+      "url": "https://d1g6eog1uhe0xm.cloudfront.net"
     }
   },
   "ava": {


### PR DESCRIPTION
Some of our European users have been complaining about slow downloads.

Eventually we should move to NSIS delta updates (newly support by electron-builder), but this is something we can do easily for now.