### PR TITLE
Move to backtrace.io

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -19,17 +19,30 @@ const { ipcRenderer, remote } = electron;
 const slobsVersion = remote.process.env.SLOBS_VERSION;
 
 if (remote.process.env.NODE_ENV === 'production') {
-  const bugsplat = require('bugsplat')('slobs', 'slobs-renderer', slobsVersion);
-  window.onerror = (messageOrEvent, source, lineno, colno, error) => bugsplat.post(error);
+  const bt = require('backtrace-node');
+
+  bt.initialize({
+    endpoint: 'https://streamlabs.sp.backtrace.io:6098',
+    token: 'e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
+    attributes: {
+      version: slobsVersion,
+      processType: 'renderer'
+    }
+  });
+
+  window.onerror = (messageOrEvent, source, lineno, colno, error) => bt.report(error);
 }
 
 electron.crashReporter.start({
-  companyName: 'Streamlabs',
-  productName: 'Streamlabs OBS',
-  submitURL: 'http://slobs.bugsplat.com/post/bp/crash/postBP.php',
+  productName: 'streamlabs-obs',
+  companyName: 'streamlabs',
+  submitURL: 
+    'https://streamlabs.sp.backtrace.io:6098/post?' +
+    'format=minidump&' +
+    'token=e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
   extra: {
-    prod: 'slobs-renderer',
-    key: slobsVersion
+    version: slobsVersion,
+    processType: 'renderer'
   }
 });
 

--- a/main.js
+++ b/main.js
@@ -21,10 +21,9 @@ const obs = require(inAsar ? '../../node-obs' : './node-obs');
 const { Updater } = require('./updater/Updater.js');
 const uuid = require('uuid/v4');
 const rimraf = require('rimraf');
-const bugsplat = require('bugsplat')('slobs', 'slobs-main', pjson.version);
+const bt = require('backtrace-node')
 
-function handleUnhandledException() {
-  // We recommend you quit your application if an uncaughtException occurs
+function handleFinishedReport() {
   dialog.showErrorBox(`Unhandled Exception`,
   'An unexpected error occured and the application must be shut down.\n' +
   'Information concerning this occasion has been sent for debugging purposes.\n' +
@@ -36,19 +35,34 @@ function handleUnhandledException() {
   }
 }
 
+function handleUnhandledException(err) {
+  bt.report(err, {}, handleFinishedReport);
+}
+
 if (pjson.env === 'production') {
-  process.on("uncaughtException", bugsplat.post);
-  bugsplat.setCallback(handleUnhandledException);
-  ipcMain.on('rendererCrash', handleUnhandledException);
+  bt.initialize({
+    disableGlobalHandler: true,
+    endpoint: 'https://streamlabs.sp.backtrace.io:6098',
+    token: 'e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
+    attributes: {
+      version: pjson.version,
+      processType: 'main'
+    }
+  });
+
+  process.on("uncaughtException", handleUnhandledException);
 }
 
 crashReporter.start({
-  companyName: 'Streamlabs',
-  productName: 'Streamlabs OBS',
-  submitURL: 'http://slobs.bugsplat.com/post/bp/crash/postBP.php',
+  productName: 'streamlabs-obs',
+  companyName: 'streamlabs',
+  submitURL: 
+    'https://streamlabs.sp.backtrace.io:6098/post?' +
+    'format=minidump&' +
+    'token=e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
   extra: {
-    prod: 'slobs-main',
-    key: pjson.version
+    version: pjson.version,
+    processType: 'main'
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "archiver": "^2.0.3",
     "asar": "^0.13.0",
     "aws-sdk": "^2.43.0",
-    "bugsplat": "^2.1.5",
+    "backtrace-node": "^0.7.3",
     "electron-updater": "^1.14.0",
     "font-manager": "^0.2.2",
     "lodash": "^4.17.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,7 +40,8 @@ module.exports = {
     // Not actually a native addons, but are super big so we don't
     // bother compiling them into our bundle.
     'aws-sdk': 'require("aws-sdk")',
-    'asar': 'require("asar")'
+    'asar': 'require("asar")',
+    'backtrace-node': 'require("backtrace-node")'
   },
 
   module: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,16 +93,16 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.1.tgz#b683eb60be358304ef146f5775db4c0e3696a550"
 
 "@types/node@*":
-  version "8.0.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.34.tgz#55f801fa2ddb2a40dd6dfc15ecfe1dde9c129fe9"
+  version "8.0.48"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.48.tgz#4e7da6e849d9e50be5865effaa55b1870ae4eede"
 
 "@types/node@^7.0.18":
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
 "@types/shelljs@^0.7.2":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.4.tgz#137b5f31306eaff4de120ffe5b9d74b297809cfc"
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.5.tgz#5834fb7385d1137bd2be5842f2c278ac36a117f4"
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
@@ -1203,6 +1203,14 @@ babylon@^6.11.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
+backtrace-node@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/backtrace-node/-/backtrace-node-0.7.3.tgz#cdc0d1f89f45a1d30fb3b77a2311947eea339e08"
+  dependencies:
+    pend "~1.2.0"
+    source-scan "~1.0.1"
+    streamsink "~1.2.0"
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -1410,12 +1418,6 @@ buffer@4.9.1, buffer@^4.3.0:
 buffers@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
-
-bugsplat@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/bugsplat/-/bugsplat-2.1.5.tgz#b9289094d77cb8f127739e876b67f1435f9aa04f"
-  dependencies:
-    request "^2.81.0"
 
 builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
@@ -4569,17 +4571,17 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-minipass@^2.0.0, minipass@^2.0.2:
+minipass@^2.0.2, minipass@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.2.1.tgz#5ada97538b1027b4cf7213432428578cb564011f"
   dependencies:
     yallist "^3.0.0"
 
 minizlib@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.0.3.tgz#d5c1abf77be154619952e253336eccab9b2a32f5"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.0.4.tgz#8ebb51dd8bbe40b0126b5633dbb36b284a2f523c"
   dependencies:
-    minipass "^2.0.0"
+    minipass "^2.2.1"
 
 mkdirp@0.5, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -6125,8 +6127,8 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
 simple-git@^1.74.1:
-  version "1.79.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.79.0.tgz#5d4402dbae48d1f91b3c1862f080abada33ef130"
+  version "1.80.1"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.80.1.tgz#48104cb4ac72576937853e1afd1eeffdc97acb29"
   dependencies:
     debug "^2.6.7"
 
@@ -6227,6 +6229,12 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, sour
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
+source-scan@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/source-scan/-/source-scan-1.0.1.tgz#0ba9f8c2a9356f9531a65beb48b7bb376504e97b"
+  dependencies:
+    streamsink "~1.2.0"
+
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -6307,6 +6315,10 @@ stream-http@^2.3.1:
     readable-stream "^2.1.0"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+streamsink@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/streamsink/-/streamsink-1.2.0.tgz#efafee9f1e22d3591ed7de3dcaa95c3f5e79f73c"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Backtrace has a better interface and more feature (such as better analytics, explicit support for custom attributes, and various others). It also already includes Windows and Electron symbol servers and we can add our own as well. 

Note that yarn.lock has been updated to reflect the bugsplat packaged removed and the backtrace-node package added.
