### PR TITLE
Streamlabels trains/combos

### DIFF
--- a/app/components/custom-source-properties/StreamlabelProperties.vue
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue
@@ -148,6 +148,19 @@
         @input="debouncedSetSettings"/>
     </div>
   </div>
+  <div class="input-container" v-if="labelSettings.include_resubs != null">
+    <div class="input-label">
+    </div>
+    <div class="input-wrapper">
+      <div class="checkbox">
+        <input
+          type="checkbox"
+          v-model="labelSettings.include_resubs"
+          @change="debouncedSetSettings"/>
+        <label>Include Resubs</label>
+      </div>
+    </div>
+  </div>
   <div class="input-container" v-if="labelSettings.format != null">
     <div class="input-label">
       <label>Preview</label>

--- a/app/components/custom-source-properties/StreamlabelProperties.vue
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue
@@ -15,7 +15,7 @@
         @input="handleInput"/>
     </div>
   </div>
-  <div class="input-container">
+  <div class="input-container" v-if="labelSettings.format != null">
     <div class="input-label">
       <label>Label Template</label>
     </div>
@@ -86,7 +86,7 @@
         @input="debouncedSetSettings"/>
     </div>
   </div>
-  <div class="input-container">
+  <div class="input-container" v-if="labelSettings.format != null">
     <div class="input-label">
       <label>Preview</label>
     </div>

--- a/app/components/custom-source-properties/StreamlabelProperties.vue
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue
@@ -86,6 +86,68 @@
         @input="debouncedSetSettings"/>
     </div>
   </div>
+  <div class="input-container" v-if="labelSettings.duration != null">
+    <div class="input-label">
+      <label>Duration (seconds)</label>
+    </div>
+    <div class="input-wrapper">
+      <input
+        type="text"
+        v-model="labelSettings.duration"
+        @input="debouncedSetSettings"/>
+    </div>
+  </div>
+  <div class="input-container select" v-if="labelSettings.show_clock != null">
+    <div class="input-label">
+      <label>Show Clock</label>
+    </div>
+    <div class="input-wrapper">
+      <multiselect
+        :options="['always', 'active']"
+        :custom-label="val => {
+          return val === 'always' ?
+            'Always, show 0:00 when inactive' :
+            'Hide when inactive';
+        }"
+        :allow-empty="false"
+        v-model="labelSettings.show_clock"
+        @input="debouncedSetSettings"/>
+    </div>
+  </div>
+  <div class="input-container select" v-if="labelSettings.show_count != null">
+    <div class="input-label">
+      <label>Show Count</label>
+    </div>
+    <div class="input-wrapper">
+      <multiselect
+        :options="['always', 'active']"
+        :custom-label="val => {
+          return val === 'always' ?
+            'Always, show 0 when inactive' :
+            'Hide when inactive';
+        }"
+        :allow-empty="false"
+        v-model="labelSettings.show_count"
+        @input="debouncedSetSettings"/>
+    </div>
+  </div>
+  <div class="input-container select" v-if="labelSettings.show_latest != null">
+    <div class="input-label">
+      <label>Show Latest</label>
+    </div>
+    <div class="input-wrapper">
+      <multiselect
+        :options="['always', 'active']"
+        :custom-label="val => {
+          return val === 'always' ?
+            'Always, show last person when inactive' :
+            'Hide when inactive';
+        }"
+        :allow-empty="false"
+        v-model="labelSettings.show_latest"
+        @input="debouncedSetSettings"/>
+    </div>
+  </div>
   <div class="input-container" v-if="labelSettings.format != null">
     <div class="input-label">
       <label>Preview</label>

--- a/app/components/custom-source-properties/StreamlabelProperties.vue
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue
@@ -11,6 +11,7 @@
         group-values="files"
         track-by="name"
         label="label"
+        :allow-empty="false"
         :value="currentlySelected"
         @input="handleInput"/>
     </div>

--- a/app/components/custom-source-properties/StreamlabelProperties.vue.ts
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue.ts
@@ -63,8 +63,6 @@ export default class StreamlabelProperties extends Vue {
   debouncedSetSettings: () => void;
 
   setSettings() {
-    console.log('dafuq');
-
     if (this.labelSettings.limit) {
       this.labelSettings.limit = parseInt(this.labelSettings.limit as any, 10);
       if (isNaN(this.labelSettings.limit)) this.labelSettings.limit = 0;

--- a/app/components/custom-source-properties/StreamlabelProperties.vue.ts
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue.ts
@@ -25,11 +25,17 @@ export default class StreamlabelProperties extends Vue {
   }
 
   currentlySelected: IStreamlabelDefinition = null;
-  labelSettings: IStreamlabelSettings = null;
 
   created() {
     this.refreshPropertyValues();
     this.debouncedSetSettings = debounce(() => this.setSettings(), 1000);
+  }
+
+
+  get labelSettings(): IStreamlabelSettings {
+    if (!this.currentlySelected) return {};
+
+    return this.streamlabelsService.state.settings[this.currentlySelected.name];
   }
 
 
@@ -38,10 +44,7 @@ export default class StreamlabelProperties extends Vue {
 
     this.statOptions.forEach(category => {
       category.files.forEach(file => {
-        if (file.name === settings.statname) {
-          this.currentlySelected = file;
-          this.labelSettings = this.streamlabelsService.getSettingsForStat(settings.statname);
-        }
+        if (file.name === settings.statname) this.currentlySelected = file;
       });
     });
   }

--- a/app/components/custom-source-properties/StreamlabelProperties.vue.ts
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue.ts
@@ -63,6 +63,8 @@ export default class StreamlabelProperties extends Vue {
   debouncedSetSettings: () => void;
 
   setSettings() {
+    console.log('dafuq');
+
     if (this.labelSettings.limit) {
       this.labelSettings.limit = parseInt(this.labelSettings.limit as any, 10);
       if (isNaN(this.labelSettings.limit)) this.labelSettings.limit = 0;

--- a/app/components/custom-source-properties/StreamlabelProperties.vue.ts
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue.ts
@@ -25,17 +25,11 @@ export default class StreamlabelProperties extends Vue {
   }
 
   currentlySelected: IStreamlabelDefinition = null;
+  labelSettings: IStreamlabelSettings = null;
 
   created() {
     this.refreshPropertyValues();
     this.debouncedSetSettings = debounce(() => this.setSettings(), 1000);
-  }
-
-
-  get labelSettings(): IStreamlabelSettings {
-    if (!this.currentlySelected) return {};
-
-    return this.streamlabelsService.state.settings[this.currentlySelected.name];
   }
 
 
@@ -44,7 +38,10 @@ export default class StreamlabelProperties extends Vue {
 
     this.statOptions.forEach(category => {
       category.files.forEach(file => {
-        if (file.name === settings.statname) this.currentlySelected = file;
+        if (file.name === settings.statname) {
+          this.currentlySelected = file;
+          this.labelSettings = this.streamlabelsService.getSettingsForStat(settings.statname);
+        }
       });
     });
   }

--- a/app/components/custom-source-properties/StreamlabelProperties.vue.ts
+++ b/app/components/custom-source-properties/StreamlabelProperties.vue.ts
@@ -77,6 +77,8 @@ export default class StreamlabelProperties extends Vue {
 
 
   get preview() {
+    if (this.labelSettings.format == null) return '';
+
     let replaced = this.labelSettings.format
       .replace(/{name}/gi, 'Fishstickslol')
       .replace(/{title}/gi, 'New Computer')

--- a/app/services/sources/properties-managers/streamlabels-manager.ts
+++ b/app/services/sources/properties-managers/streamlabels-manager.ts
@@ -1,6 +1,6 @@
 import { PropertiesManager } from './properties-manager';
 import { Inject } from 'util/injector';
-import { StreamlabelsService } from 'services/streamlabels';
+import { StreamlabelsService, IStreamlabelSubscription } from 'services/streamlabels';
 import { getDefinitions } from 'services/streamlabels/definitions';
 import { UserService } from 'services/user';
 
@@ -14,7 +14,7 @@ export class StreamlabelsManager extends PropertiesManager {
   @Inject() userService: UserService;
 
   settings: IStreamlabelsManagerSettings;
-  filename: string;
+  subscription: IStreamlabelSubscription;
   blacklist = ['read_from_file', 'file'];
   customUIComponent = 'StreamlabelProperties';
 
@@ -37,8 +37,8 @@ export class StreamlabelsManager extends PropertiesManager {
 
 
   unsubscribe() {
-    if (this.filename) {
-      this.streamlabelsService.unsubscribe(this.filename);
+    if (this.subscription) {
+      this.streamlabelsService.unsubscribe(this.subscription);
     }
   }
 
@@ -46,12 +46,12 @@ export class StreamlabelsManager extends PropertiesManager {
   refreshSubscription() {
     this.unsubscribe();
 
-    this.filename = this.streamlabelsService.subscribe(this.settings.statname);
+    this.subscription = this.streamlabelsService.subscribe(this.settings.statname);
 
     this.obsSource.update({
       ...this.obsSource.settings,
       read_from_file: true,
-      file: this.streamlabelsService.getStreamlabelsPath(this.filename)
+      file: this.subscription.path
     });
   }
 

--- a/app/services/sources/properties-managers/streamlabels-manager.ts
+++ b/app/services/sources/properties-managers/streamlabels-manager.ts
@@ -14,7 +14,7 @@ export class StreamlabelsManager extends PropertiesManager {
   @Inject() userService: UserService;
 
   settings: IStreamlabelsManagerSettings;
-  subscription: IStreamlabelSubscription;
+  private subscription: IStreamlabelSubscription;
   blacklist = ['read_from_file', 'file'];
   customUIComponent = 'StreamlabelProperties';
 
@@ -36,14 +36,14 @@ export class StreamlabelsManager extends PropertiesManager {
   }
 
 
-  unsubscribe() {
+  private unsubscribe() {
     if (this.subscription) {
       this.streamlabelsService.unsubscribe(this.subscription);
     }
   }
 
 
-  refreshSubscription() {
+  private refreshSubscription() {
     this.unsubscribe();
 
     this.subscription = this.streamlabelsService.subscribe(this.settings.statname);

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -20,7 +20,6 @@ export interface IStreamlabelSettingsDefinition {
   item_format?: { tokens: string[]; };
   item_separator?: { tokens: string[]; };
   includeResubsOption?: boolean;
-  isTrain?: boolean;
 }
 
 type TStreamlabelFormType = 'simpleFileForm' | 'itemFileForm';
@@ -556,46 +555,36 @@ const youtubeDefinitions: IStreamlabelSet = {
 const twitchDefinitions: IStreamlabelSet = {
   // Trains are currently disabled
 
-  // donation_train: {
-  //   label: 'Donation Train',
-  //   files: [
-  //     {
-  //       name: 'donation_train_clock',
-  //       label: 'Donation Train Clock',
-  //       settings: {
-  //         isTrain: true
-  //       }
-  //     },
-  //     {
-  //       name: 'donation_train_counter',
-  //       label: 'Donation Train Counter',
-  //       settings: {
-  //         isTrain: true
-  //       }
-  //     },
-  //     {
-  //       name: 'donation_train_latest_amount',
-  //       label: 'Donation Train Latest Amount',
-  //       settings: {
-  //         isTrain: true
-  //       }
-  //     },
-  //     {
-  //       name: 'donation_train_latest_donor',
-  //       label: 'Donation Train Latest Donor',
-  //       settings: {
-  //         isTrain: true
-  //       }
-  //     },
-  //     {
-  //       name: 'donation_train_total_amount',
-  //       label: 'Donation Train Total Amount',
-  //       settings: {
-  //         isTrain: true
-  //       }
-  //     }
-  //   ]
-  // },
+  donation_train: {
+    label: 'Donation Train',
+    files: [
+      {
+        name: 'donation_train_clock',
+        label: 'Donation Train Clock',
+        settings: {}
+      },
+      {
+        name: 'donation_train_counter',
+        label: 'Donation Train Counter',
+        settings: {}
+      },
+      {
+        name: 'donation_train_latest_amount',
+        label: 'Donation Train Latest Amount',
+        settings: {}
+      },
+      {
+        name: 'donation_train_latest_name',
+        label: 'Donation Train Latest Donor',
+        settings: {}
+      },
+      {
+        name: 'donation_train_total_amount',
+        label: 'Donation Train Total Amount',
+        settings: {}
+      }
+    ]
+  },
   top_cheerer: {
     label: 'Top Cheerer',
     files: [{

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -252,7 +252,7 @@ const allDefinitions: IStreamlabelSet = {
  * Used by Youtube only
  */
 const youtubeDefinitions: IStreamlabelSet = {
-  // Trains are currently disabled
+  // Trains are currently disabled for youtube
 
   // trains_combos: {
   //   label: 'Trains/Combos',
@@ -546,8 +546,6 @@ const youtubeDefinitions: IStreamlabelSet = {
  * Used by Twitch
  */
 const twitchDefinitions: IStreamlabelSet = {
-  // Trains are currently disabled
-
   donation_train: {
     label: 'Donation Train',
     files: [

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -614,7 +614,7 @@ const twitchDefinitions: IStreamlabelSet = {
       },
       {
         name: 'follow_train_latest_name',
-        label: 'Follow Train Latest Donor',
+        label: 'Follow Train Latest Follower',
         settings: {
           settingsStat: 'train_twitch_follows',
           settingsWhitelist: ['show_latest']
@@ -643,7 +643,7 @@ const twitchDefinitions: IStreamlabelSet = {
       },
       {
         name: 'subscription_train_latest_name',
-        label: 'Subscription Train Latest Donor',
+        label: 'Subscription Train Latest Subscriber',
         settings: {
           settingsStat: 'train_twitch_subscriptions',
           settingsWhitelist: ['show_latest']

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -19,7 +19,6 @@ export interface IStreamlabelSettingsDefinition {
   format?: { tokens: string[]; };
   item_format?: { tokens: string[]; };
   item_separator?: { tokens: string[]; };
-  includeResubsOption?: boolean;
   settingsStat?: string;
   settingsWhitelist?: string[];
 }
@@ -279,8 +278,7 @@ const youtubeDefinitions: IStreamlabelSet = {
         name: 'most_recent_youtube_subscriber',
         label: 'Most Recent Subscriber',
         settings: {
-          format: { tokens: ['{name}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}'] }
         }
       },
       {
@@ -289,24 +287,21 @@ const youtubeDefinitions: IStreamlabelSet = {
         settings: {
           format: { tokens: ['{list}'] },
           item_format: { tokens: ['{name}'] },
-          item_separator: { tokens: ['\\n'] },
-          includeResubsOption: true
+          item_separator: { tokens: ['\\n'] }
         }
       },
       {
         name: 'session_youtube_subscriber_count',
         label: 'Session Subscriber Count',
         settings: {
-          format: { tokens: ['{count}'] },
-          includeResubsOption: true
+          format: { tokens: ['{count}'] }
         }
       },
       {
         name: 'session_most_recent_youtube_subscriber',
         label: 'Session Most Recent Subscriber',
         settings: {
-          format: { tokens: ['{name}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}'] }
         }
       }
     ]
@@ -325,8 +320,7 @@ const youtubeDefinitions: IStreamlabelSet = {
         name: 'most_recent_youtube_sponsor',
         label: 'Most Recent Sponsor',
         settings: {
-          format: { tokens: ['{name}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}'] }
         }
       },
       {
@@ -335,24 +329,21 @@ const youtubeDefinitions: IStreamlabelSet = {
         settings: {
           format: { tokens: ['{list}'] },
           item_format: { tokens: ['{name}'] },
-          item_separator: { tokens: ['\\n'] },
-          includeResubsOption: true
+          item_separator: { tokens: ['\\n'] }
         }
       },
       {
         name: 'session_youtube_sponsor_count',
         label: 'Session Sponsor Count',
         settings: {
-          format: { tokens: ['{count}'] },
-          includeResubsOption: true
+          format: { tokens: ['{count}'] }
         }
       },
       {
         name: 'session_most_recent_youtube_sponsor',
         label: 'Session Most Recent Sponsor',
         settings: {
-          format: { tokens: ['{name}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}'] }
         }
       }
     ]
@@ -911,8 +902,7 @@ const twitchDefinitions: IStreamlabelSet = {
         name: 'most_recent_subscriber',
         label: 'Most Recent Subscriber',
         settings: {
-          format: { tokens: ['{name}', '{months}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}', '{months}'] }
         }
       },
       {
@@ -921,24 +911,21 @@ const twitchDefinitions: IStreamlabelSet = {
         settings: {
           format: { tokens: ['{list}'] },
           item_format: { tokens: ['{name}'] },
-          item_separator: { tokens: ['\\n'] },
-          includeResubsOption: true
+          item_separator: { tokens: ['\\n'] }
         }
       },
       {
         name: 'session_subscriber_count',
         label: 'Session Subscriber Count',
         settings: {
-          format: { tokens: ['{count}'] },
-          includeResubsOption: true
+          format: { tokens: ['{count}'] }
         }
       },
       {
         name: 'session_most_recent_subscriber',
         label: 'Session Most Recent Subscriber',
         settings: {
-          format: { tokens: ['{name}', '{months}'] },
-          includeResubsOption: true
+          format: { tokens: ['{name}', '{months}'] }
         }
       }
     ]

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -16,10 +16,11 @@ export interface IStreamlabelDefinition {
 }
 
 export interface IStreamlabelSettingsDefinition {
-  format: { tokens: string[]; };
+  format?: { tokens: string[]; };
   item_format?: { tokens: string[]; };
   item_separator?: { tokens: string[]; };
   includeResubsOption?: boolean;
+  isTrain?: boolean;
 }
 
 type TStreamlabelFormType = 'simpleFileForm' | 'itemFileForm';
@@ -52,44 +53,44 @@ export function getDefinitions(platform: TPlatform) {
  */
 const allDefinitions: IStreamlabelSet = {
   top_donator: {
-    label: 'Top Donator',
+    label: 'Top Donor',
     files: [{
       name: 'all_time_top_donator',
-      label: 'All-Time Top Donator',
+      label: 'All-Time Top Donor',
       settings: {
         format: { tokens: ['{name}', '{amount}'] }
       }
     }, {
       name: 'session_top_donator',
-      label: 'Session Top Donator',
+      label: 'Session Top Donor',
       settings: {
         format: { tokens: ['{name}', '{amount}'] }
       }
     }, {
       name: 'monthly_top_donator',
-      label: 'Monthly Top Donator',
+      label: 'Monthly Top Donor',
       settings: {
         format: { tokens: ['{name}', '{amount}'] }
       }
     }, {
       name: '30day_top_donator',
-      label: '30-Day Top Donator',
+      label: '30-Day Top Donor',
       settings: {
         format: { tokens: ['{name}', '{amount}'] }
       }
     }, {
       name: 'weekly_top_donator',
-      label: 'Weekly Top Donator',
+      label: 'Weekly Top Donor',
       settings: {
         format: { tokens: ['{name}', '{amount}'] }
       }
     }]
   },
   top_donators: {
-    label: 'Top Donators (Top 10)',
+    label: 'Top Donors (Top 10)',
     files: [{
       name: 'all_time_top_donators',
-      label: 'All-Time Top Donators',
+      label: 'All-Time Top Donors',
       settings: {
         format: { tokens: ['{list}'] },
         item_format: { tokens: ['{name}', '{amount}'] },
@@ -97,7 +98,7 @@ const allDefinitions: IStreamlabelSet = {
       }
     }, {
       name: 'session_top_donators',
-      label: 'Session Top Donators',
+      label: 'Session Top Donors',
       settings: {
         format: { tokens: ['{list}'] },
         item_format: { tokens: ['{name}', '{amount}'] },
@@ -105,7 +106,7 @@ const allDefinitions: IStreamlabelSet = {
       }
     }, {
       name: 'monthly_top_donators',
-      label: 'Monthly Top Donators',
+      label: 'Monthly Top Donors',
       settings: {
         format: { tokens: ['{list}'] },
         item_format: { tokens: ['{name}', '{amount}'] },
@@ -113,7 +114,7 @@ const allDefinitions: IStreamlabelSet = {
       }
     }, {
       name: '30day_top_donators',
-      label: '30-Day Top Donators',
+      label: '30-Day Top Donors',
       settings: {
         format: { tokens: ['{list}'] },
         item_format: { tokens: ['{name}', '{amount}'] },
@@ -121,7 +122,7 @@ const allDefinitions: IStreamlabelSet = {
       }
     }, {
       name: 'weekly_top_donators',
-      label: 'Weekly Top Donators',
+      label: 'Weekly Top Donors',
       settings: {
         format: { tokens: ['{list}'] },
         item_format: { tokens: ['{name}', '{amount}'] },
@@ -208,17 +209,17 @@ const allDefinitions: IStreamlabelSet = {
     }]
   },
   donators: {
-    label: 'Donators',
+    label: 'Donors',
     files: [
       {
         name: 'most_recent_donator',
-        label: 'Most Recent Donator',
+        label: 'Most Recent Donor',
         settings: {
           format: { tokens: ['{name}', '{amount}', '{message}'] }
         }
       }, {
         name: 'session_donators',
-        label: 'Session Donators (Max 25)',
+        label: 'Session Donors (Max 25)',
         settings: {
           format: { tokens: ['{list}'] },
           item_format: { tokens: ['{name}', '{amount}', '{message}'] },
@@ -226,7 +227,7 @@ const allDefinitions: IStreamlabelSet = {
         }
       }, {
         name: 'session_most_recent_donator',
-        label: 'Session Recent Donator',
+        label: 'Session Recent Donor',
         settings: {
           format: { tokens: ['{name}', '{amount}', '{message}'] }
         }
@@ -555,23 +556,43 @@ const youtubeDefinitions: IStreamlabelSet = {
 const twitchDefinitions: IStreamlabelSet = {
   // Trains are currently disabled
 
-  // trains_combos: {
-  //   label: 'Trains/Combos',
+  // donation_train: {
+  //   label: 'Donation Train',
   //   files: [
   //     {
-  //       name: 'train_tips',
-  //       label: 'Donation Train',
-  //       template: 'trainFileForm'
+  //       name: 'donation_train_clock',
+  //       label: 'Donation Train Clock',
+  //       settings: {
+  //         isTrain: true
+  //       }
   //     },
   //     {
-  //       name: 'train_twitch_follows',
-  //       label: 'Follows Train',
-  //       template: 'trainFileForm'
+  //       name: 'donation_train_counter',
+  //       label: 'Donation Train Counter',
+  //       settings: {
+  //         isTrain: true
+  //       }
   //     },
   //     {
-  //       name: 'train_twitch_subscriptions',
-  //       label: 'Subscription Train',
-  //       template: 'trainFileForm'
+  //       name: 'donation_train_latest_amount',
+  //       label: 'Donation Train Latest Amount',
+  //       settings: {
+  //         isTrain: true
+  //       }
+  //     },
+  //     {
+  //       name: 'donation_train_latest_donor',
+  //       label: 'Donation Train Latest Donor',
+  //       settings: {
+  //         isTrain: true
+  //       }
+  //     },
+  //     {
+  //       name: 'donation_train_total_amount',
+  //       label: 'Donation Train Total Amount',
+  //       settings: {
+  //         isTrain: true
+  //       }
   //     }
   //   ]
   // },

--- a/app/services/streamlabels/definitions.ts
+++ b/app/services/streamlabels/definitions.ts
@@ -20,6 +20,8 @@ export interface IStreamlabelSettingsDefinition {
   item_format?: { tokens: string[]; };
   item_separator?: { tokens: string[]; };
   includeResubsOption?: boolean;
+  settingsStat?: string;
+  settingsWhitelist?: string[];
 }
 
 type TStreamlabelFormType = 'simpleFileForm' | 'itemFileForm';
@@ -561,27 +563,100 @@ const twitchDefinitions: IStreamlabelSet = {
       {
         name: 'donation_train_clock',
         label: 'Donation Train Clock',
-        settings: {}
+        settings: {
+          settingsStat: 'train_tips',
+          settingsWhitelist: ['duration', 'show_clock']
+        }
       },
       {
         name: 'donation_train_counter',
         label: 'Donation Train Counter',
-        settings: {}
+        settings: {
+          settingsStat: 'train_tips',
+          settingsWhitelist: ['show_count']
+        }
       },
       {
         name: 'donation_train_latest_amount',
         label: 'Donation Train Latest Amount',
-        settings: {}
+        settings: {
+          settingsStat: 'train_tips',
+          settingsWhitelist: []
+        }
       },
       {
         name: 'donation_train_latest_name',
         label: 'Donation Train Latest Donor',
-        settings: {}
+        settings: {
+          settingsStat: 'train_tips',
+          settingsWhitelist: ['show_latest']
+        }
       },
       {
         name: 'donation_train_total_amount',
         label: 'Donation Train Total Amount',
-        settings: {}
+        settings: {
+          settingsStat: 'train_tips',
+          settingsWhitelist: []
+        }
+      }
+    ]
+  },
+  follow_train: {
+    label: 'Follow Train',
+    files: [
+      {
+        name: 'follow_train_clock',
+        label: 'Follow Train Clock',
+        settings: {
+          settingsStat: 'train_twitch_follows',
+          settingsWhitelist: ['duration', 'show_clock']
+        }
+      },
+      {
+        name: 'follow_train_counter',
+        label: 'Follow Train Counter',
+        settings: {
+          settingsStat: 'train_twitch_follows',
+          settingsWhitelist: ['show_count']
+        }
+      },
+      {
+        name: 'follow_train_latest_name',
+        label: 'Follow Train Latest Donor',
+        settings: {
+          settingsStat: 'train_twitch_follows',
+          settingsWhitelist: ['show_latest']
+        }
+      }
+    ]
+  },
+  subscription_train: {
+    label: 'Subscription Train',
+    files: [
+      {
+        name: 'subscription_train_clock',
+        label: 'Subscription Train Clock',
+        settings: {
+          settingsStat: 'train_twitch_subscriptions',
+          settingsWhitelist: ['duration', 'show_clock']
+        }
+      },
+      {
+        name: 'subscription_train_counter',
+        label: 'Subscription Train Counter',
+        settings: {
+          settingsStat: 'train_twitch_subscriptions',
+          settingsWhitelist: ['show_count']
+        }
+      },
+      {
+        name: 'subscription_train_latest_name',
+        label: 'Subscription Train Latest Donor',
+        settings: {
+          settingsStat: 'train_twitch_subscriptions',
+          settingsWhitelist: ['show_latest']
+        }
       }
     ]
   },

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -386,6 +386,22 @@ export class StreamlabelsService extends Service {
       this.trains.donation.mostRecentAmount = parseFloat(latest.amount);
 
       this.outputTrainInfo('donation');
+    } else if (event.type === 'follow') {
+      this.trains.follow.mostRecentEventAt = Date.now();
+      this.trains.follow.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.follow.mostRecentName = latest.name;
+
+      this.outputTrainInfo('follow');
+    } else if (event.type === 'subscription') {
+      this.trains.subscription.mostRecentEventAt = Date.now();
+      this.trains.subscription.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.subscription.mostRecentName = latest.name;
+
+      this.outputTrainInfo('subscription');
     }
   }
 

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -38,6 +38,7 @@ export interface IStreamlabelSettings {
   show_clock?: 'always' | 'active';
   show_count?: 'always' | 'active';
   show_latest?: 'always' | 'active';
+  include_resubs?: boolean;
 }
 
 

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -113,13 +113,13 @@ export class StreamlabelsService extends Service {
       mostRecentEventAt: null,
       mostRecentName: null,
       counter: 0,
-      setting: 'train_twitch_follows'
+      setting: 'train_twitch_subscriptions'
     },
     follow: {
       mostRecentEventAt: null,
       mostRecentName: null,
       counter: 0,
-      setting: 'train_twitch_subscriptions'
+      setting: 'train_twitch_follows'
     }
   };
 

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -64,6 +64,42 @@ interface ITrains {
 }
 
 
+type TSocketEvent =
+  IStreamlabelsSocketEvent |
+  IDonationSocketEvent |
+  IFollowSocketEvent |
+  ISubscriptionSocketEvent;
+
+interface IStreamlabelsSocketEvent {
+  type: 'streamlabels';
+  message: {
+    data: Dictionary<string>;
+  };
+}
+
+interface IDonationSocketEvent {
+  type: 'donation';
+  message: {
+    name: string;
+    amount: string;
+  }[];
+}
+
+interface IFollowSocketEvent {
+  type: 'follow';
+  message: {
+    name: string;
+  }[];
+}
+
+interface ISubscriptionSocketEvent {
+  type: 'subscription';
+  message: {
+    name: string;
+  }[];
+}
+
+
 function isDonationTrain(train: ITrainInfo | IDonationTrainInfo): train is IDonationTrainInfo {
   return (train as IDonationTrainInfo).donationTrain;
 }
@@ -369,8 +405,7 @@ export class StreamlabelsService extends Service {
   }
 
 
-  // TODO: Interface for socket events
-  private onSocketEvent(event: any) {
+  private onSocketEvent(event: TSocketEvent) {
     console.log('Socket Event', event);
 
     if (event.type === 'streamlabels') {

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -406,7 +406,7 @@ export class StreamlabelsService extends Service {
 
 
   private onSocketEvent(event: TSocketEvent) {
-    console.log('Socket Event', event);
+    this.log('Socket Event', event);
 
     if (event.type === 'streamlabels') {
       this.updateOutput(event.message.data);

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -63,6 +63,7 @@ interface ITrains {
   follow: ITrainInfo;
 }
 
+type TTrainType = 'donation' | 'follow' | 'subscription';
 
 type TSocketEvent =
   IStreamlabelsSocketEvent |
@@ -326,7 +327,7 @@ export class StreamlabelsService extends Service {
 
   private initTrainClockInterval() {
     this.trainInterval = window.setInterval(() => {
-      Object.keys(this.trains).forEach(trainType => {
+      Object.keys(this.trains).forEach((trainType: TTrainType) => {
         const train = this.trains[trainType] as ITrainInfo;
 
         if (train.mostRecentEventAt == null) return;
@@ -356,7 +357,7 @@ export class StreamlabelsService extends Service {
   }
 
 
-  private clearTrain(trainType: string) {
+  private clearTrain(trainType: TTrainType) {
     const train = this.trains[trainType] as ITrainInfo | IDonationTrainInfo;
 
     if (isDonationTrain(train)) {
@@ -371,7 +372,7 @@ export class StreamlabelsService extends Service {
 
 
   private outputAllTrains() {
-    Object.keys(this.trains).forEach(train => this.outputTrainInfo(train));
+    Object.keys(this.trains).forEach((train: TTrainType) => this.outputTrainInfo(train));
   }
 
 
@@ -379,7 +380,7 @@ export class StreamlabelsService extends Service {
    * Outputs all files on a train, except for the clock while the
    * train is running.
    */
-  private outputTrainInfo(trainType: string) {
+  private outputTrainInfo(trainType: TTrainType) {
     const train = this.trains[trainType] as ITrainInfo | IDonationTrainInfo;
     const settings = this.getSettingsForStat(train.setting);
     const output = {


### PR DESCRIPTION
Trains are fully client side, so this was a little tough to implement.  Unfortunately we inherited a lot of technical debt from the existing stream labels system.

I think the entire stream labels system needs to be moved entirely client-side and work off a data driven API.  Unfortunately this requires a lot of backend changes and we don't have the resources to tackle that right now.