### PR TITLE
Optimize properties objects

### DIFF
--- a/app/components/shared/forms/Input.ts
+++ b/app/components/shared/forms/Input.ts
@@ -292,7 +292,7 @@ export function getPropertiesFormData(obsSource: obs.ISource): TFormData {
   setupSourceDefaults(obsSource);
 
   const formData: TFormData = [];
-  const obsProps = obsSource.properties;
+  const obsProps = obsSource.properties();
   const obsSettings = obsSource.settings;
 
   if (!obsProps) return null;
@@ -395,7 +395,7 @@ export function setPropertiesFormData(obsSource: obs.ISource, form: TFormData) {
 
   buttons.forEach(buttonInput => {
     if (!buttonInput.value) return;
-    const obsButtonProp = obsSource.properties.get(buttonInput.name) as obs.IButtonProperty;
+    const obsButtonProp = obsSource.properties().get(buttonInput.name) as obs.IButtonProperty;
     obsButtonProp.buttonClicked(obsSource);
   });
 }
@@ -404,8 +404,9 @@ export function setPropertiesFormData(obsSource: obs.ISource, form: TFormData) {
 export function setupSourceDefaults(obsSource: obs.ISource) {
   const propSettings = obsSource.settings;
   const defaultSettings = {};
-  if (!obsSource.properties) return;
-  let obsProp = obsSource.properties.first();
+  const properties = obsSource.properties();
+  if (!properties) return;
+  let obsProp = properties.first();
   do {
     if (
       propSettings[obsProp.name] !== void 0 ||

--- a/app/services/audio.ts
+++ b/app/services/audio.ts
@@ -186,7 +186,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
     const obsAudioInput = obs.InputFactory.create('wasapi_input_capture', ipcRenderer.sendSync('getUniqueId'));
     const obsAudioOutput = obs.InputFactory.create('wasapi_output_capture', ipcRenderer.sendSync('getUniqueId'));
 
-    (obsAudioInput.properties.get('device_id') as obs.IListProperty).details.items
+    (obsAudioInput.properties().get('device_id') as obs.IListProperty).details.items
       .forEach((item: { name: string, value: string}) => {
         devices.push({
           id: item.value,
@@ -195,7 +195,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
         });
       });
 
-    (obsAudioOutput.properties.get('device_id') as obs.IListProperty).details.items
+    (obsAudioOutput.properties().get('device_id') as obs.IListProperty).details.items
       .forEach((item: { name: string, value: string}) => {
         devices.push({
           id: item.value,

--- a/app/services/config-persistence/nodes/overlays/webcam.ts
+++ b/app/services/config-persistence/nodes/overlays/webcam.ts
@@ -93,12 +93,13 @@ export class WebcamNode extends Node<ISchema, IContext> {
     const targetHeight = this.data.height * this.videoService.baseHeight;
     const targetAspect = targetWidth / targetHeight;
     const input = item.getObsInput();
+    const deviceProperties = input.properties();
 
     // Select the first video device
     // TODO: Maybe do some string matching to figure out which
     // one is actually the webcam.  For most users, their webcam
     // will be the only option here.
-    const deviceProperty = input.properties.get('video_device_id');
+    const deviceProperty = deviceProperties.get('video_device_id');
 
     // Stop loading if there aren't any devices
     if ((deviceProperty as IListProperty).details.items.length === 0) return;
@@ -110,7 +111,7 @@ export class WebcamNode extends Node<ISchema, IContext> {
     input.update(settings);
 
     // Figure out which resolutions this device can run at
-    const resolutionOptions = (input.properties.get('resolution') as IListProperty).details.items.map(item => {
+    const resolutionOptions = (deviceProperties.get('resolution') as IListProperty).details.items.map(item => {
       return this.resStringToResolution(item.value as string);
     });
 


### PR DESCRIPTION
Properties objects can take some time to create. As a result, we should
cache them when we can. In addition, I've removed `properties` as a
getter property and changed it to a function to prevent its value from
being enumerated on accident. This should fix several issues including
hitching and freezing.

By coincidence, this "fixes" a potential crash with a few DShow Filter drivers that leak resources when they're enumerated or initialized. 