### PR TITLE
Revive the overlay system

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -21,15 +21,6 @@
     <BoolInput :value="streamInfoUpdateModel" @input="setStreamInfoUpdate" />
     <BoolInput :value="leftDockModel" @input="setLeftDock" />
   </div>
-  <!-- TODO: Uncomment when we want to expose this feature -->
-  <!-- <div class="section">
-    <p>
-      This will export your current scene configuration as a reusable overlay that can be used as a base scene config by other people.  This is an experimental feature.
-    </p>
-    <button class="button button--action" @click="exportOverlay" :disabled="overlaySaving">
-      Export as Overlay
-    </button>
-  </div> -->
 </div>
 </template>
 

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -21,8 +21,6 @@ export default class ExtraSettings extends Vue {
 
   @Inject() customizationService: CustomizationService;
 
-  overlaySaving = false;
-
   cacheUploading = false;
 
   get streamInfoUpdateModel(): IFormInput<boolean> {
@@ -66,20 +64,6 @@ export default class ExtraSettings extends Vue {
       electron.remote.clipboard.writeText(file);
       alert(`Your cache directory has been successfully uploaded.  The file name ${file} has been copied to your clipboard.  Please paste it into discord and tag a developer.`);
       this.cacheUploading = false;
-    });
-  }
-
-  exportOverlay() {
-    const path = electron.remote.dialog.showSaveDialog({
-      filters: [{ name: 'Overlay File', extensions: ['overlay'] }]
-    });
-
-    if (!path) return;
-
-    this.overlaySaving = true;
-
-    this.overlaysService.saveOverlay(path).then(() => {
-      this.overlaySaving = false;
     });
   }
 

--- a/app/components/OverlaySettings.vue
+++ b/app/components/OverlaySettings.vue
@@ -1,0 +1,25 @@
+<template>
+<div class="section">
+  This is an experimental feature.  Use at your own risk.
+  <br/>
+  <br/>
+  <button
+    class="button button--action"
+    :disabled="busy"
+    @click="saveOverlay">
+    Export Overlay
+    <i class="fa fa-spinner fa-pulse" v-if="busy" />
+  </button>
+  <button
+    class="button button--action"
+    :disabled="busy"
+    @click="loadOverlay">
+    Import Overlay
+    <i class="fa fa-spinner fa-pulse" v-if="busy" />
+  </button>
+  <br/>
+  {{ message }}
+</div>
+</template>
+
+<script lang="ts" src="./OverlaySettings.vue.ts"></script>

--- a/app/components/OverlaySettings.vue.ts
+++ b/app/components/OverlaySettings.vue.ts
@@ -1,0 +1,53 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import { Inject } from 'util/injector';
+import { OverlaysPersistenceService, ConfigPersistenceService } from 'services/config-persistence';
+import electron from 'electron';
+import path from 'path';
+import { AppService } from 'services/app';
+
+@Component({})
+export default class OverlaySettings extends Vue {
+  @Inject() overlaysPersistenceService: OverlaysPersistenceService;
+  @Inject() configPersistenceService: ConfigPersistenceService;
+  @Inject() appService: AppService;
+
+  busy = false;
+  message = '';
+
+  saveOverlay() {
+    const chosenPath = electron.remote.dialog.showSaveDialog({
+      filters: [{ name: 'Overlay File', extensions: ['overlay'] }]
+    });
+
+    if (!chosenPath) return;
+
+    this.busy = true;
+    this.message = '';
+
+    // TODO: Expose progress to the user
+    this.overlaysPersistenceService.saveOverlay(chosenPath).then(() => {
+      this.busy = false;
+      this.message = `Successfully saved ${path.parse(chosenPath).base}`;
+    });
+  }
+
+  loadOverlay() {
+    const chosenPath = electron.remote.dialog.showOpenDialog({
+      filters: [{ name: 'Overlay File', extensions: ['overlay'] }]
+    });
+
+    if (!chosenPath) return;
+
+    this.busy = true;
+    this.message = '';
+
+    const filename = path.parse(chosenPath[0]).name;
+    const configName = this.configPersistenceService.suggestName(filename);
+
+    this.appService.loadOverlay(configName, chosenPath[0]).then(() => {
+      this.busy = false;
+      this.message = `Successfully loaded ${filename}.overlay`;
+    });
+  }
+}

--- a/app/components/windows/Settings.vue
+++ b/app/components/windows/Settings.vue
@@ -18,8 +18,9 @@
       <extra-settings v-if="categoryName === 'General'" />
       <hotkeys v-if="categoryName === 'Hotkeys'" />
       <api-settings v-if="categoryName === 'API'" />
+      <overlay-settings v-if="categoryName === 'Overlays'" />
       <GenericFormGroups
-        v-if="!['Hotkeys', 'API'].includes(categoryName)"
+        v-if="!['Hotkeys', 'API', 'Overlays'].includes(categoryName)"
         v-model="settingsData"
         @input="save" />
     </div>

--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -11,6 +11,7 @@ import windowMixin from '../mixins/window';
 import ExtraSettings from '../ExtraSettings.vue';
 import ApiSettings from '../ApiSettings.vue';
 import Hotkeys from '../Hotkeys.vue';
+import OverlaySettings from 'components/OverlaySettings.vue';
 
 @Component({
   components: {
@@ -20,7 +21,8 @@ import Hotkeys from '../Hotkeys.vue';
     NavItem,
     ExtraSettings,
     Hotkeys,
-    ApiSettings
+    ApiSettings,
+    OverlaySettings
   },
   mixins: [windowMixin]
 })
@@ -42,7 +44,8 @@ export default class SceneTransitions extends Vue {
     Audio: 'volume-up',
     Hotkeys: 'keyboard-o',
     Advanced: 'cogs',
-    API: 'file-code-o'
+    API: 'file-code-o',
+    Overlays: 'picture-o'
   };
 
   get categoryNames() {

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -2,6 +2,7 @@ import electron from 'electron';
 import { Service } from './services/service';
 import { AutoConfigService } from './services/auto-config';
 import { ConfigPersistenceService } from './services/config-persistence';
+import { OverlaysPersistenceService } from 'services/config-persistence';
 import { ObsImporterService } from './services/obs-importer';
 import { YoutubeService } from './services/platforms/youtube';
 import { TwitchService } from './services/platforms/twitch';
@@ -135,6 +136,7 @@ export class ServicesManager extends Service {
     FontLibraryService,
     ObsImporterService,
     ConfigPersistenceService,
+    OverlaysPersistenceService,
     AppService,
     ShortcutsService,
     CacheUploaderService,

--- a/app/services/config-persistence/config.ts
+++ b/app/services/config-persistence/config.ts
@@ -236,12 +236,17 @@ export class ConfigPersistenceService extends PersistentStatefulService<IScenesC
 
 
   switchToBlankConfig(configName = DEFAULT_SCENES_COLLECTION_NAME) {
+    this.switchToBlankConfig(configName);
+    this.setUpDefaults();
+  }
+
+
+  switchToEmptyConfig(configName: string) {
     if (this.scenesService.state.scenes.length) {
       throw 'unable to switch to blank config while current config is loaded';
     }
     this.SET_ACTIVE_COLLECTION(configName);
     this.ADD_SCENES_COLLECTIONS([configName]);
-    this.setUpDefaults();
   }
 
 

--- a/app/services/config-persistence/config.ts
+++ b/app/services/config-persistence/config.ts
@@ -236,7 +236,7 @@ export class ConfigPersistenceService extends PersistentStatefulService<IScenesC
 
 
   switchToBlankConfig(configName = DEFAULT_SCENES_COLLECTION_NAME) {
-    this.switchToBlankConfig(configName);
+    this.switchToEmptyConfig(configName);
     this.setUpDefaults();
   }
 

--- a/app/services/config-persistence/nodes/overlays/image.ts
+++ b/app/services/config-persistence/nodes/overlays/image.ts
@@ -14,34 +14,25 @@ interface IContext {
 }
 
 export class ImageNode extends Node<ISchema, IContext> {
-
   schemaVersion = 1;
 
-
-  save(context: IContext) {
+  async save(context: IContext) {
     const filePath = (context.sceneItem.getObsInput().settings as any).file;
     const newFileName = `${uniqueId()}${path.parse(filePath).ext}`;
 
     // Copy the image file
-    // TODO: Allow save to return a promise and use an asynchronous pipe
     const destination = path.join(context.assetsPath, newFileName);
     fs.writeFileSync(destination, fs.readFileSync(filePath));
 
     this.data = {
       filename: newFileName
     };
-
-    return Promise.resolve();
   }
 
-
-  load(context: IContext) {
+  async load(context: IContext) {
     const filePath = path.join(context.assetsPath, this.data.filename);
     const settings = { ...context.sceneItem.getObsInput().settings };
     settings['file'] = filePath;
     context.sceneItem.getObsInput().update(settings);
-
-    return Promise.resolve();
   }
-
 }

--- a/app/services/config-persistence/nodes/overlays/root.ts
+++ b/app/services/config-persistence/nodes/overlays/root.ts
@@ -10,25 +10,15 @@ interface IContext {
 }
 
 export class RootNode extends Node<ISchema, IContext> {
-
   schemaVersion = 1;
 
-  save(context: IContext): Promise<void> {
-    return new Promise(resolve => {
-      const scenes = new ScenesNode();
-      scenes.save(context).then(() => {
-        this.data = {
-          scenes
-        };
-        resolve();
-      });
-    });
+  async save(context: IContext): Promise<void> {
+    const scenes = new ScenesNode();
+    await scenes.save(context);
+    this.data = { scenes };
   }
 
-  load(context: IContext): Promise<void> {
-    return new Promise(resolve => {
-      this.data.scenes.load(context).then(() => resolve());
-    });
+  async load(context: IContext): Promise<void> {
+    await this.data.scenes.load(context);
   }
-
 }

--- a/app/services/config-persistence/nodes/overlays/scenes.ts
+++ b/app/services/config-persistence/nodes/overlays/scenes.ts
@@ -12,37 +12,28 @@ interface IContext {
 }
 
 export class ScenesNode extends ArrayNode<ISchema, IContext, Scene> {
-
   schemaVersion = 1;
 
   scenesService: ScenesService = ScenesService.instance;
-
 
   getItems() {
     return this.scenesService.scenes;
   }
 
+  async saveItem(scene: Scene, context: IContext): Promise<ISchema> {
+    const slots = new SlotsNode();
+    await slots.save({ scene, assetsPath: context.assetsPath });
 
-  saveItem(scene: Scene, context: IContext): Promise<ISchema> {
-    return new Promise(resolve => {
-      const slots = new SlotsNode();
-      slots.save({ scene, assetsPath: context.assetsPath }).then(() => {
-        resolve({
-          name: scene.name,
-          slots
-        });
-      });
-    });
+    return {
+      name: scene.name,
+      slots
+    };
   }
 
-
-  loadItem(obj: ISchema, context: IContext): Promise<void> {
-    return new Promise(resolve => {
-      const scene = this.scenesService.createScene(obj.name, { makeActive: true });
-      obj.slots.load({ scene, assetsPath: context.assetsPath }).then(() => {
-        resolve();
-      });
+  async loadItem(obj: ISchema, context: IContext): Promise<void> {
+    const scene = this.scenesService.createScene(obj.name, {
+      makeActive: true
     });
+    await obj.slots.load({ scene, assetsPath: context.assetsPath });
   }
-
 }

--- a/app/services/config-persistence/nodes/overlays/streamlabel.ts
+++ b/app/services/config-persistence/nodes/overlays/streamlabel.ts
@@ -1,0 +1,36 @@
+import { Node } from '../node';
+import { SceneItem } from '../../../scenes';
+import { TextNode } from './text';
+import { Inject } from '../../../../util/injector';
+import path from 'path';
+
+interface ISchema {
+  labelType: string;
+  textSource: TextNode;
+}
+
+interface IContext {
+  sceneItem: SceneItem;
+  assetsPath: string;
+}
+
+export class StreamlabelNode extends Node<ISchema, IContext> {
+  schemaVersion = 1;
+
+  async save(context: IContext) {
+    const textSource = new TextNode();
+    await textSource.save(context);
+
+    const labelType = context.sceneItem.source.getPropertiesManagerSettings().statname;
+
+    this.data = { labelType, textSource };
+  }
+
+  async load(context: IContext) {
+    await this.data.textSource.load(context);
+
+    context.sceneItem.source.replacePropertiesManager('streamlabels', {
+      statname: this.data.labelType
+    });
+  }
+}

--- a/app/services/config-persistence/nodes/overlays/text.ts
+++ b/app/services/config-persistence/nodes/overlays/text.ts
@@ -14,15 +14,12 @@ interface IContext {
 }
 
 export class TextNode extends Node<ISchema, IContext> {
-
   schemaVersion = 1;
 
-  @Inject()
-  fontLibraryService: FontLibraryService;
+  @Inject() fontLibraryService: FontLibraryService;
 
-
-  save(context: IContext) {
-    const settings = context.sceneItem.getObsInput().settings;
+  async save(context: IContext) {
+    const settings = { ...context.sceneItem.getObsInput().settings };
 
     // We only store the filename for the custom font, to prevent
     // storing a full path that could possibly leak information
@@ -32,33 +29,28 @@ export class TextNode extends Node<ISchema, IContext> {
       settings['custom_font'] = file;
     }
 
-    this.data = { settings };
+    settings['file'] = '';
 
-    return Promise.resolve();
+    this.data = { settings };
   }
 
-
-  load(context: IContext) {
+  async load(context: IContext) {
     // If a custom font was set, try to load it as a google font.
     // If this fails, not font will be installed and the plugin
     // will automatically fall back to Arial
     if (this.data.settings['custom_font']) {
-      this.fontLibraryService.downloadFont(this.data.settings['custom_font'])
-        .then(path => {
-          this.data.settings['custom_font'] = path;
-          this.updateInput(context);
-        })
-        .catch(() => this.updateInput(context));
+      const path = await this.fontLibraryService.downloadFont(
+        this.data.settings['custom_font']
+      );
+
+      this.data.settings['custom_font'] = path;
+      this.updateInput(context);
     } else {
       this.updateInput(context);
     }
-
-    return Promise.resolve();
   }
-
 
   updateInput(context: IContext) {
     context.sceneItem.getObsInput().update(this.data.settings);
   }
-
 }

--- a/app/services/config-persistence/nodes/overlays/webcam.ts
+++ b/app/services/config-persistence/nodes/overlays/webcam.ts
@@ -26,26 +26,21 @@ interface IResolution {
 }
 
 export class WebcamNode extends Node<ISchema, IContext> {
-
   schemaVersion = 1;
 
   videoService: VideoService = VideoService.instance;
   sourcesService: SourcesService = SourcesService.instance;
 
-
-  save(context: IContext) {
+  async save(context: IContext) {
     const rect = new ScalableRectangle(context.sceneItem);
 
     this.data = {
       width: rect.scaledWidth / this.videoService.baseWidth,
       height: rect.scaledHeight / this.videoService.baseHeight
     };
-
-    return Promise.resolve();
   }
 
-
-  load(context: IContext) {
+  async load(context: IContext) {
     const targetWidth = this.data.width * this.videoService.baseWidth;
     const targetHeight = this.data.height * this.videoService.baseHeight;
     const targetAspect = targetWidth / targetHeight;
@@ -69,22 +64,15 @@ export class WebcamNode extends Node<ISchema, IContext> {
       bottom: 0
     };
 
-    if ((resolution.width * scale) > targetWidth) {
-      const delta = ((resolution.width * scale) - targetWidth) / scale;
+    if (resolution.width * scale > targetWidth) {
+      const delta = (resolution.width * scale - targetWidth) / scale;
 
       crop.left = delta / 2;
       crop.right = delta / 2;
     }
 
-    this.applyScaleAndCrop(
-      context.sceneItem,
-      scale,
-      crop
-    );
-
-    return Promise.resolve();
+    this.applyScaleAndCrop(context.sceneItem, scale, crop);
   }
-
 
   // This selects the video device and picks the best resolution.
   // It should not be performed if context.existing is true
@@ -111,7 +99,9 @@ export class WebcamNode extends Node<ISchema, IContext> {
     input.update(settings);
 
     // Figure out which resolutions this device can run at
-    const resolutionOptions = (deviceProperties.get('resolution') as IListProperty).details.items.map(item => {
+    const resolutionOptions = (deviceProperties.get(
+      'resolution'
+    ) as IListProperty).details.items.map(item => {
       return this.resStringToResolution(item.value as string);
     });
 
@@ -157,7 +147,6 @@ export class WebcamNode extends Node<ISchema, IContext> {
     return bestResolution;
   }
 
-
   applyResolution(sceneItem: SceneItem, resolution: string) {
     const input = sceneItem.getObsInput();
     const settings = { ...input.settings };
@@ -169,18 +158,11 @@ export class WebcamNode extends Node<ISchema, IContext> {
     input.update(settings);
   }
 
-
   applyScaleAndCrop(item: SceneItem, scale: number, crop: ICrop) {
-    item.setPositionAndScale(
-      item.x,
-      item.y,
-      scale,
-      scale
-    );
+    item.setPositionAndScale(item.x, item.y, scale, scale);
 
     item.setCrop(crop);
   }
-
 
   resStringToResolution(resString: string): IResolution {
     const parts = resString.split('x');
@@ -190,5 +172,4 @@ export class WebcamNode extends Node<ISchema, IContext> {
       height: parseInt(parts[1], 10)
     };
   }
-
 }

--- a/app/services/config-persistence/nodes/overlays/widget.ts
+++ b/app/services/config-persistence/nodes/overlays/widget.ts
@@ -1,0 +1,38 @@
+import { Node } from '../node';
+import { SceneItem } from '../../../scenes';
+import { uniqueId } from 'lodash';
+import { WidgetType } from 'services/widgets';
+
+interface ISchema {
+  settings: object;
+  type: WidgetType;
+}
+
+interface IContext {
+  assetsPath: string;
+  sceneItem: SceneItem;
+}
+
+export class WidgetNode extends Node<ISchema, IContext> {
+  schemaVersion = 1;
+
+  async save(context: IContext) {
+    const settings = { ...context.sceneItem.getObsInput().settings };
+    const type = context.sceneItem.source.getPropertiesManagerSettings()
+      .widgetType;
+
+    // Avoid leaking the exporter's widget token
+    settings['url'] = '';
+
+    this.data = {
+      settings,
+      type
+    };
+  }
+
+  async load(context: IContext) {
+    context.sceneItem.source.replacePropertiesManager('widget', {
+      widgetType: this.data.type
+    });
+  }
+}

--- a/app/services/config-persistence/overlays.ts
+++ b/app/services/config-persistence/overlays.ts
@@ -6,13 +6,16 @@ import { ImageNode } from './nodes/overlays/image';
 import { TextNode } from './nodes/overlays/text';
 import { WebcamNode } from './nodes/overlays/webcam';
 import { VideoNode } from './nodes/overlays/video';
+import { StreamlabelNode } from './nodes/overlays/streamlabel';
+import { WidgetNode } from './nodes/overlays/widget';
 import { ConfigPersistenceService, parse } from '.';
 import { Inject } from '../../util/injector';
 import electron from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import asar from 'asar';
+import unzip from 'unzip';
+import archiver from 'archiver';
 
 const NODE_TYPES = {
   RootNode,
@@ -21,21 +24,27 @@ const NODE_TYPES = {
   ImageNode,
   TextNode,
   WebcamNode,
-  VideoNode
+  VideoNode,
+  StreamlabelNode,
+  WidgetNode
 };
 
 export class OverlaysPersistenceService extends Service {
+  @Inject() configPersistenceService: ConfigPersistenceService;
 
-  @Inject()
-  configPersistenceService: ConfigPersistenceService;
-
-
-  loadOverlay(overlayFilePath: string) {
+  async loadOverlay(overlayFilePath: string) {
     const overlayName = path.parse(overlayFilePath).name;
     const assetsPath = path.join(this.overlaysDirectory, overlayName);
 
     this.ensureOverlaysDirectory();
-    asar.extractAll(overlayFilePath, assetsPath);
+
+    await new Promise((resolve, reject) => {
+      const inStream = fs.createReadStream(overlayFilePath);
+      const outStream = unzip.Extract({ path: assetsPath });
+
+      outStream.on('close', resolve);
+      inStream.pipe(outStream);
+    });
 
     const configPath = path.join(assetsPath, 'config.json');
     const data = fs.readFileSync(configPath).toString();
@@ -45,21 +54,28 @@ export class OverlaysPersistenceService extends Service {
     this.configPersistenceService.setUpDefaultAudio();
   }
 
-
-  saveOverlay(overlayFilePath: string) {
+  async saveOverlay(overlayFilePath: string) {
     const root = new RootNode();
     const assetsPath = fs.mkdtempSync(path.join(os.tmpdir(), 'overlay-assets'));
 
-    root.save({ assetsPath });
+    await root.save({ assetsPath });
     const config = JSON.stringify(root, null, 2);
     const configPath = path.join(assetsPath, 'config.json');
     fs.writeFileSync(configPath, config);
 
-    return new Promise(resolve => {
-      asar.createPackage(assetsPath, overlayFilePath, resolve);
+    const output = fs.createWriteStream(overlayFilePath);
+    const archive = archiver('zip', { zlib: { level: 9 } });
+
+    await new Promise(resolve => {
+      output.on('close', (err: any) => {
+        resolve();
+      });
+
+      archive.pipe(output);
+      archive.directory(assetsPath, false);
+      archive.finalize();
     });
   }
-
 
   ensureOverlaysDirectory() {
     if (!fs.existsSync(this.overlaysDirectory)) {
@@ -67,9 +83,7 @@ export class OverlaysPersistenceService extends Service {
     }
   }
 
-
   get overlaysDirectory() {
     return path.join(electron.remote.app.getPath('userData'), 'Overlays');
   }
-
 }

--- a/app/services/config-persistence/overlays.ts
+++ b/app/services/config-persistence/overlays.ts
@@ -14,7 +14,7 @@ import electron from 'electron';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import unzip from 'unzip';
+import unzip from 'unzip-stream';
 import archiver from 'archiver';
 
 const NODE_TYPES = {

--- a/app/services/settings.ts
+++ b/app/services/settings.ts
@@ -104,6 +104,7 @@ export class SettingsService extends StatefulService<ISettingsState> implements 
 
     // we decided to not expose API settings for production version yet
     if (Utils.isDevMode()) categories = categories.concat(['API']);
+    categories = categories.concat('Overlays');
 
     return categories;
   }

--- a/app/services/sources/index.ts
+++ b/app/services/sources/index.ts
@@ -265,7 +265,6 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     this.sourceRemoved.next(source.sourceState);
   }
 
-
   suggestName(name: string): string {
     return namingHelpers.suggestName(name, (name: string) => this.getSourceByName(name));
   }
@@ -543,6 +542,22 @@ export class Source implements ISourceApi {
 
   getPropertiesManagerUI() {
     return this.sourcesService.propertiesManagers[this.sourceId].manager.customUIComponent;
+  }
+
+
+  /**
+   * Replaces the current properties manager on a source
+   * @param type the type of the new properties manager
+   * @param settings the properties manager settings
+   */
+  replacePropertiesManager(type: TPropertiesManager, settings: Dictionary<any>) {
+    const oldManager = this.sourcesService.propertiesManagers[this.sourceId].manager;
+    oldManager.destroy();
+
+    const managerKlass = PROPERTIES_MANAGER_TYPES[type];
+    this.sourcesService.propertiesManagers[this.sourceId].manager =
+      new managerKlass(this.getObsInput(), settings);
+    this.sourcesService.propertiesManagers[this.sourceId].type = type;
   }
 
 

--- a/main.js
+++ b/main.js
@@ -212,8 +212,14 @@ function startApp() {
 
   if (isDevMode) {
     require('devtron').install();
+
+    // Vue dev tools appears to cause strange non-deterministic
+    // interference with certain NodeJS APIs, expecially asynchronous
+    // IO from the renderer process.  Enable at your own risk.
+
     // const devtoolsInstaller = require('electron-devtools-installer');
     // devtoolsInstaller.default(devtoolsInstaller.VUEJS_DEVTOOLS);
+
     openDevTools();
   }
 

--- a/main.js
+++ b/main.js
@@ -212,8 +212,8 @@ function startApp() {
 
   if (isDevMode) {
     require('devtron').install();
-    const devtoolsInstaller = require('electron-devtools-installer');
-    devtoolsInstaller.default(devtoolsInstaller.VUEJS_DEVTOOLS);
+    // const devtoolsInstaller = require('electron-devtools-installer');
+    // devtoolsInstaller.default(devtoolsInstaller.VUEJS_DEVTOOLS);
     openDevTools();
   }
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "asar": "^0.13.0",
     "aws-sdk": "^2.43.0",
-    "backtrace-node": "^0.7.3",
     "backtrace-js": "^0.0.4",
+    "backtrace-node": "^0.7.3",
     "electron-updater": "^1.14.0",
     "font-manager": "^0.2.2",
     "lodash": "^4.17.4",
@@ -73,7 +73,6 @@
     "obs-studio-node": "file:./obs-studio-node",
     "rimraf": "^2.6.1",
     "socket.io-client": "2.0.3",
-    "unzip": "^0.1.11",
     "uuid": "^3.0.1",
     "vue-popperjs": "^1.2.2"
   },
@@ -123,6 +122,7 @@
     "tslint-loader": "^3.5.3",
     "typedoc": "^0.9.0",
     "typescript": "^2.4.2",
+    "unzip-stream": "^0.2.1",
     "urijs": "^1.18.5",
     "vue": "^2.1.10",
     "vue-color": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "arch": "x64"
   },
   "dependencies": {
-    "archiver": "^2.0.3",
     "asar": "^0.13.0",
     "aws-sdk": "^2.43.0",
     "backtrace-node": "^0.7.3",
@@ -73,6 +72,7 @@
     "obs-studio-node": "file:./obs-studio-node",
     "rimraf": "^2.6.1",
     "socket.io-client": "2.0.3",
+    "unzip": "^0.1.11",
     "uuid": "^3.0.1",
     "vue-popperjs": "^1.2.2"
   },
@@ -82,6 +82,7 @@
     "@types/lodash": "^4.14.64",
     "@types/node": "^7.0.18",
     "@types/socket.io-client": "^1.4.31",
+    "archiver": "^2.0.3",
     "ava": "^0.19.1",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.2.3",
@@ -95,7 +96,7 @@
     "devtron": "^1.4.0",
     "electron": "1.7.7",
     "electron-builder": "^19.22.1",
-    "electron-devtools-installer": "^2.1.0",
+    "electron-devtools-installer": "^2.2.1",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-plugin-import": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "devDependencies": {
     "7zip-bin": "^2.0.4",
+    "@types/archiver": "^2.0.1",
     "@types/lodash": "^4.14.64",
     "@types/node": "^7.0.18",
     "@types/socket.io-client": "^1.4.31",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,14 +36,15 @@ module.exports = {
   // We want to dynamically require native addons
   externals: {
     'font-manager': 'require("font-manager")',
-    'socket.io-client': 'require("socket.io-client")',
-    'rimraf': 'require("rimraf")',
 
-    // Not actually a native addons, but are super big so we don't
-    // bother compiling them into our bundle.
+    // Not actually a native addons, but for one reason or another
+    // we don't want them compiled in our webpack bundle.
     'aws-sdk': 'require("aws-sdk")',
     'asar': 'require("asar")',
-    'backtrace-node': 'require("backtrace-node")'
+    'backtrace-node': 'require("backtrace-node")',
+    'socket.io-client': 'require("socket.io-client")',
+    'rimraf': 'require("rimraf")',
+    'unzip': 'require("unzip")'
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,6 @@ module.exports = {
     'backtrace-node': 'require("backtrace-node")',
     'socket.io-client': 'require("socket.io-client")',
     'rimraf': 'require("rimraf")',
-    'unzip': 'require("unzip")',
     'backtrace-js': 'require("backtrace-js")'
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2547,9 +2547,9 @@ electron-chromedriver@~1.7.1:
     electron-download "^4.1.0"
     extract-zip "^1.6.5"
 
-electron-devtools-installer@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.1.0.tgz#fee3b23e491aa10dfc77192c58cf5596cc2ba53e"
+electron-devtools-installer@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/electron-devtools-installer/-/electron-devtools-installer-2.2.1.tgz#0beb73ccbf65cbc4d09e706cebda638f839b8c55"
   dependencies:
     "7zip" "0.0.6"
     cross-unzip "0.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,12 @@
     ansi-styles "^2.2.1"
     esutils "^2.0.2"
 
+"@types/archiver@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-2.0.1.tgz#223044ac1e924d07b679b727a145755f858c413b"
+  dependencies:
+    "@types/glob" "*"
+
 "@types/fs-extra@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7118,6 +7118,13 @@ unzip-response@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-2.0.1.tgz#d2f0f737d16b0615e72a6935ed04214572d56f97"
 
+unzip-stream@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/unzip-stream/-/unzip-stream-0.2.1.tgz#2a52fde6e57788dfb1297aab38c70ec548dfae91"
+  dependencies:
+    binary "^0.3.0"
+    mkdirp "^0.5.1"
+
 unzip@^0.1.11:
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/unzip/-/unzip-0.1.11.tgz#89749c63b058d7d90d619f86b98aa1535d3b97f0"


### PR DESCRIPTION
In this PR:
- Expose overlay import/export in a new tab of settings
- Move overlay save/load to use async/await for code tidiness
- Allow importing of an overlay into a new scene collection named after the overlay file
- Overlays now support exporting/importing streamlabels
- Overlays now support exporting/importing widgets
