### PR TITLE
fix overlay widget importing

### DIFF
--- a/app/services/scenes-collections/nodes/overlays/widget.ts
+++ b/app/services/scenes-collections/nodes/overlays/widget.ts
@@ -34,6 +34,9 @@ export class WidgetNode extends Node<ISchema, IContext> {
     context.sceneItem.source.replacePropertiesManager('widget', {
       widgetType: this.data.type
     });
+
+    // Make sure we don't override the url setting
+    delete this.data.settings['url'];
     context.sceneItem.getObsInput().update(this.data.settings);
   }
 }

--- a/app/services/scenes-collections/nodes/overlays/widget.ts
+++ b/app/services/scenes-collections/nodes/overlays/widget.ts
@@ -37,6 +37,6 @@ export class WidgetNode extends Node<ISchema, IContext> {
 
     // Make sure we don't override the url setting
     delete this.data.settings['url'];
-    context.sceneItem.getObsInput().update(this.data.settings);
+    context.sceneItem.getSource().updateSettings(this.data.settings);
   }
 }

--- a/app/services/scenes-collections/nodes/overlays/widget.ts
+++ b/app/services/scenes-collections/nodes/overlays/widget.ts
@@ -34,5 +34,6 @@ export class WidgetNode extends Node<ISchema, IContext> {
     context.sceneItem.source.replacePropertiesManager('widget', {
       widgetType: this.data.type
     });
+    context.sceneItem.getObsInput().update(this.data.settings);
   }
 }

--- a/app/services/sources/properties-managers/widget-manager.ts
+++ b/app/services/sources/properties-managers/widget-manager.ts
@@ -34,9 +34,7 @@ export class WidgetManager extends PropertiesManager {
 
   setWidgetType(type: WidgetType) {
     this.obsSource.update({
-      url: this.widgetsService.getWidgetUrl(type),
-      width: WidgetDefinitions[type].width,
-      height: WidgetDefinitions[type].height
+      url: this.widgetsService.getWidgetUrl(type)
     });
   }
 


### PR DESCRIPTION
We weren't importing saved settings on the browser source.  I already packaged up a version on this branch for Eric to distribute to designers, so we just need to make sure this hits staging before next release.