### PR TITLE
Fix typo preventing end stream via hotkeys

### DIFF
--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -69,7 +69,7 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
     {
       name: 'TOGGLE_STOP_STREAMING',
       description: () => 'Stop Streaming',
-      down: () => getStreamingService().startStreaming(),
+      down: () => getStreamingService().stopStreaming(),
       isActive: () => !getStreamingService().isStreaming
     },
     {


### PR DESCRIPTION
A fix for:
* https://tracker.streamlabs.com/view.php?id=100
* https://tracker.streamlabs.com/view.php?id=97