### PR TITLE
Upgrade vue-color which comes with various fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "unzip-stream": "^0.2.1",
     "urijs": "^1.18.5",
     "vue": "^2.1.10",
-    "vue-color": "^2.0.6",
+    "vue-color": "^2.4.3",
     "vue-loader": "^10.2.0",
     "vue-multiselect": "2.0.3",
     "vue-property-decorator": "^5.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7286,9 +7286,9 @@ vue-class-component@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-5.0.1.tgz#feda06c3da266cee9064e224ba491e089923dce8"
 
-vue-color@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/vue-color/-/vue-color-2.0.6.tgz#3a5d214dcb8cbb8c5fc2073986e01c268a8fe83c"
+vue-color@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/vue-color/-/vue-color-2.4.3.tgz#184bff4e4c163a6dd391cdbf460172cef600c187"
   dependencies:
     lodash.throttle "^4.0.0"
     material-colors "^1.0.0"


### PR DESCRIPTION
Fixes the following:
* Dragging outside of the color picker area resets hue bar
* Specifying a hex value is ridiculous at best
* Hovering near the bottom of the color picker causes chaotic and weird behavior
* A more consistent feel in general