### PR TITLE
Implement guest API system

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -43,6 +43,7 @@ import { ObserveList } from './util/service-observer';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
+import { GuestApiService } from 'services/guest-api';
 
 const { ipcRenderer } = electron;
 
@@ -143,7 +144,8 @@ export class ServicesManager extends Service {
     IpcServerService,
     TcpServerService,
     StreamInfoService,
-    StreamlabelsService
+    StreamlabelsService,
+    GuestApiService
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/guest-api.ts
+++ b/app/services/guest-api.ts
@@ -22,7 +22,7 @@ export interface IGuestApiCallback {
 }
 
 /**
- * A dictionary of functions to expose to the child window
+ * A dictionary of functions to expose to the guest content
  */
 export interface IRequestHandler {
   [key: string]: (...args: any[]) => Promise<any>;

--- a/app/services/guest-api.ts
+++ b/app/services/guest-api.ts
@@ -1,0 +1,86 @@
+import { Service } from 'services/service';
+
+/**
+ * Shared message interchange format
+ */
+export interface IGuestApiRequest {
+  id: string;
+  method: string;
+  args: any[];
+}
+
+export interface IGuestApiResponse {
+  id: string;
+  error: boolean;
+  result: any;
+}
+
+export interface IGuestApiCallback {
+  requestId: string;
+  callbackId: string;
+  args: any[];
+}
+
+/**
+ * A dictionary of functions to expose to the child window
+ */
+export interface IRequestHandler {
+  [key: string]: (...args: any[]) => Promise<any>;
+}
+
+/**
+ * This class allows injection of functions into webviews.
+ */
+export class GuestApiService extends Service {
+  /**
+   * Exposes the passed functions to the webview.  You should be careful
+   * what functions you expose, as the caller is considered un-trusted.
+   * @param webview the target webview
+   * @param requestHandler an object with the API you want to expose
+   */
+  exposeApi(webview: Electron.WebviewTag, requestHandler: IRequestHandler) {
+    webview.addEventListener('ipc-message', msg => {
+      if (msg.channel === 'guestApiRequest') {
+        const apiRequest: IGuestApiRequest = msg.args[0];
+
+        const mappedArgs = apiRequest.args.map(arg => {
+          const isCallbackPlaceholder = (typeof arg === 'object') && arg && arg.__guestApiCallback;
+
+          if (isCallbackPlaceholder) {
+            return (...args: any[]) => {
+              const callbackObj: IGuestApiCallback = {
+                requestId: apiRequest.id,
+                callbackId: arg.id,
+                args
+              };
+
+              webview.send('guestApiCallback', callbackObj);
+            };
+          }
+
+          return arg;
+        });
+
+        requestHandler[apiRequest.method](...mappedArgs)
+          .then(result => {
+            const response: IGuestApiResponse = {
+              id: apiRequest.id,
+              error: false,
+              result
+            };
+
+            webview.send('guestApiResponse', response);
+          })
+          .catch(result => {
+            const response: IGuestApiResponse = {
+              id: apiRequest.id,
+              error: true,
+              result
+            };
+
+            webview.send('guestApiResponse', response);
+          });
+      }
+    });
+  }
+}

--- a/guest-api/index.ts
+++ b/guest-api/index.ts
@@ -1,0 +1,93 @@
+/**
+ * This script is injected into guest webviews and used by the app
+ * to expose small pieces of functionality based on the guest content.
+ */
+
+import electron from 'electron';
+import {
+  IGuestApiRequest,
+  IGuestApiResponse,
+  IGuestApiCallback
+} from '../app/services/guest-api';
+
+(() => {
+  interface IRequest {
+    resolve: (val: any) => void;
+    reject: (val: any) => void;
+    callbacks: {
+      [callbackId: string]: Function;
+    };
+  }
+
+  const requests: {
+    [requestId: string]: IRequest;
+  } = {};
+  let idCounter = 0;
+
+  const getUniqueId = () => {
+    idCounter += 1;
+    return idCounter.toString();
+  };
+
+  electron.ipcRenderer.on(
+    'guestApiCallback',
+    (event: any, response: IGuestApiCallback) => {
+      requests[response.requestId].callbacks[response.callbackId](...response.args);
+    }
+  );
+
+  electron.ipcRenderer.on(
+    'guestApiResponse',
+    (event: any, response: IGuestApiResponse) => {
+      if (response.error) {
+        requests[response.id].reject(response.result);
+      } else {
+        requests[response.id].resolve(response.result);
+      }
+    }
+  );
+
+  global['streamlabsOBS'] = new Proxy(
+    {},
+    {
+      get(target, key) {
+        return (...args: any[]) => {
+          const requestId = getUniqueId();
+          requests[requestId] = {
+            resolve: null,
+            reject: null,
+            callbacks: {}
+          };
+          const promise = new Promise((resolve, reject) => {
+            requests[requestId].resolve = resolve;
+            requests[requestId].reject = reject;
+          });
+          const mappedArgs = args.map(arg => {
+            if (typeof arg === 'function') {
+              const callbackId = getUniqueId();
+
+              requests[requestId].callbacks[callbackId] = arg;
+
+              return {
+                __guestApiCallback: true,
+                id: callbackId
+              };
+            }
+
+            return arg;
+          });
+
+          const apiRequest: IGuestApiRequest = {
+            id: requestId,
+            method: key.toString(),
+            args: mappedArgs
+          };
+
+          electron.ipcRenderer.sendToHost('guestApiRequest', apiRequest);
+
+          return promise;
+        };
+      }
+    }
+  );
+})();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,8 @@ const plugins = [];
 module.exports = {
   entry: {
     renderer: './app/app.ts',
-    updater: './updater/ui.js'
+    updater: './updater/ui.js',
+    'guest-api': './guest-api'
   },
   output: {
     path: __dirname + '/bundles',


### PR DESCRIPTION
## The Problem:
We need to expose an API for remotely loaded webpages in guest webviews that allows them to interact with the host application (Streamlabs OBS).  Because the host is extremely privileged (full node integration), we need to be very careful about what API we provide to the remote content.  We want to be able to provide the minimum possible API on a per-webview basis.  This will usually be 1 or 2 specific-purpose functions that the guest content will call.

## Theory
Electron allows us to inject a privileged preload script that can expose some global functions before node integration is removed from the webview and the guest content is loaded.

## Solution
For guest webviews that require access to our app, we require a preload script that sets up a global `streamlabsOBS` proxy object.  The Vue component that owns the webview can expose one or more functions to that webview by passing the webview and a request handler object to the `GuestApiService`, which performs the necessary setup.  When the guest content calls a function on the `streamlabsOBS` global, it is proxied to the request handler.  Any callback functions are replaced with placeholder objects and proxied via IPC events.  Functions on the request handler object must be asynchronous and return a promise.