### PR TITLE
selectively lock out the UI while loading

### DIFF
--- a/app/components/StartStreamingButton.vue
+++ b/app/components/StartStreamingButton.vue
@@ -1,7 +1,11 @@
 <template>
 <button
   class="button button--go-live"
-  :class="{'button--soft-warning': (streamingService.isStreaming && streamingService.stopStreaming), 'button--action': streamingService.startStreaming}"
+  :class="{
+    'button--soft-warning': (streamingService.isStreaming && streamingService.stopStreaming),
+    'button--action': streamingService.startStreaming
+  }"
+  :disabled="disabled"
   @click="toggleStreaming">{{streamButtonLabel}}</button>
 </template>
 

--- a/app/components/StartStreamingButton.vue
+++ b/app/components/StartStreamingButton.vue
@@ -1,10 +1,7 @@
 <template>
 <button
-  class="button button--go-live"
-  :class="{
-    'button--soft-warning': (streamingService.isStreaming && streamingService.stopStreaming),
-    'button--action': streamingService.startStreaming
-  }"
+  class="button button--go-live button--action"
+  :class="{ 'button--soft-warning': streamingService.isStreaming }"
   :disabled="disabled"
   @click="toggleStreaming">{{streamButtonLabel}}</button>
 </template>

--- a/app/components/StartStreamingButton.vue.ts
+++ b/app/components/StartStreamingButton.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import { StreamingService } from '../services/streaming';
 import { Inject } from '../util/injector';
 import { NavigationService } from '../services/navigation';
@@ -8,19 +8,22 @@ import { CustomizationService } from '../services/customization';
 
 @Component({})
 export default class StartStreamingButton extends Vue {
-
   @Inject() streamingService: StreamingService;
   @Inject() userService: UserService;
   @Inject() customizationService: CustomizationService;
   @Inject() navigationService: NavigationService;
 
+  @Prop() disabled: boolean;
+
   toggleStreaming() {
     if (this.streamingService.isStreaming) {
       this.streamingService.stopStreaming();
     } else {
-      if (this.userService.isLoggedIn()
-        && this.customizationService.state.updateStreamInfoOnLive
-        && this.userService.platform.type === 'twitch') {
+      if (
+        this.userService.isLoggedIn() &&
+        this.customizationService.state.updateStreamInfoOnLive &&
+        this.userService.platform.type === 'twitch'
+      ) {
         this.streamingService.showEditStreamInfo();
       } else {
         this.streamingService.startStreaming();
@@ -38,5 +41,4 @@ export default class StartStreamingButton extends Vue {
 
     return 'Go Live';
   }
-
 }

--- a/app/components/StudioFooter.vue
+++ b/app/components/StudioFooter.vue
@@ -8,6 +8,7 @@
     </div>
     <div class="nav-item">
       <button
+        :disabled="locked"
         class="record-button"
         @click="toggleRecording"
         :class="{ active: streamingService.isRecording }">
@@ -15,7 +16,7 @@
       </button>
     </div>
     <div class="nav-item">
-      <start-streaming-button />
+      <start-streaming-button :disabled="locked" />
     </div>
   </div>
 </div>

--- a/app/components/StudioFooter.vue.ts
+++ b/app/components/StudioFooter.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import { Inject } from '../util/injector';
 import { StreamingService } from '../services/streaming';
 import StartStreamingButton from './StartStreamingButton.vue';
@@ -15,12 +15,10 @@ import { UserService } from '../services/user';
   }
 })
 export default class StudioFooterComponent extends Vue {
+  @Inject() streamingService: StreamingService;
+  @Inject() userService: UserService;
 
-  @Inject()
-  streamingService: StreamingService;
-
-  @Inject()
-  userService:UserService;
+  @Prop() locked: boolean;
 
   toggleRecording() {
     if (this.recording) {
@@ -37,5 +35,4 @@ export default class StudioFooterComponent extends Vue {
   get loggedIn() {
     return this.userService.isLoggedIn();
   }
-
 }

--- a/app/components/TopNav.vue
+++ b/app/components/TopNav.vue
@@ -11,19 +11,19 @@
     <button
       @click="navigateDashboard"
       class="tab-button"
-      :class="{ active: page === 'Dashboard' }" :disabled="!isUserLoggedIn">
+      :class="{ active: page === 'Dashboard' }" :disabled="!isUserLoggedIn || locked">
       <i class="fa fa-tachometer"/> Dashboard
     </button>
     <button
       @click="navigateStudio"
       class="tab-button"
-      :class="{ active: page === 'Studio' }">
+      :class="{ active: page === 'Studio' }" :disabled="locked">
       <i class="fa fa-video-camera"/> Editor
     </button>
     <button
       @click="navigateLive"
       class="tab-button"
-      :class="{ active: page === 'Live' }" :disabled="!isUserLoggedIn">
+      :class="{ active: page === 'Live' }" :disabled="!isUserLoggedIn || locked">
       <i class="fa fa-list"/> Live
     </button>
   </div>

--- a/app/components/TopNav.vue.ts
+++ b/app/components/TopNav.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import { Inject } from '../util/injector';
 import { CustomizationService } from '../services/customization';
 import { NavigationService } from '../services/navigation';
@@ -21,6 +21,8 @@ export default class TopNav extends Vue {
   @Inject() userService: UserService;
 
   slideOpen = false;
+
+  @Prop() locked: boolean;
 
   navigateStudio() {
     this.navigationService.navigate('Studio');

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -5,15 +5,15 @@
   <div class="main-contents">
     <live-dock v-if="isLoggedIn && leftDock && !isOnboarding" :onLeft="true" />
     <div class="main-middle">
-      <div v-if="applicationLoading" class="main-loading">
+      <top-nav v-if="(page !== 'Onboarding')" :locked="applicationLoading"></top-nav>
+      <div v-if="shouldLockContent" class="main-loading">
         <i class="fa fa-spinner fa-pulse main-loading-spinner"/>
       </div>
-      <top-nav v-if="(page !== 'Onboarding') && !applicationLoading"></top-nav>
       <component
-        v-if="!applicationLoading"
+        v-if="!shouldLockContent"
         class="main-page-container"
         :is="page"/>
-      <studio-footer v-if="(page !== 'Onboarding') && !applicationLoading"/>
+      <studio-footer v-if="(page !== 'Onboarding')" :locked="applicationLoading" />
     </div>
     <live-dock v-if="isLoggedIn && !leftDock && !isOnboarding" />
   </div>

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -81,4 +81,14 @@ export default class Main extends Vue {
     return this.navigationService.state.currentPage === 'Onboarding';
   }
 
+  /**
+   * Only certain pages get locked out while the application
+   * is loading.  Other pages are OK to keep using.
+   */
+  get shouldLockContent() {
+    return this.applicationLoading &&
+      ((this.navigationService.state.currentPage === 'Studio') ||
+      (this.navigationService.state.currentPage === 'Live'));
+  }
+
 }


### PR DESCRIPTION
Previously we just replaced almost the entire UI with a spinner while loading.  However, overlays require that we actually be able to show more specific information while loading an overlay.  To enable this, we are moving over to more selectively locking out specific pieces of the UI.  Now, during the loading state we:

- Show a spinner in place of the Editor and Live pages
- Disable navigation in the Top Nav
- Disable toggling streaming and recording in the footer

This new system is possibly slightly more prone to breakage since more parts of the app need to know about and understand the loading state.  However, it is a little less jarring, and is required for overlays.