### PR TITLE
fix scene collection switching

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -163,22 +163,26 @@ export class AppService extends StatefulService<IAppState>
   /**
    * remove the config and load the new one
    */
-  removeCurrentConfig() {
+  async removeCurrentConfig() {
+    this.START_LOADING();
+    this.disableAutosave();
     this.scenesCollectionsService.removeConfig();
     if (this.scenesCollectionsService.hasConfigs()) {
       this.loadConfig('', { saveCurrent: false });
     } else {
-      this.switchToBlankConfig();
+      await this.switchToBlankConfig();
     }
   }
 
   /**
    * reset current scenes and switch to blank config
    */
-  switchToBlankConfig(configName?: string) {
+  async switchToBlankConfig(configName?: string) {
     this.reset();
     this.scenesCollectionsService.switchToBlankConfig(configName);
+    await this.scenesCollectionsService.rawSave();
     this.enableAutoSave();
+    this.FINISH_LOADING();
   }
 
   @track('app_close')


### PR DESCRIPTION
This fixes a couple minor bugs with scene collection switching:
- Immediately save blank configs, otherwise if you switch away and switch back it will break and cause an infinite loading spinner
- Show the spinner when removing configs to prevent interfering with the de-loading process.