### PR TITLE
fix mixer memory leaks when switching scenes

### DIFF
--- a/app/components/Mixer.vue
+++ b/app/components/Mixer.vue
@@ -11,7 +11,7 @@
     </div>
   </div>
   <div class="studio-controls-selector mixer-panel">
-    <MixerItem v-for="audioSource in audioSources" :audioSource="audioSource" :key="audioSource.name"/>
+    <MixerItem v-for="audioSource in audioSources" :audioSource="audioSource" :key="audioSource.sourceId"/>
   </div>
 </div>
 </template>

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -17,6 +17,7 @@ import {
   IAudioDevice, IAudioServiceApi, IAudioSource, IAudioSourceApi, IAudioSourcesState, IFader,
   IVolmeter
 } from './audio-api';
+import { Observable } from 'rxjs/Observable';
 
 const { ipcRenderer } = electron;
 
@@ -34,7 +35,7 @@ interface IAudioSourceData {
   fader?: obs.IFader;
   volmeter?: obs.IVolmeter;
   callbackInfo?: obs.ICallbackData;
-  stream?: Subject<IVolmeter>;
+  stream?: Observable<IVolmeter>;
 }
 
 @InitAfter('SourcesService')


### PR DESCRIPTION
It turns out that `volmeter.addCallback` is not really safe memory-wise, and we should call it as infrequently as possible.