### PR TITLE
dynamic notifications

### DIFF
--- a/app/components/NotificationsArea.vue
+++ b/app/components/NotificationsArea.vue
@@ -17,17 +17,18 @@
     <span class="fa fa-info-circle"></span>
   </div>
 
-  <div class="notifications__container">
+  <div class="notifications__container flex--grow" ref="notificationsContainer">
     <div
-        v-for="notify in notifications"
-        class="notification"
-        @click="onNotificationClickHandler(notify.id)"
-        :class="{
-      'info': notify.type == 'INFO',
-      'warning': notify.type == 'WARNING',
-      'has-action': notify.action && !notify.outdated,
-      'outdated': notify.outdated
-    }"
+      v-for="notify in notifications"
+      class="notification"
+      v-show="showExtendedNotifications"
+      @click="onNotificationClickHandler(notify.id)"
+      :class="{
+        'info': notify.type == 'INFO',
+        'warning': notify.type == 'WARNING',
+        'has-action': notify.action && !notify.outdated,
+        'outdated': notify.outdated
+      }"
     >
       {{ notify.message }} <span v-if="notify.showTime"> {{ moment(notify.date) }} </span>
     </div>
@@ -43,7 +44,7 @@
 
 .notifications-area {
   overflow: hidden;
-  min-width: 300px;
+  min-width: 50px;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -51,7 +52,6 @@
 
 .notifications__container {
   position: relative;
-  min-width: 350px;
   height: 30px;
 }
 

--- a/app/components/NotificationsArea.vue.ts
+++ b/app/components/NotificationsArea.vue.ts
@@ -18,11 +18,19 @@ interface IUiNotification extends INotification {
 export default class NotificationsArea extends Vue {
   @Inject() private notificationsService: NotificationsService;
 
+  showExtendedNotifications = true;
+
+  sizeCheckIntervalId: number;
+
   notifications: IUiNotification[] = [];
   private notificationQueue: INotification[] = [];
   private notifyAudio: HTMLAudioElement;
   private checkQueueIntervalId: number = null;
   private canShowNextNotify = true;
+
+  $refs: {
+    notificationsContainer: HTMLDivElement;
+  };
 
   mounted() {
     this.notifyAudio = new Audio(notificationAudio);
@@ -39,6 +47,14 @@ export default class NotificationsArea extends Vue {
       () => this.checkQueue(),
       QUEUE_TIME
     );
+
+    this.sizeCheckIntervalId = window.setInterval(() => {
+      if (this.$refs.notificationsContainer.offsetWidth < 300) {
+        this.showExtendedNotifications = false;
+      } else {
+        this.showExtendedNotifications = true;
+      }
+    }, 1000);
   }
 
   destroyed() {

--- a/app/components/NotificationsArea.vue.ts
+++ b/app/components/NotificationsArea.vue.ts
@@ -59,6 +59,7 @@ export default class NotificationsArea extends Vue {
 
   destroyed() {
     clearInterval(this.checkQueueIntervalId);
+    clearInterval(this.sizeCheckIntervalId);
   }
 
   get unreadCount() {

--- a/app/components/StudioFooter.vue
+++ b/app/components/StudioFooter.vue
@@ -1,8 +1,8 @@
 <template>
 <div class="footer">
-  <div class="flex flex--center">
+  <div class="flex flex--center flex--grow">
     <performance-metrics />
-    <notifications-area class="notifications-area"/>
+    <notifications-area class="notifications-area flex--grow"/>
   </div>
 
   <div class="nav-right">

--- a/app/styles/classes.less
+++ b/app/styles/classes.less
@@ -19,6 +19,10 @@
   flex-direction: column;
 }
 
+.flex--grow {
+  flex-grow: 1;
+}
+
 .flex__column {
   display: flex;
   flex-flow: column;


### PR DESCRIPTION
It's a little weird, but I think this is going to be the most reliable solution for notifications.  Basically the solution involves allowing the notifications area to grow/shrink to take up all the remaining space in the footer.  Then, the notifications area is constantly checking the size of itself, and hides the full text of the notification if the area it occupies is too small.