### PR TITLE
Add title attribute to BrowserWindow

### DIFF
--- a/main.js
+++ b/main.js
@@ -122,7 +122,8 @@ function startApp() {
     width: 1600,
     height: 1000,
     show: false,
-    frame: false
+    frame: false,
+    title: "Streamlabs OBS",
   });
 
   mainWindow.setMenu(null);


### PR DESCRIPTION
This change makes it so that "slobs-client" isn't visible in Task Switcher.
  
![image](https://user-images.githubusercontent.com/4652603/34588957-cf31a6d2-f17d-11e7-8fa6-9a14543d1e69.png)
