### PR TITLE
Add fix for custom fonts

### DIFF
--- a/app/components/shared/forms/FontInput.vue.ts
+++ b/app/components/shared/forms/FontInput.vue.ts
@@ -25,6 +25,7 @@ class FontInput extends Input<IFormInput<IFont>> {
       ...this.value,
       value: {
         path: font.path,
+        face: font.face,
         size: Number(font.size)
       }
     });
@@ -34,6 +35,7 @@ class FontInput extends Input<IFormInput<IFont>> {
   get googleFont() {
     return {
       path: this.value.value.path,
+      face: this.value.value.face,
       size: this.value.value.size
     };
   }

--- a/app/components/shared/forms/GoogleFontSelector.vue.ts
+++ b/app/components/shared/forms/GoogleFontSelector.vue.ts
@@ -67,6 +67,7 @@ export default class GoogleFontSelector extends Input<IGoogleFont> {
       const style = family.styles[0];
 
       this.updateStyles();
+      this.value.face = familyName;
       this.setStyle(style.name);
     });
   }
@@ -77,14 +78,14 @@ export default class GoogleFontSelector extends Input<IGoogleFont> {
 
     this.fontLibraryService.findStyle(this.selectedFamily, styleName).then(style => {
       this.fontLibraryService.downloadFont(style.file).then(fontPath => {
-        this.emitInput({ path: fontPath, size: this.value.size });
+        this.emitInput({ ...this.value, path: fontPath });
         this.loading = false;
       });
     });
   }
 
   setSize(size: string) {
-    this.emitInput({ path: this.value.path, size });
+    this.emitInput({ ...this.value, size });
   }
 
 }

--- a/app/components/shared/forms/Input.ts
+++ b/app/components/shared/forms/Input.ts
@@ -93,6 +93,7 @@ export interface IFont {
 }
 
 export interface IGoogleFont {
+  face?: string;
   path?: string;
   size?: string;
 }

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -464,7 +464,6 @@ export class ServicesManager extends Service {
             throw 'IPC request failed: check the errors in the main window';
           }
 
-          console.log('response', response);
           const result = response.result;
           response.mutations.forEach(mutation => commitMutation(mutation));
 

--- a/app/services/font-library.ts
+++ b/app/services/font-library.ts
@@ -45,6 +45,27 @@ export class FontLibraryService extends Service {
     return Promise.resolve(this.manifest);
   }
 
+  /* This scans the entire manifest (which is slow)
+   * to find a filename, then finds the family name
+   * in the parent. This also doesn't take into account
+   * font files yet. This function is used mostly for
+   * upgrading config schema */
+  findFontFile(baseFileName: string): Promise<IFontFamily> {
+    return this.getManifest().then(manifest => {
+      for (const family_name in manifest.families) {
+        const family = manifest.families[family_name];
+
+        for (const style_name in family.styles) {
+          const style = family.styles[style_name];
+
+          if (baseFileName === style.file) {
+            return family;
+          }
+        }
+      }
+    });
+  }
+
 
   findFamily(family: string): Promise<IFontFamily> {
     return this.getManifest().then(manifest => {

--- a/app/services/font-library.ts
+++ b/app/services/font-library.ts
@@ -52,11 +52,11 @@ export class FontLibraryService extends Service {
    * upgrading config schema */
   findFontFile(baseFileName: string): Promise<IFontFamily> {
     return this.getManifest().then(manifest => {
-      for (const family_name in manifest.families) {
-        const family = manifest.families[family_name];
+      for (let i = 0; i < manifest.families.length; ++i) {
+        const family = manifest.families[i];
 
-        for (const style_name in family.styles) {
-          const style = family.styles[style_name];
+        for (let k = 0; k < family.styles.length; ++k) {
+          const style = family.styles[k];
 
           if (baseFileName === style.file) {
             return family;

--- a/app/services/scenes-collections/nodes/sources.ts
+++ b/app/services/scenes-collections/nodes/sources.ts
@@ -1,13 +1,17 @@
 import { Node } from './node';
-import { SourcesService, Source, TSourceType } from '../../sources';
 import { FiltersNode } from './filters';
-import { FontLibraryService } from '../../font-library';
-import { AudioService } from '../../audio';
-import { HotkeysService } from '../../hotkeys';
-import { Inject } from '../../../util/injector';
 import { HotkeysNode } from './hotkeys';
+import { 
+  SourcesService, 
+  Source, 
+  TSourceType, 
+  TPropertiesManager 
+} from 'services/sources';
+import { FontLibraryService } from 'services/font-library';
+import { AudioService } from 'services/audio';
+import { HotkeysService } from 'services/hotkeys';
+import { Inject } from '../../../util/injector';
 import * as obs from '../../../../obs-api';
-import { TPropertiesManager } from 'services/sources';
 import path from 'path';
 
 interface ISchema {


### PR DESCRIPTION
There's a new migration pattern for sources that will add face properties to the settings.font object. This is similar to a normal font but wasn't required before. 

This should also fix custom fonts and outlines. 