### PR TITLE
Combine ISliderInputForm with INumberInputForm

### DIFF
--- a/app/components/shared/forms/Input.ts
+++ b/app/components/shared/forms/Input.ts
@@ -67,11 +67,6 @@ export interface IPathInputValue extends IFormInput<string> {
 }
 
 export interface INumberInputValue extends IFormInput<number> {
-  minVal?: number;
-  maxVal?: number;
-}
-
-export interface ISliderInputValue extends IFormInput<number> {
   minVal: number;
   maxVal: number;
   stepVal: number;
@@ -209,18 +204,16 @@ export function obsValuesToInputValues(
       prop.value = !!prop.value;
 
     } else if (['OBS_PROPERTY_INT', 'OBS_PROPERTY_FLOAT', 'OBS_PROPERTY_DOUBLE'].includes(obsProp.type)) {
-
-      prop.value = Number(prop.value);
+      prop = {
+        ...prop,
+        value: Number(prop.value),
+        minVal: Number(obsProp.minVal),
+        maxVal: Number(obsProp.maxVal),
+        stepVal: Number(obsProp.stepVal)
+      } as INumberInputValue;
 
       if (obsProp.subType === 'OBS_NUMBER_SLIDER') {
         prop.type = 'OBS_PROPERTY_SLIDER';
-        prop = {
-          ...prop,
-          type: 'OBS_PROPERTY_SLIDER',
-          minVal: Number(obsProp.minVal),
-          maxVal: Number(obsProp.maxVal),
-          stepVal: Number(obsProp.stepVal)
-        } as ISliderInputValue;
       }
     } else if (obsProp.type === 'OBS_PROPERTY_PATH') {
 
@@ -349,13 +342,14 @@ export function getPropertiesFormData(obsSource: obs.ISource): TFormData {
     }
 
     if (isNumberProperty(obsProp)) {
+      Object.assign(formItem as INumberInputValue, {
+        minVal: obsProp.details.min,
+        maxVal: obsProp.details.max,
+        stepVal: obsProp.details.step
+      });
+
       if (obsProp.details.type === obs.ENumberType.Slider) {
-        Object.assign(formItem as ISliderInputValue, {
-          minVal: obsProp.details.min,
-          maxVal: obsProp.details.max,
-          stepVal: obsProp.details.step,
-          type: 'OBS_PROPERTY_SLIDER'
-        });
+        formItem.type = 'OBS_PROPERTY_SLIDER';
       }
     }
 

--- a/app/components/shared/forms/SliderInput.vue.ts
+++ b/app/components/shared/forms/SliderInput.vue.ts
@@ -1,17 +1,17 @@
 import { throttle } from 'lodash-decorators';
 import { Component, Prop } from 'vue-property-decorator';
-import { ISliderInputValue, TObsType, Input } from './Input';
+import { INumberInputValue, TObsType, Input } from './Input';
 import Slider from '../Slider.vue';
 
 @Component({
   components: { Slider }
 })
-class SliderInput extends Input<ISliderInputValue> {
+class SliderInput extends Input<INumberInputValue> {
 
   static obsType: TObsType;
 
   @Prop()
-  value: ISliderInputValue;
+  value: INumberInputValue;
 
   @throttle(100)
   updateValue(value: number) {

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -11,7 +11,7 @@ import { Inject } from '../../util/injector';
 import { InitAfter } from '../../util/service-observer';
 import { WindowsService } from '../windows';
 import {
-  IBitmaskInput, IFormInput, IListInput, ISliderInputValue, TFormData,
+  IBitmaskInput, IFormInput, IListInput, INumberInputValue, TFormData,
 } from '../../components/shared/forms/Input';
 import {
   IAudioDevice, IAudioServiceApi, IAudioSource, IAudioSourceApi, IAudioSourcesState, IFader,
@@ -285,7 +285,7 @@ export class AudioSource implements IAudioSourceApi {
   getSettingsForm(): TFormData {
 
     return [
-      <ISliderInputValue>{
+      <INumberInputValue>{
         name: 'deflection',
         value: Math.round(this.fader.deflection * 100),
         description: 'Volume (%)',


### PR DESCRIPTION
When IntInput components were being used, minVal and maxVal
were used while undefined. To fix this as simply as possible,
I combined the ISliderInputForm and INumberInputForm (since
they actually should be the same to begin with) and make sure
any number-based property has a stepVal, minVal, and maxVal.

This fixes any non-slider number property in that it allowed
infinite values. Some plugins didn't like this, such as the
browser source which would crash if a width or height set
a value that was beyond its limits.