### PR TITLE
add API parse error message

### DIFF
--- a/app/services/tcp-server.ts
+++ b/app/services/tcp-server.ts
@@ -335,7 +335,7 @@ export class TcpServerService extends PersistentStatefulService<ITcpServersSetti
           this.jsonrpcService.createError(null,{
             code: E_JSON_RPC_ERROR.INVALID_REQUEST,
             message: 'Make sure that the request is valid json. ' +
-            'If you request string contains multiple requests, ensure requests are separated ' +
+            'If request string contains multiple requests, ensure requests are separated ' +
             'by a single newline character LF ( ASCII code 10)'
           }));
       }

--- a/app/services/tcp-server.ts
+++ b/app/services/tcp-server.ts
@@ -332,7 +332,12 @@ export class TcpServerService extends PersistentStatefulService<ITcpServersSetti
       } catch (e) {
         this.sendResponse(
           client,
-          this.jsonrpcService.createError(null,{ code: E_JSON_RPC_ERROR.INVALID_REQUEST }));
+          this.jsonrpcService.createError(null,{
+            code: E_JSON_RPC_ERROR.INVALID_REQUEST,
+            message: 'Make sure that the request is valid json. ' +
+            'If you request string contains multiple requests, ensure requests are separated ' +
+            'by a single newline character LF ( ASCII code 10)'
+          }));
       }
     });
   }


### PR DESCRIPTION
As it turned out, sometimes we need to duplicate the documentation 