### PR TITLE
remove CPU stat from the UI

### DIFF
--- a/app/components/PerformanceMetrics.vue
+++ b/app/components/PerformanceMetrics.vue
@@ -1,13 +1,6 @@
 <template>
 <div class="performance-metrics flex flex--center">
   <span class="performance-metric-wrapper">
-    <img class="performance-metric-icon" src="../../media/images/icons/cpu.png">
-    <span class="performance-metric">
-      <span class="performance-metric__value">{{ cpuPercent }}%</span> CPU
-    </span>
-  </span>
-
-  <span class="performance-metric-wrapper">
     <img class="performance-metric-icon" src="../../media/images/icons/fps.png">
     <span class="performance-metric">
       <span class="performance-metric__value">{{ frameRate }}</span> FPS

--- a/app/components/PerformanceMetrics.vue.ts
+++ b/app/components/PerformanceMetrics.vue.ts
@@ -7,16 +7,8 @@ import { compact } from 'lodash';
 
 @Component({})
 export default class PerformanceMetrics extends Vue {
-
-  @Inject()
-  streamingService: StreamingService;
-
-  @Inject()
-  performanceService: PerformanceService;
-
-  get cpuPercent() {
-    return this.performanceService.state.CPU.toFixed(1);
-  }
+  @Inject() streamingService: StreamingService;
+  @Inject() performanceService: PerformanceService;
 
   get frameRate() {
     return this.performanceService.state.frameRate.toFixed(2);
@@ -27,7 +19,9 @@ export default class PerformanceMetrics extends Vue {
   }
 
   get percentDropped() {
-    return (this.performanceService.state.percentageDroppedFrames || 0).toFixed(1);
+    return (this.performanceService.state.percentageDroppedFrames || 0).toFixed(
+      1
+    );
   }
 
   get bandwidth() {
@@ -49,5 +43,4 @@ export default class PerformanceMetrics extends Vue {
 
     return null;
   }
-
 }


### PR DESCRIPTION
We've discovered that this number doesn't fully account for all application processes, and is usually lower than the number reported by task manager.  We don't want to be giving users inaccurate information, so we are just going to disable this until we can get more accurate data.  In the meantime we can point people towards task manager or other 3rd party tools for accurately tracking CPU usage.