### PR TITLE
The last of the probably final font changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "backtrace-node": "^0.7.3",
     "electron-updater": "^2.18.2",
     "electron-window-state": "^4.1.1",
-    "font-manager": "^0.2.2",
+    "font-manager": "git+https://github.com/computerquip-streamlabs/font-manager.git",
     "lodash": "^4.17.4",
     "node-fontinfo": "^0.0.2",
     "node-libuiohook": "file:./node-libuiohook",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3569,9 +3569,9 @@ fn-name@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
 
-font-manager@^0.2.2:
+"font-manager@git+https://github.com/computerquip-streamlabs/font-manager.git":
   version "0.2.2"
-  resolved "https://registry.yarnpkg.com/font-manager/-/font-manager-0.2.2.tgz#18a1c5b6ec7f91e22a17c71cbbaa0ea4e68e3a44"
+  resolved "git+https://github.com/computerquip-streamlabs/font-manager.git#b4620d050ed2eeb0431fe014a3a9896fb4bf987d"
   dependencies:
     nan "~2.2.0"
 


### PR DESCRIPTION
The upstream font-manager doesn't handle oblique style fonts. As a result, I had to modify it slightly to pass this information. I've also removed any areas we were parsing a font style string as it seems to be error-prone and we now use the flags directly. 

It seems that whether or not the style string has bold doesn't matter as most fonts think anything above regular weight is actually bold and should be passed to GDI+ as such. For instance, even though bold is normally 700, Qt passes anything above normal (which is 400 weight in our case) as bold. 