### PR TITLE
Update electron version everywhere

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,5 @@
 arch=x64
 runtime=electron
-target=1.7.10
+target=1.7.11
 disturl=https://atom.io/download/electron
 build_from_source=true

--- a/bin/rebuild-node-obs.js
+++ b/bin/rebuild-node-obs.js
@@ -11,7 +11,7 @@ let cmakeJsPath = null;
 
 /* Configurable variables */
 const runtime = 'electron';
-const runtimeVersion = '1.7.10';
+const runtimeVersion = '1.7.11';
 const configType = 'Release';
 
 /** This assumes cmake is in the global PATH variable. */

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "cmake-js": {
     "runtime": "electron",
-    "runtimeVersion": "1.7.10",
+    "runtimeVersion": "1.7.11",
     "arch": "x64"
   },
   "dependencies": {


### PR DESCRIPTION
This doesn't really affect anything since native modules built for electron 1.7.10 also work on 1.7.11, but it's good to be consistent.