### PR TITLE
Experimental CPU optimization

### DIFF
--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -172,23 +172,10 @@
   background: @red;
   margin: 0 6px;
   box-shadow: 0 0 0 rgba(252, 62, 63, 0.4);
-  animation: livepulse 2s infinite;
 
   &.live-dock-offline {
     background: @grey;
     animation: none;
-  }
-}
-
-@keyframes livepulse {
-  0% {
-    box-shadow: 0 0 0 0 rgba(252, 62, 63, 0.4);
-  }
-  70% {
-    box-shadow: 0 0 0 10px rgba(0, 0, 0, 0);
-  }
-  100% {
-    box-shadow: 0 0 0 0 rgba(0, 0, 0, 0);
   }
 }
 

--- a/app/components/MixerVolmeter.vue
+++ b/app/components/MixerVolmeter.vue
@@ -24,9 +24,6 @@
     .absolute(0, auto, 0, 0);
     width: 100%;
     background-color: @teal;
-    transition-property: transform;
-    transition-duration: 100ms;
-    transition-timing-function: linear;
     transform-origin: left center;
   }
 
@@ -34,9 +31,6 @@
     .absolute(0, auto, 0, 0);
     width: 2px;
     background-color: @input-border-color;
-    transition-property: left;
-    transition-duration: 100ms;
-    transition-timing-function: linear;
   }
 }
 

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -29,7 +29,7 @@ export enum E_AUDIO_CHANNELS {
   INPUT_3 = 5,
 }
 
-const VOLMETER_UPDATE_INTERVAL = 100;
+const VOLMETER_UPDATE_INTERVAL = 50;
 
 interface IAudioSourceData {
   fader?: obs.IFader;

--- a/main.js
+++ b/main.js
@@ -15,6 +15,8 @@ process.env.SLOBS_VERSION = pjson.version;
 const { app, BrowserWindow, ipcMain, session, crashReporter, dialog } = require('electron');
 const bt = require('backtrace-node');
 
+app.disableHardwareAcceleration();
+
 function handleFinishedReport() {
   dialog.showErrorBox(`Unhandled Exception`,
   'An unexpected error occured and the application must be shut down.\n' +


### PR DESCRIPTION
Disabling CSS animations and disabling hardware acceleration seems to put us in a much better state for CPU.  We are going to release this as a preview and get some feedback.  If people prefer the animations we can always make it an option.  But right now, stream quality comes first.