### PR TITLE
flush manifest on autosave

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -521,6 +521,7 @@ export class SceneCollectionsService extends Service
   private enableAutoSave() {
     this.autoSaveInterval = window.setInterval(() => {
       this.save();
+      this.stateService.flushManifestFile();
     }, 60 * 1000);
   }
 


### PR DESCRIPTION
Without this, if you crash, you'll lose any scene collections you created since starting the application.