### PR TITLE
Scene Collections V2: Management UI and Error Handling

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -77,6 +77,10 @@ h4 {
   }
 }
 
+.link--pointer {
+  cursor: pointer;
+}
+
 .link--uppercase {
   text-transform: uppercase;
   letter-spacing: .7px;

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -9,7 +9,7 @@
         @keypress="handleKeypress"
         v-model="editableName" />
       <i class="fa fa-check" @click.stop="submitRename" />
-      <i class="fa fa-times" @click.stop="cancelRename" />
+      <i class="fa fa-times" @click.stop="cancelRename" v-if="!needsRename" />
     </div>
     <div v-else>
       {{ collection.name }}

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -3,14 +3,22 @@
   class="editable-scene-collection flex flex--center flex--justify-start"
   :class="{ 'editable-scene-collection--selected': selected }">
   <span class="editable-scene-collection--name">
-    <div v-if="renaming">
-      <input type="text" v-model="editableName" />
+    <div v-if="renaming" class="flex flex--center flex--justify-start">
+      <input
+        class="input--transparent"
+        type="text"
+        v-model="editableName" />
       <i class="fa fa-check" @click="submitRename" />
       <i class="fa fa-times" @click="cancelRename" />
     </div>
     <div v-else>
       {{ collection.name }}
     </div>
+  </span>
+  <span
+    class="editable-scene-collection--active"
+    v-if="isActive">
+    Active
   </span>
   <span class="editable-scene-collection--modified">
     Updated {{ modified }}
@@ -19,7 +27,7 @@
     <span @click="startRenaming">Rename</span>
   </a>
   <a class="editable-scene-collection--action editable-scene-collection--action-delete link link--underlined">
-    <span>Delete</span>
+    <span @click="remove">Delete</span>
   </a>
 </div>
 </template>
@@ -36,7 +44,7 @@
   font-size: 14px;
   cursor: pointer;
 
-  >span, >a {
+  span, a, input, i {
     margin-right: 8px;
   }
 
@@ -49,6 +57,11 @@
   }
 }
 
+.editable-scene-collection--active {
+  font-size: 12px;
+  color: @teal;
+}
+
 .editable-scene-collection--action {
   display: none;
 }
@@ -59,6 +72,10 @@
 
 .editable-scene-collection--name {
   color: @white;
+
+  input {
+    font-size: 14px;
+  }
 }
 
 .editable-scene-collection--modified {

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -44,7 +44,7 @@
 .editable-scene-collection {
   height: 35px;
   padding: 5px;
-
+  .radius;
   font-size: 14px;
   cursor: pointer;
 
@@ -75,8 +75,7 @@
 }
 
 .editable-scene-collection--name {
-  color: @black;
-  max-width: 250px;
+  max-width: 230px;
 
   >div {
     white-space: nowrap;
@@ -97,12 +96,16 @@
 .night-theme {
   .editable-scene-collection {
     &:hover {
-      background: @night-hover;
+      background-color: @night-hover;
     }
   }
 
   .editable-scene-collection--name {
     color: @white;
+
+    input {
+      background: transparent;
+    }
   }
 }
 </style>

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -49,7 +49,7 @@
   }
 
   &:hover {
-    background: @night-accent-light;
+    background: @day-hover;
 
     .editable-scene-collection--action {
       display: inline;
@@ -71,7 +71,7 @@
 }
 
 .editable-scene-collection--name {
-  color: @white;
+  color: @black;
 
   input {
     font-size: 14px;
@@ -80,5 +80,17 @@
 
 .editable-scene-collection--modified {
   font-size: 12px;
+}
+
+.night-theme {
+  .editable-scene-collection {
+    &:hover {
+      background: @night-hover;
+    }
+  }
+
+  .editable-scene-collection--name {
+    color: @white;
+  }
 }
 </style>

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -1,0 +1,67 @@
+<template>
+<div
+  class="editable-scene-collection flex flex--center flex--justify-start"
+  :class="{ 'editable-scene-collection--selected': selected }">
+  <span class="editable-scene-collection--name">
+    <div v-if="renaming">
+      <input type="text" v-model="editableName" />
+      <i class="fa fa-check" @click="submitRename" />
+      <i class="fa fa-times" @click="cancelRename" />
+    </div>
+    <div v-else>
+      {{ collection.name }}
+    </div>
+  </span>
+  <span class="editable-scene-collection--modified">
+    Updated {{ modified }}
+  </span>
+  <a class="editable-scene-collection--action link link--underlined">
+    <span @click="startRenaming">Rename</span>
+  </a>
+  <a class="editable-scene-collection--action editable-scene-collection--action-delete link link--underlined">
+    <span>Delete</span>
+  </a>
+</div>
+</template>
+
+<script lang="ts" src="./EditableSceneCollection.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../styles/index";
+
+.editable-scene-collection {
+  height: 35px;
+  padding: 5px;
+
+  font-size: 14px;
+  cursor: pointer;
+
+  >span, >a {
+    margin-right: 8px;
+  }
+
+  &:hover {
+    background: @night-accent-light;
+
+    .editable-scene-collection--action {
+      display: inline;
+    }
+  }
+}
+
+.editable-scene-collection--action {
+  display: none;
+}
+
+.editable-scene-collection--action-delete {
+  color: @red;
+}
+
+.editable-scene-collection--name {
+  color: @white;
+}
+
+.editable-scene-collection--modified {
+  font-size: 12px;
+}
+</style>

--- a/app/components/EditableSceneCollection.vue
+++ b/app/components/EditableSceneCollection.vue
@@ -1,15 +1,15 @@
 <template>
-<div
-  class="editable-scene-collection flex flex--center flex--justify-start"
-  :class="{ 'editable-scene-collection--selected': selected }">
+<div class="editable-scene-collection flex flex--center flex--justify-start" @dblclick="makeActive">
   <span class="editable-scene-collection--name">
     <div v-if="renaming" class="flex flex--center flex--justify-start">
       <input
+        ref="rename"
         class="input--transparent"
         type="text"
+        @keypress="handleKeypress"
         v-model="editableName" />
-      <i class="fa fa-check" @click="submitRename" />
-      <i class="fa fa-times" @click="cancelRename" />
+      <i class="fa fa-check" @click.stop="submitRename" />
+      <i class="fa fa-times" @click.stop="cancelRename" />
     </div>
     <div v-else>
       {{ collection.name }}
@@ -20,14 +20,18 @@
     v-if="isActive">
     Active
   </span>
-  <span class="editable-scene-collection--modified">
+  <span class="editable-scene-collection--modified flex--grow">
     Updated {{ modified }}
   </span>
   <a class="editable-scene-collection--action link link--underlined">
-    <span @click="startRenaming">Rename</span>
+    <span @click.stop="startRenaming">Rename</span>
   </a>
+  <a v-if="!duplicating" class="editable-scene-collection--action link link--underlined">
+    <span @click.stop="duplicate">Duplicate</span>
+  </a>
+  <i class="fa fa-spinner fa-pulse" v-else />
   <a class="editable-scene-collection--action editable-scene-collection--action-delete link link--underlined">
-    <span @click="remove">Delete</span>
+    <span @click.stop="remove">Delete</span>
   </a>
 </div>
 </template>
@@ -72,9 +76,17 @@
 
 .editable-scene-collection--name {
   color: @black;
+  max-width: 250px;
+
+  >div {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
   input {
     font-size: 14px;
+    width: 250px;
   }
 }
 

--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -12,7 +12,11 @@ export default class EditableSceneCollection extends Vue {
 
   renaming = false;
   editableName = '';
-  deleting = false;
+  duplicating = false;
+
+  $refs: {
+    rename: HTMLInputElement;
+  };
 
   get collection() {
     return this.sceneCollectionsService.collections.find(coll => coll.id === this.collectionId);
@@ -26,9 +30,30 @@ export default class EditableSceneCollection extends Vue {
     return this.collection.id === this.sceneCollectionsService.activeCollection.id;
   }
 
+  handleKeypress(e: KeyboardEvent) {
+    if (e.code === 'Enter') this.submitRename();
+  }
+
+  makeActive() {
+    this.sceneCollectionsService.load(this.collection.id);
+  }
+
+  duplicate() {
+    this.duplicating = true;
+
+    setTimeout(() => {
+      this.sceneCollectionsService.duplicate(this.collection.name, this.collection.id).then(() => {
+        this.duplicating = false;
+      }).catch(() => {
+        this.duplicating = false;
+      });
+    }, 500);
+  }
+
   startRenaming() {
     this.renaming = true;
     this.editableName = this.collection.name;
+    this.$nextTick(() => this.$refs.rename.focus());
   }
 
   submitRename() {

--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -12,13 +12,18 @@ export default class EditableSceneCollection extends Vue {
 
   renaming = false;
   editableName = '';
+  deleting = false;
 
   get collection() {
-    return this.sceneCollectionsService.getCollection(this.collectionId);
+    return this.sceneCollectionsService.collections.find(coll => coll.id === this.collectionId);
   }
 
   get modified() {
     return moment(this.collection.modified).fromNow();
+  }
+
+  get isActive() {
+    return this.collection.id === this.sceneCollectionsService.activeCollection.id;
   }
 
   startRenaming() {
@@ -36,7 +41,8 @@ export default class EditableSceneCollection extends Vue {
   }
 
   remove() {
-    // TODO: Implement
+    if (!confirm(`Are you sure you want to remove ${this.collection.name}?`)) return;
+    this.sceneCollectionsService.delete(this.collectionId);
   }
 
 }

--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -1,0 +1,42 @@
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+import { SceneCollectionsService } from 'services/scene-collections';
+import { Inject } from 'util/injector';
+import moment from 'moment';
+
+@Component({})
+export default class EditableSceneCollection extends Vue {
+  @Inject() sceneCollectionsService: SceneCollectionsService;
+  @Prop() collectionId: string;
+  @Prop() selected: boolean;
+
+  renaming = false;
+  editableName = '';
+
+  get collection() {
+    return this.sceneCollectionsService.getCollection(this.collectionId);
+  }
+
+  get modified() {
+    return moment(this.collection.modified).fromNow();
+  }
+
+  startRenaming() {
+    this.renaming = true;
+    this.editableName = this.collection.name;
+  }
+
+  submitRename() {
+    this.sceneCollectionsService.rename(this.editableName, this.collectionId);
+    this.renaming = false;
+  }
+
+  cancelRename() {
+    this.renaming = false;
+  }
+
+  remove() {
+    // TODO: Implement
+  }
+
+}

--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { Inject } from 'util/injector';
 import moment from 'moment';
@@ -17,6 +17,19 @@ export default class EditableSceneCollection extends Vue {
   $refs: {
     rename: HTMLInputElement;
   };
+
+  mounted() {
+    if (this.collection.needsRename) this.startRenaming();
+  }
+
+  get needsRename() {
+    return this.collection.needsRename;
+  }
+
+  @Watch('needsRename')
+  onNeedsRenamedChanged(newVal: boolean) {
+    if (newVal) this.startRenaming();
+  }
 
   get collection() {
     return this.sceneCollectionsService.collections.find(coll => coll.id === this.collectionId);

--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -9,7 +9,8 @@
   <div
     class="modal-layout-content"
     :style="contentStyle">
-    <slot name="content"/>
+    <slot name="content" v-if="!loading"/>
+    <i class="fa fa-spinner fa-pulse" v-else/>
   </div>
   <div v-if="showControls" class="modal-layout-controls">
     <button

--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -10,7 +10,7 @@
     class="modal-layout-content"
     :style="contentStyle">
     <slot name="content" v-if="!loading"/>
-    <i class="fa fa-spinner fa-pulse" v-else/>
+    <i class="fa fa-spinner fa-pulse modal-layout-spinner" v-else/>
   </div>
   <div v-if="showControls" class="modal-layout-controls">
     <button
@@ -54,6 +54,14 @@
 .modal-layout-content {
   flex-grow: 1;
   height: 100%;
+}
+
+.modal-layout-spinner {
+  font-size: 36px;
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  margin: 100px 0;
 }
 
 .modal-layout-controls {

--- a/app/components/ModalLayout.vue.ts
+++ b/app/components/ModalLayout.vue.ts
@@ -1,9 +1,10 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { WindowsService } from '../services/windows';
-import { CustomizationService } from '../services/customization';
-import { Inject } from '../util/injector';
+import { WindowsService } from 'services/windows';
+import { CustomizationService } from 'services/customization';
+import { Inject } from 'util/injector';
 import TitleBar from './TitleBar.vue';
+import { AppService } from 'services/app'
 
 @Component({
   components: { TitleBar }
@@ -13,11 +14,9 @@ export default class ModalLayout extends Vue {
   contentStyle: Object = {};
   fixedStyle: Object = {};
 
-  @Inject()
-  customizationService: CustomizationService;
-
-  @Inject()
-  windowsService: WindowsService;
+  @Inject() customizationService: CustomizationService;
+  @Inject() windowsService: WindowsService;
+  @Inject() appService: AppService;
 
   // The title shown at the top of the window
   @Prop()
@@ -85,6 +84,10 @@ export default class ModalLayout extends Vue {
     } else {
       this.windowsService.closeChildWindow();
     }
+  }
+
+  get loading() {
+    return this.appService.state.loading;
   }
 
 }

--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -9,6 +9,7 @@
         <div class="dropdown-menu__item" @click="duplicateCollection">Duplicate</div>
         <div class="dropdown-menu__item" @click="renameCollection">Rename</div>
         <div class="dropdown-menu__item" @click="removeCollection">Remove</div>
+        <div class="dropdown-menu__item" @click="manageCollections">Manage</div>
         <div class="dropdown-menu__separator"></div>
         <div
           v-for="sceneCollection in sceneCollections"

--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -4,8 +4,14 @@
 
     <div class="scene-collections-wrapper">
 
-      <DropdownMenu :title="activeCollection.name">
-        <div class="dropdown-menu__item" @click="manageCollections">Manage</div>
+      <DropdownMenu class="scene-collections__dropdown" :title="activeCollection.name">
+        <div class="input-wrapper input-wrapper--search">
+          <input class="input--search" type="text" placeholder="Search" v-model="searchQuery" />
+        </div>
+
+        <div class="link link--pointer" @click="manageCollections">
+          Manage All
+        </div>
         <div class="dropdown-menu__separator"></div>
         <div
           v-for="sceneCollection in sceneCollections"
@@ -62,5 +68,14 @@
   position: relative;
   display: flex;
   align-items: center;
+}
+
+.input-wrapper--search {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.scene-collections__dropdown {
+  min-width: 200px;
 }
 </style>

--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -5,10 +5,6 @@
     <div class="scene-collections-wrapper">
 
       <DropdownMenu :title="activeCollection.name">
-        <div class="dropdown-menu__item" @click="addCollection">New</div>
-        <div class="dropdown-menu__item" @click="duplicateCollection">Duplicate</div>
-        <div class="dropdown-menu__item" @click="renameCollection">Rename</div>
-        <div class="dropdown-menu__item" @click="removeCollection">Remove</div>
         <div class="dropdown-menu__item" @click="manageCollections">Manage</div>
         <div class="dropdown-menu__separator"></div>
         <div

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -91,28 +91,6 @@ export default class SceneSelector extends Vue {
     this.sceneCollectionsService.load(id);
   }
 
-  addCollection() {
-    this.sceneCollectionsService.showNameConfig();
-  }
-
-
-  duplicateCollection() {
-    this.sceneCollectionsService.showNameConfig({
-      sceneCollectionToDuplicate: this.activeCollection.id
-    });
-  }
-
-
-  renameCollection() {
-    this.sceneCollectionsService.showNameConfig({ rename: true });
-  }
-
-
-  removeCollection() {
-    if (!confirm(`remove ${this.activeCollection.name} ?`)) return;
-    this.sceneCollectionsService.delete();
-  }
-
   manageCollections() {
     this.sceneCollectionsService.showManageWindow();
   }

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -10,6 +10,7 @@ import { AppService } from '../services/app';
 import DropdownMenu from './shared/DropdownMenu.vue';
 import HelpTip from './shared/HelpTip.vue';
 import { EDismissable } from 'services/dismissables';
+import Fuse from 'fuse.js';
 
 @Component({
   components: { Selector, DropdownMenu, HelpTip },
@@ -19,6 +20,8 @@ export default class SceneSelector extends Vue {
   @Inject() sceneCollectionsService: SceneCollectionsService;
   @Inject() appService: AppService;
   @Inject() scenesTransitionsService: ScenesTransitionsService;
+
+  searchQuery = '';
 
   showContextMenu() {
     const menu = new Menu();
@@ -68,7 +71,18 @@ export default class SceneSelector extends Vue {
   }
 
   get sceneCollections() {
-    return this.sceneCollectionsService.collections;
+    const list = this.sceneCollectionsService.collections;
+
+    if (this.searchQuery) {
+      const fuse = new Fuse(list, {
+        shouldSort: true,
+        keys: ['name']
+      });
+
+      return fuse.search(this.searchQuery);
+    }
+
+    return list;
   }
 
   get activeId() {

--- a/app/components/SceneSelector.vue.ts
+++ b/app/components/SceneSelector.vue.ts
@@ -113,6 +113,10 @@ export default class SceneSelector extends Vue {
     this.sceneCollectionsService.delete();
   }
 
+  manageCollections() {
+    this.sceneCollectionsService.showManageWindow();
+  }
+
   get helpTipDismissable() {
     return EDismissable.SceneCollectionsHelpTip;
   }

--- a/app/components/shared/DropdownMenu.vue
+++ b/app/components/shared/DropdownMenu.vue
@@ -23,7 +23,7 @@
   background-color: @day-primary;
   .border;
   .radius;
-  padding: 6px 12px;
+  padding: 10px;
   max-height: 166px;
   overflow-y: auto;
   transform: none!important;
@@ -50,7 +50,7 @@
   height: 1px;
   background-color: @grey;
   opacity: .2;
-  margin: 4px 0;
+  margin: 10px 0;
 }
 
 .dropdown-menu__item {

--- a/app/components/windows/ManageSceneCollections.vue
+++ b/app/components/windows/ManageSceneCollections.vue
@@ -4,6 +4,10 @@
   :show-cancel="false"
   :done-handler="close">
   <div slot="content">
+    <div class="manage-scene-collections--new" @click="create">
+      <i class="fa fa-plus" />
+      Create New
+    </div>
     <editable-scene-collection
       v-for="collection in collections"
       :key="collection.id"
@@ -13,3 +17,26 @@
 </template>
 
 <script lang="ts" src="./ManageSceneCollections.vue.ts"></script>
+
+<style lang="less" scoped>
+@import "../../styles/index";
+
+.manage-scene-collections--new {
+  font-size: 14px;
+  height: 35px;
+  padding: 5px;
+  cursor: pointer;
+
+  &:hover {
+    background: @day-hover;
+  }
+}
+
+.night-theme {
+  .manage-scene-collections--new {
+    &:hover {
+      background: @night-hover;
+    }
+  }
+}
+</style>

--- a/app/components/windows/ManageSceneCollections.vue
+++ b/app/components/windows/ManageSceneCollections.vue
@@ -1,0 +1,15 @@
+<template>
+<modal-layout
+  title="Manage Scene Collections"
+  :show-cancel="false"
+  :done-handler="close">
+  <div slot="content">
+    <editable-scene-collection
+      v-for="collection in collections"
+      :key="collection.id"
+      :collection-id="collection.id"/>
+  </div>
+</modal-layout>
+</template>
+
+<script lang="ts" src="./ManageSceneCollections.vue.ts"></script>

--- a/app/components/windows/ManageSceneCollections.vue
+++ b/app/components/windows/ManageSceneCollections.vue
@@ -4,11 +4,16 @@
   :show-cancel="false"
   :done-handler="close">
   <div slot="content">
-    <div class="manage-scene-collections--new" @click="create">
-      <i class="fa fa-plus" />
-      Create New
+    <div class="manage-scene-collections__header">
+      <div class="input-wrapper input-wrapper--search">
+        <input class="input--search" type="text" placeholder="Search" v-model="searchQuery" />
+      </div>
+
+      <button class="button button--action" @click="create">
+        <i class="fa fa-plus" />
+        Create New
+      </button>
     </div>
-    <input type="text" placeholder="Search" v-model="searchQuery" />
     <editable-scene-collection
       v-for="collection in collections"
       :key="collection.id"
@@ -22,15 +27,15 @@
 <style lang="less" scoped>
 @import "../../styles/index";
 
-.manage-scene-collections--new {
-  font-size: 14px;
-  height: 35px;
-  padding: 5px;
-  cursor: pointer;
+.manage-scene-collections__header {
+  margin-bottom: 20px;
+  .flex;
+  .flex--space-between;
+  align-items: center;
+}
 
-  &:hover {
-    background: @day-hover;
-  }
+.input-wrapper--search {
+  width: 50%;
 }
 
 .night-theme {

--- a/app/components/windows/ManageSceneCollections.vue
+++ b/app/components/windows/ManageSceneCollections.vue
@@ -8,6 +8,7 @@
       <i class="fa fa-plus" />
       Create New
     </div>
+    <input type="text" placeholder="Search" v-model="searchQuery" />
     <editable-scene-collection
       v-for="collection in collections"
       :key="collection.id"

--- a/app/components/windows/ManageSceneCollections.vue.ts
+++ b/app/components/windows/ManageSceneCollections.vue.ts
@@ -6,6 +6,7 @@ import { WindowsService } from 'services/windows';
 import { Inject } from 'util/injector';
 import { SceneCollectionsService } from 'services/scene-collections';
 import EditableSceneCollection from 'components/EditableSceneCollection.vue';
+import Fuse from 'fuse.js';
 
 @Component({
   mixins: [windowMixin],
@@ -18,6 +19,8 @@ export default class ManageSceneCollections extends Vue {
   @Inject() windowsService: WindowsService;
   @Inject() sceneCollectionsService: SceneCollectionsService;
 
+  searchQuery = '';
+
   close() {
     this.sceneCollectionsService.stateService.flushManifestFile();
     this.windowsService.closeChildWindow();
@@ -28,7 +31,18 @@ export default class ManageSceneCollections extends Vue {
   }
 
   get collections() {
-    return this.sceneCollectionsService.collections;
+    const list = this.sceneCollectionsService.collections;
+
+    if (this.searchQuery) {
+      const fuse = new Fuse(list, {
+        shouldSort: true,
+        keys: ['name']
+      });
+
+      return fuse.search(this.searchQuery);
+    }
+
+    return list;
   }
 
 }

--- a/app/components/windows/ManageSceneCollections.vue.ts
+++ b/app/components/windows/ManageSceneCollections.vue.ts
@@ -19,7 +19,12 @@ export default class ManageSceneCollections extends Vue {
   @Inject() sceneCollectionsService: SceneCollectionsService;
 
   close() {
+    this.sceneCollectionsService.stateService.flushManifestFile();
     this.windowsService.closeChildWindow();
+  }
+
+  create() {
+    this.sceneCollectionsService.create();
   }
 
   get collections() {

--- a/app/components/windows/ManageSceneCollections.vue.ts
+++ b/app/components/windows/ManageSceneCollections.vue.ts
@@ -1,0 +1,29 @@
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+import windowMixin from 'components/mixins/window';
+import ModalLayout from 'components/ModalLayout.vue';
+import { WindowsService } from 'services/windows';
+import { Inject } from 'util/injector';
+import { SceneCollectionsService } from 'services/scene-collections';
+import EditableSceneCollection from 'components/EditableSceneCollection.vue';
+
+@Component({
+  mixins: [windowMixin],
+  components: {
+    ModalLayout,
+    EditableSceneCollection
+  }
+})
+export default class ManageSceneCollections extends Vue {
+  @Inject() windowsService: WindowsService;
+  @Inject() sceneCollectionsService: SceneCollectionsService;
+
+  close() {
+    this.windowsService.closeChildWindow();
+  }
+
+  get collections() {
+    return this.sceneCollectionsService.collections;
+  }
+
+}

--- a/app/components/windows/ManageSceneCollections.vue.ts
+++ b/app/components/windows/ManageSceneCollections.vue.ts
@@ -27,7 +27,7 @@ export default class ManageSceneCollections extends Vue {
   }
 
   create() {
-    this.sceneCollectionsService.create();
+    this.sceneCollectionsService.create({ needsRename: true });
   }
 
   get collections() {

--- a/app/components/windows/NameSceneCollection.vue.ts
+++ b/app/components/windows/NameSceneCollection.vue.ts
@@ -40,7 +40,7 @@ export default class NameSceneCollection extends Vue {
       this.sceneCollectionsService.duplicate(this.name);
       this.windowsService.closeChildWindow();
     } else {
-      this.sceneCollectionsService.create(this.name);
+      this.sceneCollectionsService.create({ name: this.name });
       this.windowsService.closeChildWindow();
     }
   }

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -67,18 +67,21 @@ export class ObsImporterService extends Service {
       fs.readFileSync(sceneCollectionPath).toString()
     );
 
-    await this.sceneCollectionsService.create(collection.name, () => {
-      this.importSources(configJSON);
-      this.importScenes(configJSON);
-      this.importSceneOrder(configJSON);
-      this.importMixerSources(configJSON);
-      this.importTransitions(configJSON);
+    await this.sceneCollectionsService.create({
+      name: collection.name,
+      setupFunction: () => {
+        this.importSources(configJSON);
+        this.importScenes(configJSON);
+        this.importSceneOrder(configJSON);
+        this.importMixerSources(configJSON);
+        this.importTransitions(configJSON);
 
-      if (this.scenesService.scenes.length === 0) {
-        return false;
+        if (this.scenesService.scenes.length === 0) {
+          return false;
+        }
+
+        return true;
       }
-
-      return true;
     });
   }
 

--- a/app/services/scene-collections/nodes/array-node.ts
+++ b/app/services/scene-collections/nodes/array-node.ts
@@ -13,26 +13,20 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<IArraySch
 
   abstract getItems(context: TContext): TItem[];
 
-  save(context: TContext): Promise<void> {
-    return new Promise(resolve => {
-      Promise.all(this.getItems(context).map(item => {
-        return this.saveItem(item, context);
-      })).then(values => {
-        this.data = { items: compact(values) };
-        resolve();
-      });
-    });
+  async save(context: TContext): Promise<void> {
+    const values = await Promise.all(this.getItems(context).map(item => {
+      return this.saveItem(item, context);
+    }));
+
+    this.data = { items: compact(values) };
   }
 
-  load(context: TContext): Promise<void> {
-    return new Promise(resolve => {
-      Promise.all(this.data.items.map(item => {
-        return this.loadItem(item, context);
-      })).then((afterLoadItemsCallbacks) => {
-        Promise.all(afterLoadItemsCallbacks.map(callback => callback && callback()))
-          .then(() => resolve());
-      });
-    });
+  async load(context: TContext): Promise<void> {
+    const afterLoadItemsCallbacks = await Promise.all(this.data.items.map(item => {
+      return this.loadItem(item, context);
+    }));
+
+    await Promise.all(afterLoadItemsCallbacks.map(callback => callback && callback()));
   }
 
 }

--- a/app/services/scene-collections/nodes/array-node.ts
+++ b/app/services/scene-collections/nodes/array-node.ts
@@ -22,11 +22,20 @@ export abstract class ArrayNode<TSchema, TContext, TItem> extends Node<IArraySch
   }
 
   async load(context: TContext): Promise<void> {
+    await this.beforeLoad(context);
+
     const afterLoadItemsCallbacks = await Promise.all(this.data.items.map(item => {
       return this.loadItem(item, context);
     }));
 
     await Promise.all(afterLoadItemsCallbacks.map(callback => callback && callback()));
+  }
+
+  /**
+   * Can be called before loading to do some data munging
+   * @param context the context
+   */
+  async beforeLoad(context: TContext): Promise<void> {
   }
 
 }

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -16,47 +16,32 @@ export class RootNode extends Node<ISchema, {}> {
 
   schemaVersion = 1;
 
-  save(): Promise<void> {
+  async save(): Promise<void> {
     const sources = new SourcesNode();
     const scenes = new ScenesNode();
     const transition = new TransitionNode();
     const hotkeys = new HotkeysNode();
 
-    return new Promise(resolve => {
-      sources.save({}).then(() => {
-        return scenes.save({});
-      }).then(() => {
-        return transition.save();
-      }).then(() => {
-        return hotkeys.save({});
-      }).then(() => {
-        this.data = {
-          sources,
-          scenes,
-          transition,
-          hotkeys
-        };
+    await sources.save({});
+    await scenes.save({});
+    await transition.save();
+    await hotkeys.save({});
 
-        resolve();
-      });
-    });
+    this.data = {
+      sources,
+      scenes,
+      transition,
+      hotkeys
+    };
   }
 
-  load(): Promise<void> {
-    return new Promise(resolve => {
-      this.data.sources.load({}).then(() => {
-        return this.data.scenes.load({});
-      }).then(() => {
-        return this.data.transition.load();
-      }).then(() => {
-        if (this.data.hotkeys) {
-          return this.data.hotkeys.load({});
-        }
+  async load(): Promise<void> {
+    await this.data.sources.load({});
+    await this.data.scenes.load({});
+    await this.data.transition.load();
 
-        return Promise.resolve();
-      }).then(() => {
-        resolve();
-      });
-    });
+    if (this.data.hotkeys) {
+      await this.data.hotkeys.load({});
+    }
   }
 }

--- a/app/services/scene-collections/nodes/scene-items.ts
+++ b/app/services/scene-collections/nodes/scene-items.ts
@@ -71,6 +71,21 @@ export class SceneItemsNode extends Node<ISchema, {}> {
     });
   }
 
+  /**
+   * Do some data sanitizing
+   */
+  sanitizeIds() {
+    // Look for duplicate ids
+    const ids: Dictionary<boolean> = {};
+
+    this.data.items = this.data.items.filter(item => {
+      if (ids[item.id]) return false;
+
+      ids[item.id] = true;
+      return true;
+    });
+  }
+
   load(context: IContext): Promise<void> {
     context.scene.addSources(this.data.items);
 

--- a/app/services/scene-collections/nodes/scenes.ts
+++ b/app/services/scene-collections/nodes/scenes.ts
@@ -43,6 +43,21 @@ export class ScenesNode extends ArrayNode<ISceneSchema, {}, Scene> {
     });
   }
 
+  /**
+   * Do some data sanitizing
+   */
+  async beforeLoad() {
+    // Look for duplicate ids
+    const ids: Dictionary<boolean> = {};
+
+    this.data.items = this.data.items.filter(item => {
+      if (ids[item.id]) return false;
+
+      ids[item.id] = true;
+      return true;
+    });
+  }
+
   loadItem(obj: ISceneSchema): Promise<() => Promise<void>> {
     return new Promise(resolve => {
       const scene = this.scenesService.createScene(

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -166,7 +166,24 @@ export class SourcesNode extends Node<ISchema, {}> {
     source.updateSettings({ font: settings.font });
   }
 
+  /**
+   * Do some data sanitizing
+   */
+  sanitizeIds() {
+    // Look for duplicate ids
+    const ids: Dictionary<boolean> = {};
+
+    this.data.items = this.data.items.filter(item => {
+      if (ids[item.id]) return false;
+
+      ids[item.id] = true;
+      return true;
+    });
+  }
+
   load(context: {}): Promise<void> {
+    this.sanitizeIds();
+
     // This shit is complicated, IPC sucks
     const sourceCreateData = this.data.items.map(source => {
       return {

--- a/app/services/scene-collections/scene-collections-api.ts
+++ b/app/services/scene-collections/scene-collections-api.ts
@@ -9,9 +9,9 @@ export interface ISceneCollectionsServiceApi {
 
   /**
    * Create and load a new empty scene collection
-   * @param name the name of the new collection
+   * @param options an optional options object
    */
-  create(name?: string): Promise<void>;
+  create(options?: ISceneCollectionCreateOptions): Promise<void>;
 
   /**
    * Fetch a list of all scene collections and information
@@ -43,6 +43,22 @@ export interface ISceneCollectionsServiceApi {
    * Subscribe to receive notifications when a collection is switched to
    */
   collectionSwitched: Observable<ISceneCollectionsManifestEntry>;
+
+  /**
+   * Subscribe to receive notifications when attempting to switch to a new collection
+   */
+  collectionWillSwitch: Observable<void>;
+
+  /**
+   * Subscribe to receive notifications when a collection is updated (renamed)
+   */
+  collectionUpdated: Observable<ISceneCollectionsManifestEntry>;
+}
+
+export interface ISceneCollectionCreateOptions {
+  setupFunction?: () => boolean;
+  needsRename?: boolean;
+  name?: string;
 }
 
 export interface ISceneCollectionSchema {

--- a/app/services/scene-collections/scene-collections-api.ts
+++ b/app/services/scene-collections/scene-collections-api.ts
@@ -69,4 +69,5 @@ export interface ISceneCollectionsManifestEntry {
   serverId?: number;
   deleted: boolean;
   modified: string;
+  needsRename: boolean;
 }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -231,15 +231,17 @@ export class SceneCollectionsService extends Service
   }
 
   /**
-   * Duplicates the current scene collection and switch
-   * to it.
+   * Duplicates a scene collection.
    * @param name the name of the new scene collection
    */
-  async duplicate(name: string) {
-    await this.save();
-    const id = uuid();
-    await this.insertCollection(id, name);
-    await this.setActiveCollection(id);
+  async duplicate(name: string, id?: string) {
+    this.disableAutoSave();
+
+    id = id || this.activeCollection.id;
+    const newId = uuid();
+    await this.stateService.copyCollectionFile(id, newId);
+    await this.insertCollection(newId, name);
+    this.enableAutoSave();
   }
 
   /**
@@ -324,7 +326,7 @@ export class SceneCollectionsService extends Service
     this.windowsService.showWindow({
       componentName: 'ManageSceneCollections',
       size: {
-        width: 600,
+        width: 700,
         height: 800
       }
     });

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -486,18 +486,22 @@ export class SceneCollectionsService extends Service
     await this.save();
 
     // we should remove inactive scenes first to avoid the switching between scenes
-    this.scenesService.scenes.forEach(scene => {
-      if (scene.id === this.scenesService.activeSceneId) return;
-      scene.remove(true);
-    });
+    try {
+      this.scenesService.scenes.forEach(scene => {
+        if (scene.id === this.scenesService.activeSceneId) return;
+        scene.remove(true);
+      });
 
-    if (this.scenesService.activeScene) {
-      this.scenesService.activeScene.remove(true);
+      if (this.scenesService.activeScene) {
+        this.scenesService.activeScene.remove(true);
+      }
+
+      this.sourcesService.sources.forEach(source => {
+        if (source.type !== 'scene') source.remove();
+      });
+    } catch (e) {
+      console.error('Error deloading application state');
     }
-
-    this.sourcesService.sources.forEach(source => {
-      if (source.type !== 'scene') source.remove();
-    });
 
     this.hotkeysService.unregisterAll();
   }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -182,17 +182,26 @@ export class SceneCollectionsService extends Service
   }
 
   /**
-   * Deletes the current scene collection
+   * Deletes a scene collection.  If no id is specified, it
+   * will delete the current collection.
+   * @param id the id of the collection to delete
    */
-  async delete(): Promise<void> {
-    this.startLoadingOperation();
-    await this.deloadCurrentApplicationState();
-    await this.removeCollection(this.activeCollection.id);
+  async delete(id?: string): Promise<void> {
+    id = id || this.activeCollection.id;
 
-    if (this.collections.length > 0) {
-      this.load(this.collections[0].id);
-    } else {
-      this.create();
+    const removingActiveCollection = id === this.activeCollection.id;
+
+    this.removeCollection(id);
+
+    if (removingActiveCollection) {
+      this.startLoadingOperation();
+      await this.deloadCurrentApplicationState();
+
+      if (this.collections.length > 0) {
+        this.load(this.collections[0].id);
+      } else {
+        this.create();
+      }
     }
   }
 
@@ -538,7 +547,7 @@ export class SceneCollectionsService extends Service
   /**
    * Deletes on the server and removes from the store
    */
-  private async removeCollection(id: string) {
+  private removeCollection(id: string) {
     this.collectionRemoved.next(this.collections.find(coll => coll.id === id));
     this.stateService.DELETE_COLLECTION(id);
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -149,6 +149,7 @@ export class SceneCollectionsService extends Service
         console.warn(
           `Unsuccessful recovery of scene collection ${id} attempted`
         );
+        alert('Failed to load scene collection.  A new one will be created instead.');
         await this.create();
       }
     }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -178,6 +178,7 @@ export class SceneCollectionsService extends Service
 
     await this.insertCollection(id, name);
     await this.setActiveCollection(id);
+    this.stateService.SET_NEEDS_RENAME(id);
     this.finishLoadingOperation();
   }
 
@@ -241,6 +242,7 @@ export class SceneCollectionsService extends Service
     const newId = uuid();
     await this.stateService.copyCollectionFile(id, newId);
     await this.insertCollection(newId, name);
+    this.stateService.SET_NEEDS_RENAME(newId);
     this.enableAutoSave();
   }
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -800,7 +800,7 @@ export class SceneCollectionsService extends Service
           const name = parsed['activeCollection'];
           const collection = this.collections.find(coll => coll.name === name);
 
-          await this.setActiveCollection(collection.id);
+          if (collection) await this.setActiveCollection(collection.id);
         }
       }
     }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -197,12 +197,13 @@ export class SceneCollectionsService extends Service
   }
 
   /**
-   * Renames the current scene collection
+   * Renames a scene collection.
    * @param name the name of the new scene collection
+   * @param id if not present, will operate on the current collection
    */
-  rename(name: string) {
+  rename(name: string, id?: string) {
     this.stateService.RENAME_COLLECTION(
-      this.activeCollection.id,
+      id || this.activeCollection.id,
       name,
       new Date().toISOString()
     );
@@ -305,6 +306,27 @@ export class SceneCollectionsService extends Service
         height: 250
       }
     });
+  }
+
+  /**
+   * Show the window to manage scene collections
+   */
+  showManageWindow() {
+    this.windowsService.showWindow({
+      componentName: 'ManageSceneCollections',
+      size: {
+        width: 600,
+        height: 800
+      }
+    });
+  }
+
+  /**
+   * Returns the collection with the specified id
+   * @param id the id of the collection
+   */
+  getCollection(id: string) {
+    return this.collections.find(coll => coll.id === id);
   }
 
   /**

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -167,7 +167,7 @@ export class SceneCollectionsService extends Service
    * up some state.  This should really only be used by the OBS
    * importer.
    */
-  async create(options?: ISceneCollectionCreateOptions): Promise<void> {
+  async create(options: ISceneCollectionCreateOptions = {}): Promise<void> {
     this.startLoadingOperation();
     await this.deloadCurrentApplicationState();
 

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -32,7 +32,11 @@ export class SceneCollectionsStateService extends StatefulService<
   };
 
   get collections() {
-    return this.state.collections.filter(coll => !coll.deleted);
+    return this.state.collections.filter(coll => !coll.deleted).sort((a, b) => {
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+      return 0;
+    });
   }
 
   get activeCollection() {
@@ -165,6 +169,24 @@ export class SceneCollectionsStateService extends StatefulService<
 
         resolve();
       });
+    });
+  }
+
+  /**
+   * Copies a collection file
+   * @param sourceId the scene collection to copy
+   * @param destId the scene collection to copy to
+   */
+  copyCollectionFile(sourceId: string, destId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const rd = fs.createReadStream(this.getCollectionFilePath(sourceId));
+      const wr = fs.createWriteStream(this.getCollectionFilePath(destId));
+
+      rd.on('error', err => reject(err));
+      wr.on('error', err => reject(err));
+      wr.on('close', () => resolve());
+
+      rd.pipe(wr);
     });
   }
 

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -250,8 +250,14 @@ export class SceneCollectionsStateService extends StatefulService<
       id,
       name,
       deleted: false,
-      modified
+      modified,
+      needsRename: false
     });
+  }
+
+  @mutation()
+  SET_NEEDS_RENAME(id: string) {
+    this.state.collections.find(coll => coll.id === id).needsRename = true;
   }
 
   @mutation()
@@ -269,6 +275,7 @@ export class SceneCollectionsStateService extends StatefulService<
     const coll = this.state.collections.find(coll => coll.id === id);
     coll.name = name;
     coll.modified = modified;
+    coll.needsRename = false;
   }
 
   @mutation()

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -63,18 +63,55 @@ export class SceneCollectionsStateService extends StatefulService<
   async loadManifestFile() {
     await this.ensureDirectory();
 
-    const exists = await new Promise(resolve => {
-      fs.exists(this.manifestFilePath, exists => resolve(exists));
+    try {
+      const exists = await new Promise(resolve => {
+        fs.exists(this.manifestFilePath, exists => resolve(exists));
+      });
+      const data = await this.readCollectionFile(this.manifestFilePath);
+
+      if (data) {
+        const parsed = JSON.parse(data);
+        const recovered = await this.checkAndRecoverManifest(parsed);
+
+        if (recovered) this.LOAD_STATE(recovered);
+      }
+    } catch (e) {
+      console.error('Error loading manifest file from disk');
+    }
+
+    await this.flushManifestFile();
+  }
+
+  /**
+   * Takes a parsed manifest and checks it for data integrity
+   * errors.  If possible, it will attempt to recover it.
+   * Otherwise, it will return undefined.
+   */
+  async checkAndRecoverManifest(obj: ISceneCollectionsManifest): Promise<ISceneCollectionsManifest> {
+    // If there is no collections array, this is unrecoverable
+    if (!Array.isArray(obj.collections)) return;
+
+    // Get a list of all json files in the directory
+    const files = await this.listCollectionFiles();
+
+    // Filter out collections we can't recover, and fix ones we can
+    const filtered = obj.collections.filter(coll => {
+      // If there is no id, this is unrecoverable
+      if (coll.id == null) return false;
+
+      // If there isn't a corresponding file on disk, it shouldn't be in
+      // the manifest.  It may be redownloaded from the server.
+      if (!files.includes(`${coll.id}.json`)) return false;
+
+      // We can recover these
+      if (coll.deleted == null) coll.deleted = false;
+      if (coll.modified == null) coll.modified = (new Date()).toISOString();
+
+      return true;
     });
 
-    if (exists) {
-      const data = await this.readCollectionFile(this.manifestFilePath);
-      if (data) {
-        this.LOAD_STATE(JSON.parse(data));
-      }
-    } else {
-      await this.flushManifestFile();
-    }
+    obj.collections = filtered;
+    return obj;
   }
 
   /**
@@ -151,6 +188,22 @@ export class SceneCollectionsStateService extends StatefulService<
         });
       });
     }
+  }
+
+  /**
+   * Returns a list of files in the collections directory
+   */
+  private listCollectionFiles(): Promise<string[]> {
+    return new Promise((resolve, reject) => {
+      fs.readdir(this.collectionsDirectory, (err, files) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+
+        resolve(files);
+      });
+    });
   }
 
   get collectionsDirectory() {

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -32,11 +32,7 @@ export class SceneCollectionsStateService extends StatefulService<
   };
 
   get collections() {
-    return this.state.collections.filter(coll => !coll.deleted).sort((a, b) => {
-      if (a.name < b.name) return -1;
-      if (a.name > b.name) return 1;
-      return 0;
-    });
+    return this.state.collections.filter(coll => !coll.deleted);
   }
 
   get activeCollection() {
@@ -250,7 +246,7 @@ export class SceneCollectionsStateService extends StatefulService<
 
   @mutation()
   ADD_COLLECTION(id: string, name: string, modified: string) {
-    this.state.collections.push({
+    this.state.collections.unshift({
       id,
       name,
       deleted: false,

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -120,7 +120,10 @@ export class Scene implements ISceneApi {
 
   removeItem(sceneItemId: string) {
     const sceneItem = this.getItem(sceneItemId);
-    if (!sceneItem) throw new Error(`SceneItem ${sceneItemId} not found`);
+    if (!sceneItem) {
+      console.error(`SceneItem ${sceneItemId} not found`);
+      return;
+    }
 
     sceneItem.getObsSceneItem().remove();
     this.REMOVE_SOURCE_FROM_SCENE(sceneItemId);

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -17,6 +17,7 @@ import AdvancedAudio from '../components/windows/AdvancedAudio.vue';
 import Notifications from '../components/windows/Notifications.vue';
 import Troubleshooter from '../components/windows/Troubleshooter.vue';
 import Blank from '../components/windows/Blank.vue';
+import ManageSceneCollections from 'components/windows/ManageSceneCollections.vue';
 import { mutation, StatefulService } from './stateful-service';
 import electron from 'electron';
 
@@ -71,7 +72,8 @@ export class WindowsService extends StatefulService<IWindowsState> {
     EditStreamInfo,
     AdvancedAudio,
     Notifications,
-    Troubleshooter
+    Troubleshooter,
+    ManageSceneCollections
   };
 
   private windows: Electron.BrowserWindow[] = BrowserWindow.getAllWindows();

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -94,7 +94,8 @@ button,
   align-content: center;
 }
 
-.button--twitch, .button--yt {
+.button--twitch,
+.button--yt {
   width: 48%;
 }
 
@@ -110,7 +111,8 @@ button,
   font-size: 16px;
 }
 
-.square-button--twitch, .button--twitch {
+.square-button--twitch,
+.button--twitch {
   background: #6441A4;
 
   &:hover {
@@ -142,6 +144,7 @@ button,
     background: lighten(#3B5998, 4%);
   }
 }
+
 .square-button--twitter {
   background: #1DA1F2;
 

--- a/app/styles/inputs.less
+++ b/app/styles/inputs.less
@@ -35,6 +35,21 @@
   }
 }
 
+.input-wrapper--search {
+  position: relative;
+
+  &:after {
+    content: '\f002';
+    font-family: FontAwesome;
+    .absolute(@top: 0, @right: 8px, @bottom: 0);
+    line-height: 36px;
+  }
+}
+
+.input--search {
+  padding: 0 30px 0 8px;
+}
+
 input[type=text],
 input[type="password"],
 textarea {

--- a/app/styles/mixins.less
+++ b/app/styles/mixins.less
@@ -84,6 +84,10 @@
   }
 }
 
+.icon--margin {
+  margin-right: 6px;
+}
+
 // Paddings
 .no-padding-left {
   padding-left: 0;

--- a/main.js
+++ b/main.js
@@ -254,10 +254,13 @@ function startApp() {
     // interference with certain NodeJS APIs, expecially asynchronous
     // IO from the renderer process.  Enable at your own risk.
 
-    // const devtoolsInstaller = require('electron-devtools-installer');
-    // devtoolsInstaller.default(devtoolsInstaller.VUEJS_DEVTOOLS);
+    const devtoolsInstaller = require('electron-devtools-installer');
+    devtoolsInstaller.default(devtoolsInstaller.VUEJS_DEVTOOLS);
 
-    openDevTools();
+    setTimeout(() => {
+      openDevTools();
+    }, 10 * 1000);
+
   }
 
   // Initialize various OBS services

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-vue": "^2.0.1",
     "file-loader": "^1.1.6",
+    "fuse.js": "^3.2.0",
     "js-yaml": "^3.8.3",
     "less": "^2.7.2",
     "less-loader": "^4.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3641,6 +3641,10 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
+fuse.js@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.2.0.tgz#f0448e8069855bf2a3e683cdc1d320e7e2a07ef4"
+
 gauge@~1.2.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93"


### PR DESCRIPTION
In this PR:
- Handle malformed or non-parseable data in the manifest file
- Handle manifest file that points to collection files that don't exist
- Attempt to recover bad/incomplete data stored in the manifest
- Add a new "Manage" view that allows renaming and deleting of scene collections without switching to them, which may be impossible if they contain bad data

Still To Do:
- Add a way to bulk delete all data locally and on servers
- Add a way to force a sync to the server and possibly see sync status or view last sync time
- Flush manifest when closing window