### PR TITLE
fix cursors and disable Ctrl+A shortcut

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -346,16 +346,6 @@ th {
   padding-bottom: 10px;
 }
 
-// disable user selection (prevent Ctrl+A select the whole application screen)
-// https://github.com/electron/electron/issues/2538
-:not(input):not(textarea),
-:not(input):not(textarea)::after,
-:not(input):not(textarea)::before {
-  -webkit-user-select: none;
-  user-select: none;
-  cursor: default;
-}
-
 // Scrolls
 ::-webkit-scrollbar {
   width: 6px;

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -133,7 +133,6 @@ export class SelectionService
     return this.getIds().includes(itemId);
   }
 
-  @shortcut('Ctrl+A')
   selectAll() {
     this.select(this.getScene().getItems().map(item => item.sceneItemId));
     return this;


### PR DESCRIPTION
The multiselection PR broke virtually all `cursor: pointer;` CSS rules in our app by adding a highly generic, yet high specificity CSS rule that overrides the cursor to `default`.

I've removed that rule, and also removed the `Ctrl+A` shortcut which was the original reason for adding that rule.