### PR TITLE
recover from overlay installation failures

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -287,8 +287,14 @@ export class SceneCollectionsService extends Service
     await this.insertCollection(id, name);
     await this.setActiveCollection(id);
 
-    await this.overlaysPersistenceService.loadOverlay(filePath);
-    this.setupDefaultAudio();
+    try {
+      await this.overlaysPersistenceService.loadOverlay(filePath);
+      this.setupDefaultAudio();
+    } catch (e) {
+      // We tried really really hard :(
+      console.error('Overlay installation failed');
+    }
+
     await this.saveCurrentApplicationStateAs(id);
     this.finishLoadingOperation();
   }


### PR DESCRIPTION
This should very very rarely happen, but if there is an exception during overlay installation, it most likely is 99% usable.  So let's not do an infinite spinner and instead continue as if it succeeded.