### PR TITLE
Rename default sources

### DIFF
--- a/app/components/Hotkeys.vue
+++ b/app/components/Hotkeys.vue
@@ -10,7 +10,7 @@
   <hotkey-group
     v-for="(sourceHotkeys, sourceId) in hotkeySet.sources"
     :key="sourceId"
-    :title="sourcesService.getSource(sourceId).displayName"
+    :title="sourcesService.getSource(sourceId).name"
     :hotkeys="sourceHotkeys"/>
 </div>
 </template>

--- a/app/components/MixerItem.vue
+++ b/app/components/MixerItem.vue
@@ -2,7 +2,7 @@
 <div class="mixer-item" :class="{ muted: audioSource.muted}">
 
   <div class="flex">
-    <div class="source-name">{{ audioSource.source.displayName }}</div>
+    <div class="source-name">{{ audioSource.source.name }}</div>
     <div class="db-value">
       <div v-if="audioSource.fader.deflection == 0">-Inf dB</div>
       <div v-if="audioSource.fader.deflection !== 0">{{ audioSource.fader.db.toFixed(1) }} dB</div>

--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -34,7 +34,7 @@ export default class AddSource extends Vue {
   });
 
   existingSources = this.sources.map(source => {
-    return { name: source.displayName, value: source.sourceId };
+    return { name: source.name, value: source.sourceId };
   });
 
   selectedSourceId = this.sources[0].sourceId;

--- a/app/components/windows/AdvancedAudio.vue
+++ b/app/components/windows/AdvancedAudio.vue
@@ -18,7 +18,7 @@
       </tr>
 
       <tr v-for="audioSource in audioSources">
-        <td>{{ audioSource.displayName }}</td>
+        <td>{{ audioSource.name }}</td>
         <td v-for="formInput in audioSource.getSettingsForm()" :class="'column-' + formInput.name">
           <component
               v-if="propertyComponentForType(formInput.type)"

--- a/app/components/windows/SourceFilters.vue.ts
+++ b/app/components/windows/SourceFilters.vue.ts
@@ -66,7 +66,7 @@ export default class SourceFilters extends Vue {
   }
 
   get sourceDisplayName() {
-    return this.sourcesService.getSource(this.sourceId).displayName;
+    return this.sourcesService.getSource(this.sourceId).name;
   }
 
   removeFilter() {

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -67,7 +67,7 @@ export default class SourceProperties extends Vue {
 
   get windowTitle() {
     const source = this.sourcesService.getSource(this.sourceId);
-    return source ? `Properties for '${source.displayName}'` : '';
+    return source ? `Properties for '${source.name}'` : '';
   }
 
 }

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -279,10 +279,6 @@ export class AudioSource implements IAudioSourceApi {
     Utils.applyProxy(this, sourceState);
   }
 
-  get displayName() {
-    return this.source.displayName;
-  }
-
   getModel(): IAudioSource & ISource {
     return { ...this.audioSourceState, ...this.source.sourceState };
   }

--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -99,7 +99,7 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       name: 'TOGGLE_SOURCE_VISIBILITY_SHOW',
       description: (sceneItemId) => {
         const sceneItem = getScenesService().getSceneItem(sceneItemId);
-        return `Show '${sceneItem.source.displayName}'`;
+        return `Show '${sceneItem.source.name}'`;
       },
       shouldApply: (sceneItemId) => getScenesService().getSceneItem(sceneItemId).video,
       isActive: (sceneItemId) => getScenesService().getSceneItem(sceneItemId).visible,
@@ -110,7 +110,7 @@ const HOTKEY_ACTIONS: Dictionary<IHotkeyAction[]> = {
       name: 'TOGGLE_SOURCE_VISIBILITY_HIDE',
       description: (sceneItemId) => {
         const sceneItem = getScenesService().getSceneItem(sceneItemId);
-        return `Hide '${sceneItem.source.displayName}'`;
+        return `Hide '${sceneItem.source.name}'`;
       },
       shouldApply: (sceneItemId) => getScenesService().getSceneItem(sceneItemId).video,
       isActive: (sceneItemId) => !getScenesService().getSceneItem(sceneItemId).visible,

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -249,17 +249,6 @@ export class SourcesNode extends Node<ISchema, {}> {
 
       this.data.items.forEach(source => {
 
-        if (source.name === 'AuxAudioDevice1') {
-          source.name =  'Mic/Aux';
-          return;
-        }
-
-        if (source.name === 'DesktopAudioDevice1') {
-          source.name = 'Desktop Audio';
-          return;
-
-        }
-
         const desktopDeviceMatch = /^DesktopAudioDevice(\d)$/.exec(source.name);
         if (desktopDeviceMatch) {
           const index = parseInt(desktopDeviceMatch[1], 10);

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -49,7 +49,7 @@ export interface ISourceInfo {
 
 export class SourcesNode extends Node<ISchema, {}> {
 
-  schemaVersion = 2;
+  schemaVersion = 3;
 
   @Inject() private fontLibraryService: FontLibraryService;
   @Inject() private sourcesService: SourcesService;
@@ -239,5 +239,43 @@ export class SourcesNode extends Node<ISchema, {}> {
     return new Promise(resolve => {
       Promise.all(promises).then(() => resolve());
     });
+  }
+
+
+  migrate(version: number) {
+
+    // migrate audio sources names
+    if (version < 3) {
+
+      this.data.items.forEach(source => {
+
+        if (source.name === 'AuxAudioDevice1') {
+          source.name =  'Mic/Aux';
+          return;
+        }
+
+        if (source.name === 'DesktopAudioDevice1') {
+          source.name = 'Desktop Audio';
+          return;
+
+        }
+
+        const desktopDeviceMatch = /^DesktopAudioDevice(\d)$/.exec(source.name);
+        if (desktopDeviceMatch) {
+          const index = parseInt(desktopDeviceMatch[1], 10);
+          source.name = 'Desktop Audio' + (index > 1 ? ' ' + index : '');
+          return;
+        }
+
+        const auxDeviceMatch = /^AuxAudioDevice(\d)$/.exec(source.name);
+        if (auxDeviceMatch) {
+          const index = parseInt(auxDeviceMatch[1], 10);
+          source.name = 'Mic/Aux' + (index > 1 ? ' ' + index : '');
+          return;
+        }
+
+      });
+
+    }
   }
 }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -546,14 +546,14 @@ export class SceneCollectionsService extends Service
    */
   private setupDefaultAudio() {
     this.sourcesService.createSource(
-      'DesktopAudioDevice1',
+      'Desktop Audio',
       'wasapi_output_capture',
       {},
       { channel: E_AUDIO_CHANNELS.OUTPUT_1 }
     );
 
     this.sourcesService.createSource(
-      'AuxAudioDevice1',
+      'Mic/Aux',
       'wasapi_input_capture',
       {},
       { channel: E_AUDIO_CHANNELS.INPUT_1 }

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -113,7 +113,6 @@ export class Source implements ISourceApi {
   }
 
   setName(newName: string) {
-    debugger;
     this.SET_NAME(newName);
     this.sourcesService.sourceUpdated.next(this.sourceState);
   }

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -33,29 +33,6 @@ export class Source implements ISourceApi {
   @Inject()
   scenesService: ScenesService;
 
-  /**
-   * displayName can be localized in future releases
-   */
-  get displayName() {
-    if (this.name === 'AuxAudioDevice1') return 'Mic/Aux';
-    if (this.name === 'DesktopAudioDevice1') return 'Desktop Audio';
-    const desktopDeviceMatch = /^DesktopAudioDevice(\d)$/.exec(this.name);
-    const auxDeviceMatch = /^AuxAudioDevice(\d)$/.exec(this.name);
-
-    if (desktopDeviceMatch) {
-      const index = parseInt(desktopDeviceMatch[1], 10);
-      return 'Desktop Audio' + (index > 1 ? ' ' + index : '');
-    }
-
-    if (auxDeviceMatch) {
-      const index = parseInt(auxDeviceMatch[1], 10);
-      return 'Mic/Aux' + (index > 1 ? ' ' + index : '');
-    }
-
-    return this.name;
-  }
-
-
   getObsInput(): obs.IInput {
     return obs.InputFactory.fromName(this.sourceId);
   }

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -18,7 +18,6 @@ export interface ISource {
 
 
 export interface ISourceApi extends ISource {
-  displayName: string;
   updateSettings(settings: Dictionary<any>): void;
   getSettings(): Dictionary<any>;
   getPropertiesManagerType(): TPropertiesManager;

--- a/app/util/menus/EditMenu.ts
+++ b/app/util/menus/EditMenu.ts
@@ -78,14 +78,6 @@ export class EditMenu extends Menu {
 
       this.append({ type: 'separator' });
 
-      if (!isMultipleSelection) {
-        this.append({
-          label: 'Rename',
-          click: () =>
-            this.sourcesService.showRenameSource(selectedItem.sourceId)
-        });
-      }
-
       this.append({
         label: 'Remove',
         accelerator: 'Delete',
@@ -139,6 +131,13 @@ export class EditMenu extends Menu {
     }
 
     if (this.source && !isMultipleSelection) {
+
+      this.append({
+        label: 'Rename',
+        click: () =>
+          this.sourcesService.showRenameSource(this.source.sourceId)
+      });
+
       this.append({ type: 'separator' });
 
       this.append({


### PR DESCRIPTION
Since we have id based source system instead name based, the `source.displayName` seems pretty unless and I removed it. Also, the new OBS release allows to rename default sources, so I added this feature to this PR. As a bonus, if users are going to choose some non-default device as the default source SLOBS will use the device.
The one downside of this PR users that already have set up default audio sources will get other names for them. For example `DesktopAudioDevice1` instead `Desktop Audio`. And I'm not sure is it worth to make a migration for that,

I decided to make this PR now until guys from Elgato didn't fully implement the streamdeck support. They are working on the default audio sources now.
![image](https://user-images.githubusercontent.com/3768346/36054485-8f5e9700-0dab-11e8-8ccd-fea673d9f78b.png)
