### PR TITLE
preserve properties manager when duplicating

### DIFF
--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -126,7 +126,11 @@ export class Source implements ISourceApi {
     return this.sourcesService.createSource(
       this.sourcesService.suggestName(this.name),
       this.type,
-      this.getSettings()
+      this.getSettings(),
+      {
+        propertiesManager: this.getPropertiesManagerType(),
+        propertiesManagerSettings: this.getPropertiesManagerSettings()
+      }
     );
   }
 


### PR DESCRIPTION
Without this, a streamlabel source will become a regular text source when duplicated.