### PR TITLE
fix source properties screentests

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -325,6 +325,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
 
 
   showSourceProperties(sourceId: string) {
+    this.windowsService.closeChildWindow();
     this.windowsService.showWindow({
       componentName: 'SourceProperties',
       queryParams: { sourceId },


### PR DESCRIPTION
`showSourceProperties` didn't show the properties window if this window was already opened