### PR TITLE
Modify optimized encoder checkbox to reveal profile dropdown

### DIFF
--- a/app/components/windows/EditStreamInfo.vue
+++ b/app/components/windows/EditStreamInfo.vue
@@ -47,7 +47,7 @@
             </div>
           </div>
         </div>
-        <div class="input-container select">
+        <div class="input-container select" v-show="useOptimizedProfile">
           <div class="input-label">
             <label>Profile</label>
           </div>


### PR DESCRIPTION
This will only reveal the Profile drop down if the checkbox is enabled. 
Requested by a few users to avoid confusion.
![2018-02-23_11-00-40](https://user-images.githubusercontent.com/5510965/36614551-f1ff258c-1891-11e8-95f8-2ffb5b3664b7.gif)
