### PR TITLE
NSIS installer id for analytics

### DIFF
--- a/installer.nsh
+++ b/installer.nsh
@@ -1,0 +1,5 @@
+!macro customInstall
+  FileOpen $0 "$INSTDIR\installername" w
+  FileWrite $0 $EXEFILE
+  FileClose $0
+!macroend

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "0.8.13-preview.2",
+  "version": "0.8.13-preview.1",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && webpack-cli --progress --mode development",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "0.8.13-preview.1",
+  "version": "0.8.13-preview.2",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && webpack-cli --progress --mode development",
@@ -47,7 +47,8 @@
       "license": "AGREEMENT",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
-      "perMachine": true
+      "perMachine": true,
+      "include": "installer.nsh"
     }
   },
   "ava": {


### PR DESCRIPTION
Parse the installer ID out of the executable filename, and send it along with analytics events.

The other piece of this is an AWS Lambda@Edge function that allows writing ids into installer filenames as they are downloaded.  That piece is already live.