### PR TITLE
stop erroring manifest

### DIFF
--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -59,7 +59,7 @@ export class SceneCollectionsStateService extends StatefulService<
         if (recovered) this.LOAD_STATE(recovered);
       }
     } catch (e) {
-      console.error('Error loading manifest file from disk');
+      console.warn('Error loading manifest file from disk');
     }
 
     await this.flushManifestFile();


### PR DESCRIPTION
This is a fairly normal state when starting up from a fresh cache, so lets stop burning through sentry events.