### PR TITLE
use cached facemask plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node-boost/
 electron.sln
 electron.VC.db
 .vs/
+plugins/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,17 +9,17 @@ install:
 
 test_script:
   - yarn test
-  - yarn screentest
-  - 7z a screentest.zip test-dist\screentest\*
-  - ps: $env:warning_ico = ":warning:"
-  - ps: $env:success_ico = ":white_check_mark:"
-  - ps: $env:changed_screens = (Get-Content -Raw -Path test-dist\screentest\state.json | ConvertFrom-Json).changedScreens
-  - ps: $env:project_link = "https://ci.appveyor.com/project/Streamlabs/streamlabs-obs"
-  - ps: If ($env:changed_screens -gt 0) {Add-AppveyorMessage "$env:warning_ico $env:changed_screens screens have been changed $env:project_link/build/$env:APPVEYOR_BUILD_VERSION/artifacts"} else { Add-AppveyorMessage "$env:success_ico no screens changed" }
+  # - yarn screentest
+  # - 7z a screentest.zip test-dist\screentest\*
+  # - ps: $env:warning_ico = ":warning:"
+  # - ps: $env:success_ico = ":white_check_mark:"
+  # - ps: $env:changed_screens = (Get-Content -Raw -Path test-dist\screentest\state.json | ConvertFrom-Json).changedScreens
+  # - ps: $env:project_link = "https://ci.appveyor.com/project/Streamlabs/streamlabs-obs"
+  # - ps: If ($env:changed_screens -gt 0) {Add-AppveyorMessage "$env:warning_ico $env:changed_screens screens have been changed $env:project_link/build/$env:APPVEYOR_BUILD_VERSION/artifacts"} else { Add-AppveyorMessage "$env:success_ico no screens changed" }
 
-artifacts:
-  - path: 'screentest.zip'
-    name: Screentests
+# artifacts:
+#   - path: 'screentest.zip'
+#     name: Screentests
 
 notifications:
   - provider: GitHubPullRequest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,6 @@ artifacts:
 notifications:
   - provider: GitHubPullRequest
     template: "{{#failed}}:x: build failed{{/failed}} {{#jobs}} {{#messages}} {{message}} {{/messages}} {{/jobs}}"
+
+cache:
+  - plugins

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "watch": "yarn clear && webpack-cli --watch --progress --mode development",
     "start": "electron .",
     "install-plugins": "yarn install --cwd bin && node bin/install-plugins.js",
+    "clear-plugins": "rm -rf plugins",
     "package": "rm -rf dist && build -w --x64 --em.env=production",
     "package:preview": "rm -rf dist && build -w --x64 --em.env=production --em.name=\"slobs-client-preview\" --config.productName=\"Streamlabs OBS Preview\" --config.appId=\"com.streamlabs.slobspreview\"",
     "release": "yarn install --cwd bin && node bin/release.js",


### PR DESCRIPTION
A few things here:
- Download plugins to `<slobs-dir>/plugins` with a consistent filename, so we can cache them in the appveyor build dir
- Cache the plugins directory
- Add a 2 second sleep after successful download of the plugin archive, in attempt to resolve the "in use by another process" issue we are seeing on appveyor
- Disable screen tests for now
