### PR TITLE
add more troubleshooter settings

### DIFF
--- a/app/components/NotificationsSettings.vue.ts
+++ b/app/components/NotificationsSettings.vue.ts
@@ -39,7 +39,7 @@ export default class NotificationsSettings extends Vue {
       settings[formInput.name] = formInput.value;
     });
     this.troubleshooterService.setSettings(settings);
-    this.settingsFormData = this.notificationsService.getSettingsFormData();
+    this.troubleshooterFormData = this.troubleshooterService.getSettingsFormData();
   }
 
 

--- a/app/components/shared/forms/SliderInput.vue
+++ b/app/components/shared/forms/SliderInput.vue
@@ -14,6 +14,7 @@
           :interval="value.stepVal"
           tooltip="always"
           :valueBox="true"
+          :enabled="value.enabled"
           :usePercentages="value.usePercentages"
         />
       </div>

--- a/app/services/performance-monitor/performance-monitor.ts
+++ b/app/services/performance-monitor/performance-monitor.ts
@@ -75,12 +75,15 @@ export class PerformanceMonitorService extends StatefulService<IMonitorState> {
     };
 
     const {
+      skippedEnabled,
       skippedThreshold,
+      laggedEnabled,
       laggedThreshold,
+      droppedEnabled,
       droppedThreshold
     } = this.troubleshooterService.getSettings();
 
-    if (currentStats.framesEncoded !== 0) {
+    if (skippedEnabled && currentStats.framesEncoded !== 0) {
       const framesSkipped = currentStats.framesSkipped - this.state.framesSkipped;
       const framesEncoded = currentStats.framesEncoded - this.state.framesEncoded;
       const skippedFactor = framesSkipped / framesEncoded;
@@ -91,7 +94,7 @@ export class PerformanceMonitorService extends StatefulService<IMonitorState> {
       }
     }
 
-    if (currentStats.framesRendered !== 0) {
+    if (laggedEnabled && currentStats.framesRendered !== 0) {
       const framesLagged = currentStats.framesLagged - this.state.framesLagged;
       const framesRendered = currentStats.framesRendered - this.state.framesRendered;
       const laggedFactor = framesLagged / framesRendered;
@@ -101,7 +104,7 @@ export class PerformanceMonitorService extends StatefulService<IMonitorState> {
       }
     }
 
-    if (this.droppedFramesRecords.length) {
+    if (droppedEnabled && this.droppedFramesRecords.length) {
       const droppedFramesFactor =
         this.droppedFramesRecords.reduce((a, b) => a + b) /
         this.droppedFramesRecords.length;

--- a/app/services/troubleshooter/troubleshooter-api.ts
+++ b/app/services/troubleshooter/troubleshooter-api.ts
@@ -1,8 +1,11 @@
 import { TFormData } from '../../components/shared/forms/Input';
 
 export interface ITroubleshooterSettings {
+  skippedEnabled: boolean;
   skippedThreshold: number;
+  laggedEnabled: boolean;
   laggedThreshold: number;
+  droppedEnabled: boolean;
   droppedThreshold: number;
 }
 

--- a/app/services/troubleshooter/troubleshooter.ts
+++ b/app/services/troubleshooter/troubleshooter.ts
@@ -1,6 +1,6 @@
 import { mutation } from '../stateful-service';
 import { PersistentStatefulService } from 'services/persistent-stateful-service';
-import { INumberInputValue, TFormData } from '../../components/shared/forms/Input';
+import { IFormInput, INumberInputValue, TFormData } from '../../components/shared/forms/Input';
 import { ITroubleshooterServiceApi, ITroubleshooterSettings, TIssueCode } from './troubleshooter-api';
 import { WindowsService } from 'services/windows';
 import { Inject } from '../../util/injector';
@@ -18,8 +18,11 @@ export class TroubleshooterService
 
   static defaultState: ITroubleshooterState = {
     settings: {
+      skippedEnabled: true,
       skippedThreshold: 0.15,
+      laggedEnabled: false,
       laggedThreshold: 0.15,
+      droppedEnabled: true,
       droppedThreshold: 0.1,
     }
   };
@@ -35,6 +38,15 @@ export class TroubleshooterService
     const settings = this.state.settings;
 
     return [
+      <IFormInput<boolean>> {
+        value: settings.skippedEnabled,
+        name: 'skippedEnabled',
+        description: 'Detect skipped frames',
+        type: 'OBS_PROPERTY_BOOL',
+        visible: true,
+        enabled: true,
+      },
+
       <INumberInputValue> {
         value: settings.skippedThreshold,
         name: 'skippedThreshold',
@@ -43,9 +55,18 @@ export class TroubleshooterService
         minVal: 0,
         maxVal: 1,
         stepVal: 0.01,
-        visible: true,
+        visible: settings.skippedEnabled,
         enabled: true,
         usePercentages: true,
+      },
+
+      <IFormInput<boolean>> {
+        value: settings.laggedEnabled,
+        name: 'laggedEnabled',
+        description: 'Detect lagged frames',
+        type: 'OBS_PROPERTY_BOOL',
+        visible: true,
+        enabled: true,
       },
 
       <INumberInputValue> {
@@ -56,9 +77,18 @@ export class TroubleshooterService
         minVal: 0,
         maxVal: 1,
         stepVal: 0.01,
-        visible: true,
+        visible: settings.laggedEnabled,
         enabled: true,
         usePercentages: true,
+      },
+
+      <IFormInput<boolean>> {
+        value: settings.droppedEnabled,
+        name: 'droppedEnabled',
+        description: 'Detect dropped frames',
+        type: 'OBS_PROPERTY_BOOL',
+        visible: true,
+        enabled: true,
       },
 
       <INumberInputValue> {
@@ -69,7 +99,7 @@ export class TroubleshooterService
         minVal: 0,
         maxVal: 1,
         stepVal: 0.01,
-        visible: true,
+        visible: settings.droppedEnabled,
         enabled: true,
         usePercentages: true,
       }


### PR DESCRIPTION
Eric Freytag requested this feature.
- Each troubleshooter notifications can be disabled/enabled
- Lagged frames detection is disabled by default