### PR TITLE
various scene collection stability fixes

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -161,9 +161,6 @@ export class SceneCollectionsService extends Service
       }
     }
 
-    // Fall back to an empty collection
-    if (this.scenesService.scenes.length === 0) this.setupEmptyCollection();
-
     this.finishLoadingOperation();
   }
 
@@ -450,6 +447,10 @@ export class SceneCollectionsService extends Service
 
         data = this.stateService.readCollectionFile(id, true);
         await this.loadDataIntoApplicationState(data);
+      }
+
+      if (this.scenesService.scenes.length === 0) {
+        throw new Error('Scene collection was loaded but there were no scenes.');
       }
 
       // Everything was successful, write a backup

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -81,6 +81,12 @@ export class SceneCollectionsService extends Service
   private initialized = false;
 
   /**
+   * Whether a valid collection is currently loaded.
+   * Is used to decide whether we should save.
+   */
+  private collectionLoaded = false;
+
+  /**
    * Does not use the standard init function so we can have asynchronous
    * initialization.
    */
@@ -123,6 +129,7 @@ export class SceneCollectionsService extends Service
    * Saves the current scene collection
    */
   async save(): Promise<void> {
+    if (!this.collectionLoaded) return;
     if (!this.activeCollection) return;
     await this.saveCurrentApplicationStateAs(this.activeCollection.id);
     this.stateService.SET_MODIFIED(
@@ -187,7 +194,8 @@ export class SceneCollectionsService extends Service
       this.setupEmptyCollection();
     }
 
-    await this.saveCurrentApplicationStateAs(id);
+    this.collectionLoaded = true;
+    await this.save();
     this.finishLoadingOperation();
   }
 
@@ -297,7 +305,8 @@ export class SceneCollectionsService extends Service
       console.error('Overlay installation failed', e);
     }
 
-    await this.saveCurrentApplicationStateAs(id);
+    this.collectionLoaded = true;
+    await this.save();
     this.finishLoadingOperation();
   }
 
@@ -455,6 +464,7 @@ export class SceneCollectionsService extends Service
 
       // Everything was successful, write a backup
       this.stateService.writeDataToCollectionFile(id, data, true);
+      this.collectionLoaded = true;
     } else {
       await this.attemptRecovery(id);
     }
@@ -545,6 +555,7 @@ export class SceneCollectionsService extends Service
     }
 
     this.hotkeysService.clearAllHotkeys();
+    this.collectionLoaded = false;
   }
 
   /**

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -118,7 +118,10 @@ export class SceneCollectionsStateService extends StatefulService<
   readCollectionFile(id: string, backup?: boolean) {
     let filePath = this.getCollectionFilePath(id);
     if (backup) filePath = `${filePath}.bak`;
-    return this.fileManagerService.read(filePath);
+    return this.fileManagerService.read(filePath, {
+      validateJSON: true,
+      retries: 2
+    });
   }
 
   /**

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -473,11 +473,15 @@ export class StreamlabelsService extends Service {
 
 
   private ensureDirectory() {
-    if (fs.existsSync(this.streamlabelsDirectory)) {
-      rimraf.sync(this.streamlabelsDirectory);
-    }
+    try {
+      if (fs.existsSync(this.streamlabelsDirectory)) {
+        rimraf.sync(this.streamlabelsDirectory);
+      }
 
-    fs.mkdirSync(this.streamlabelsDirectory);
+      fs.mkdirSync(this.streamlabelsDirectory);
+    } catch (e) {
+      console.error('Error ensuring streamlabels directory!');
+    }
   }
 
 


### PR DESCRIPTION
- Add the option to validate parseable JSON when reading a file
- Retry file reading
- Stop just creating a new scene if we failed to load any scenes, and treat it as a failure
- Recover from errors when ensuring streamlabels folder
- Use a flag to make sure we are only saving when we are in a state where things successfully loaded.