### PR TITLE
refresh by loading chat url instead of just refreshing the page

### DIFF
--- a/app/components/Chat.vue.ts
+++ b/app/components/Chat.vue.ts
@@ -94,7 +94,7 @@ export default class Chat extends Vue {
   }
 
   refresh() {
-    this.$refs.chat.reload();
+    this.$refs.chat.loadURL(this.chatUrl);
   }
 
   private onSettingsChangedHandler(changedSettings: Partial<ICustomizationSettings>) {


### PR DESCRIPTION
This is useful in situations where the chat window has navigated away from the original page.