### PR TITLE
Add YouTube offline chat message

### DIFF
--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -74,6 +74,11 @@
       <div class="live-dock-chat" v-if="isTwitch || isMixer || (isYoutube && isStreaming)">
         <chat ref="chat" />
       </div>
+      <div class="flex flex--center flex--column live-dock-chat--offline" v-else >
+        <img class="flex flex--center flex--column margin-bot--20" src="../../media/images/sleeping-kevin-night.png">
+        <span>Your chat is currently offline</span>
+      </div>
+
 
 
     </div>
@@ -188,6 +193,14 @@
 .live-dock-chat {
   flex-grow: 1;
   position: relative;
+}
+
+.live-dock-chat--offline {
+  height: 100%;
+
+  img{ 
+    width: 75%;
+  }
 }
 
 .live-dock-pulse {


### PR DESCRIPTION
This adds a offline chat indicator if you are specifically using YouTube since they don't show chat while offline.
![electron_2018-04-11_12-44-20](https://user-images.githubusercontent.com/5510965/38639965-b6dc9ba4-3d87-11e8-9300-7f9cdb2adcda.png)