### PR TITLE
fix load state in PersistentStatefulService

### DIFF
--- a/app/services/persistent-stateful-service.ts
+++ b/app/services/persistent-stateful-service.ts
@@ -1,3 +1,4 @@
+import { merge } from 'lodash';
 import { StatefulService } from './stateful-service';
 import Utils from './utils';
 
@@ -15,10 +16,7 @@ export abstract class PersistentStatefulService<
     const persisted =
       JSON.parse(localStorage.getItem(this.localStorageKey)) || {};
 
-    return {
-      ...this.defaultState,
-      ...persisted
-    };
+    return merge({}, this.defaultState, persisted);
   }
 
   static get localStorageKey() {


### PR DESCRIPTION
That fixes the issue with troubleshooter notifications. PersistantStatefulService must use deep merge with defaultState to load the right state