### PR TITLE
remove tests from the release process

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -196,12 +196,6 @@ async function runScript() {
   info('Compiling assets...');
   executeCmd('yarn compile:production');
 
-  info('Running tests...');
-  executeCmd('yarn test');
-
-  info('The current revision has passed testing and is ready to be');
-  info('packaged and released');
-
   const pjson = JSON.parse(fs.readFileSync('package.json'));
   const currentVersion = pjson.version;
 


### PR DESCRIPTION
These tests take a long time and draw out the release process.  They are a relic from before we had our test suite reliably running on a CI server.