### PR TITLE
change timestamp server to digicert

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
       "perMachine": true,
       "allowToChangeInstallationDirectory": true,
       "include": "installer.nsh"
+    },
+    "win": {
+      "rfc3161TimeStampServer": "http://timestamp.digicert.com"
     }
   },
   "ava": {


### PR DESCRIPTION
The default timestamp server used by electron builder is down.