### PR TITLE
recommend adding by reference for widgets of the same type

### DIFF
--- a/app/components/windows/AddSource.vue
+++ b/app/components/windows/AddSource.vue
@@ -30,7 +30,14 @@
 
     <div class="row">
       <div class="columns small-12">
-        <h4>Add Existing Source</h4>
+        <h4>
+          Add Existing Source
+          <span
+            v-if="propertiesManager === 'widget'"
+            class="recommended-label">
+            Recommended
+          </span>
+        </h4>
       </div>
     </div>
     <div class="sources-browser row">
@@ -98,6 +105,16 @@
   text-align: right;
   padding-top: 20px;
   padding-bottom: 20px;
+}
+
+.recommended-label {
+  color: @teal;
+  margin-left: 10px;
+  text-transform: none;
+}
+
+.studio-controls-selector {
+  width: 100%;
 }
 
 </style>

--- a/app/components/windows/NameSource.vue.ts
+++ b/app/components/windows/NameSource.vue.ts
@@ -13,18 +13,10 @@ import { WidgetsService, WidgetDefinitions, WidgetType } from '../../services/wi
   mixins: [windowMixin]
 })
 export default class NameSource extends Vue {
-
-  @Inject()
-  sourcesService: ISourcesServiceApi;
-
-  @Inject()
-  scenesService: IScenesServiceApi;
-
-  @Inject()
-  widgetsService: WidgetsService;
-
-  @Inject()
-  windowsService: WindowsService;
+  @Inject() sourcesService: ISourcesServiceApi;
+  @Inject() scenesService: IScenesServiceApi;
+  @Inject() widgetsService: WidgetsService;
+  @Inject() windowsService: WindowsService;
 
   options: {
     sourceType?: TSourceType,

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -5,14 +5,17 @@ import {
   ISource,
   SourcesService,
   TPropertiesManager,
+  ISourceComparison,
   PROPERTIES_MANAGER_TYPES
 } from './index';
-import { mutation, ServiceHelper } from '../stateful-service';
-import { Inject } from '../../util/injector';
-import { ScenesService } from '../scenes';
-import { TFormData } from '../../components/shared/forms/Input';
-import Utils from '../utils';
+import { mutation, ServiceHelper } from 'services/stateful-service';
+import { Inject } from 'util/injector';
+import { ScenesService } from 'services/scenes';
+import { TFormData } from 'components/shared/forms/Input';
+import Utils from 'services/utils';
+import { WidgetType } from 'services/widgets';
 import * as obs from '../../../obs-api';
+import { isEqual } from 'lodash';
 
 
 @ServiceHelper()
@@ -49,6 +52,30 @@ export class Source implements ISourceApi {
 
   getSettings(): Dictionary<any> {
     return this.getObsInput().settings;
+  }
+
+  /**
+   * Compares the details of this source to another, to determine
+   * whether adding as a reference makes sense.
+   * @param comparison the comparison details of the other source
+   */
+  isSameType(comparison: ISourceComparison): boolean {
+    if (this.channel) return;
+
+    return isEqual(this.getComparisonDetails(), comparison);
+  }
+
+  getComparisonDetails(): ISourceComparison {
+    const details: ISourceComparison = {
+      type: this.type,
+      propertiesManager: this.getPropertiesManagerType()
+    };
+
+    if (this.getPropertiesManagerType() === 'widget') {
+      details.widgetType = this.getPropertiesManagerSettings().widgetType;
+    }
+
+    return details;
   }
 
 

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -60,7 +60,7 @@ export class Source implements ISourceApi {
    * @param comparison the comparison details of the other source
    */
   isSameType(comparison: ISourceComparison): boolean {
-    if (this.channel) return;
+    if (this.channel) return false;
 
     return isEqual(this.getComparisonDetails(), comparison);
   }

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -16,10 +16,21 @@ export interface ISource extends IResource {
   channel?: number;
 }
 
+/**
+ * Used to compare whether 2 sources are functionally
+ * equivalent and should be created as a reference.
+ */
+export interface ISourceComparison {
+  type: TSourceType;
+  propertiesManager: TPropertiesManager;
+  widgetType?: WidgetType;
+}
+
 
 export interface ISourceApi extends ISource {
   updateSettings(settings: Dictionary<any>): void;
   getSettings(): Dictionary<any>;
+  isSameType(comparison: ISourceComparison): boolean;
   getPropertiesManagerType(): TPropertiesManager;
   getPropertiesManagerSettings(): Dictionary<any>;
   getPropertiesManagerUI(): string;

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -355,10 +355,10 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
 
-  showAddSource(sourceType: TSourceType, propertiesManager?: TPropertiesManager) {
+  showAddSource(sourceType: TSourceType, propertiesManager?: TPropertiesManager, widgetType?: WidgetType) {
     this.windowsService.showWindow({
       componentName: 'AddSource',
-      queryParams: { sourceType, propertiesManager },
+      queryParams: { sourceType, propertiesManager, widgetType },
       size: {
         width: 600,
         height: 540


### PR DESCRIPTION
Changes:
- When there is already an existing widget of the same type, show the "Add Source" screen instead of the "Name Source" screen
- Consolidate logic that is used to determine if an existing source of that type exists
- Add a recommended label for adding by reference when adding a new widget