### PR TITLE
Input: Test for number of properties first

### DIFF
--- a/app/components/shared/forms/Input.ts
+++ b/app/components/shared/forms/Input.ts
@@ -298,6 +298,7 @@ export function getPropertiesFormData(obsSource: obs.ISource): TFormData {
   const obsSettings = obsSource.settings;
 
   if (!obsProps) return null;
+  if (!obsProps.count()) return null;
 
   let obsProp = obsProps.first();
   do {
@@ -430,6 +431,7 @@ export function setupSourceDefaults(obsSource: obs.ISource) {
   const properties = obsSource.properties;
 
   if (!properties) return;
+  if (!properties.count()) return;
 
   let obsProp = properties.first();
   do {


### PR DESCRIPTION
Ran into this with the obs-studio-node `ipc-integration` branch, SLOBS is not properly testing if the source actually has properties. Instead we get an exception and a white window.

This happens due to different behavior in osn staging and ipc-integration. ipc-integration usually does not return an object when there's nothing to return (i.e. the returned object would be a lie), while staging actually returns an object even if that object would be invalid. So for ipc-integration to work correctly, testing for null/undefined must be done.