### PR TITLE
fix oauth login scope for Twitch

### DIFF
--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -22,8 +22,8 @@ export class TwitchService extends Service implements IPlatformService {
 
   get authUrl() {
     const host = this.hostsService.streamlabs;
-    const query = `_=${Date.now()}&skip_splash=true&external=electron&twitch&force_verify&scope=channel_read,
-      channel_editor&origin=slobs`;
+    const query = `_=${Date.now()}&skip_splash=true&external=electron&twitch&force_verify&` +
+      'scope=channel_read,channel_editor&origin=slobs';
     return `https://${host}/slobs/login?${query}`;
   }
 


### PR DESCRIPTION
Twitch suddenly started caring if there are extra spaces in the login scope.  Not sure how we ended up adding this line break in the first place...