### PR TITLE
Performance Monitor: Stop monitoring if we're stopping monitoring

### DIFF
--- a/app/services/performance-monitor/performance-monitor.ts
+++ b/app/services/performance-monitor/performance-monitor.ts
@@ -60,6 +60,7 @@ export class PerformanceMonitorService extends StatefulService<IMonitorState> {
 
 
   stop() {
+    this.performanceService.stop();
     clearInterval(this.intervalId);
     this.intervalId = null;
     if (this.droppedFramesSubscr) this.droppedFramesSubscr.unsubscribe();


### PR DESCRIPTION
Another one encountered rarely in obs-studio-node `ipc-integration`, at random we crash the server (and thus the client) as the performance monitor calls out into obs after shutting down obs.