### PR TITLE
Adjusted Wheel Widget Height

### DIFF
--- a/app/services/widgets.ts
+++ b/app/services/widgets.ts
@@ -339,7 +339,7 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
     },
 
     width: 600,
-    height: 600,
+    height: 800,
 
     x: 0,
     y: 1,


### PR DESCRIPTION
Adjusted the default Wheel widget height to 800 to have the result shown by default for new users setting up a wheel first time.