### PR TITLE
Fix mouse drift when dragging sources

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import _ from 'lodash';
-import DragHandler from 'util/DragHandler';
+import { DragHandler } from 'util/DragHandler';
 import { Inject } from 'util/injector';
 import { ScenesService, SceneItem, Scene } from 'services/scenes';
 import { VideoService } from 'services/video';
@@ -107,8 +107,14 @@ export default class StudioEditor extends Vue {
 
   startDragging(event: MouseEvent) {
     this.dragHandler = new DragHandler(event, {
-      renderedWidth: this.renderedWidth,
-      renderedHeight: this.renderedHeight
+      displaySize: {
+        x: this.renderedWidth,
+        y: this.renderedHeight
+      },
+      displayOffset: {
+        x: this.renderedOffsetX,
+        y: this.renderedOffsetY
+      }
     });
   }
 
@@ -121,7 +127,6 @@ export default class StudioEditor extends Vue {
   }
 
   handleMouseUp(event: MouseEvent) {
-
     this.canDrag = true;
 
     // If neither a drag or resize was initiated, it must have been


### PR DESCRIPTION
My old implementation of source dragging was based on measuring the change in mouse movement, rather than calculating the new position based on the current mouse position.  This works fine without snapping enabled, but with snapping it introduces fairly annoying mouse drift that gets worse the more we are snapping.

These changes modify the drag handler to calculate the new source position solely based on the current position of the mouse.  Any snapping is applied after the fact, so that means that when a source leaves a snapped position it will return to its original position under the mouse cursor.  At the end, we translate the new position into a delta which we can equally apply to all selected sources.  This new system feels much better to use.