### PR TITLE
fix google font downloading for overlay text sources

### DIFF
--- a/app/services/scene-collections/nodes/overlays/text.ts
+++ b/app/services/scene-collections/nodes/overlays/text.ts
@@ -40,6 +40,10 @@ export class TextNode extends Node<ISchema, IContext> {
     const settings = this.data.settings;
 
     this.updateInput(context);
+
+    // This is a bit of a hack to force us to immediately download the
+    // google font.
+    context.sceneItem.getSource().replacePropertiesManager('default', {});
   }
 
   updateInput(context: IContext) {


### PR DESCRIPTION
This is the same hack we use to get media sources to back up immediately.  This is thoroughly tech debt and I plan on circling back and refactoring the overlay loading system in order to prevent weird issues like this.  Luckily I think that refactor won't require us to change the overlay config file format.