### PR TITLE
update sl-vue-tree

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8674,8 +8674,8 @@ single-line-log@^1.1.2:
     string-width "^1.0.1"
 
 "sl-vue-tree@https://github.com/stream-labs/sl-vue-tree.git":
-  version "1.4.0"
-  resolved "https://github.com/stream-labs/sl-vue-tree.git#e83355f3669221729ccac5f15dce11008ddbdc64"
+  version "1.5.1"
+  resolved "https://github.com/stream-labs/sl-vue-tree.git#aaa1f528c7ab6f8239a4499bee55e76ea050a65b"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I've got some complaints about `sl-vue-tree`. People expect that dragging to the bottom sets the root level for the node. https://github.com/holiber/sl-vue-tree/issues/5
![reordering](https://user-images.githubusercontent.com/3768346/41575621-3d7295de-7338-11e8-89bf-89174be8601a.gif)
