### PR TITLE
Add confirmation dialogue to deletion of sources

### DIFF
--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -1,4 +1,5 @@
 import { uniq } from 'lodash';
+import electron from 'electron';
 import { mutation, StatefulService, ServiceHelper } from 'services/stateful-service';
 import {
   Scene,
@@ -9,6 +10,7 @@ import {
   IPartialTransform,
   TSceneNode, ISceneItemNode, SceneItemFolder, TSceneNodeModel
 } from 'services/scenes';
+import { $t } from 'services/i18n';
 import { Inject } from '../../util/injector';
 import { shortcut } from '../shortcuts';
 import { ISelection, ISelectionServiceApi, ISelectionState, TNodesList } from './selection-api';
@@ -95,7 +97,19 @@ export class SelectionService
 
   @shortcut('Delete')
   remove() {
-    return this.getSelection().remove.call(this);
+    const name = this.getLastSelected().name;
+    electron.remote.dialog.showMessageBox(
+      electron.remote.getCurrentWindow(),
+      {
+        type: 'warning',
+        message: $t('Are you sure you want to remove %{sceneName}?', { sceneName: name }),
+        buttons: [$t('Cancel'), $t('OK')]
+      },
+      ok => {
+        if (!ok) return;
+        return this.getSelection().remove.call(this);
+      }
+    );
   }
 
   @shortcut('ArrowLeft')

--- a/test/helpers/spectron/sources.js
+++ b/test/helpers/spectron/sources.js
@@ -1,6 +1,7 @@
 // Source helper functions
 import { focusMain, focusChild } from '.';
 import { contextMenuClick } from './context-menu';
+import { dialogDismiss } from './dialog';
 
 async function clickSourceAction(t, selector) {
   await t.context.app.client
@@ -15,6 +16,7 @@ export async function clickAddSource(t) {
 
 export async function clickRemoveSource(t) {
   await clickSourceAction(t, '.icon-subtract');
+  await dialogDismiss(t, 'OK');
 }
 
 export async function clickSourceProperties(t) {


### PR DESCRIPTION
Expands the selection service to add a confirmation dialogue when removing sources whether it be via the Delete key, the context menu, or the minus button.