### PR TITLE
download backed up media with the proper extension

### DIFF
--- a/app/services/media-backup.ts
+++ b/app/services/media-backup.ts
@@ -178,7 +178,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     // These are the 2 locations that will be checked for valid media files
     const filesToCheck = [
       originalFilePath,
-      this.getMediaFilePath(serverId)
+      this.getMediaFilePath(serverId, data.filename)
     ];
 
     for (const fileToCheck of filesToCheck) {
@@ -211,7 +211,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     let downloadedPath: string;
 
     try {
-      downloadedPath = await this.withRetry(() => this.downloadFile(data.url, serverId));
+      downloadedPath = await this.withRetry(() => this.downloadFile(data.url, serverId, data.filename));
     } catch (e) {
       console.error(`[Media Backup] Error downloading file: ${e.body}`);
 
@@ -287,9 +287,9 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     });
   }
 
-  private downloadFile(url: string, serverId: number) {
+  private downloadFile(url: string, serverId: number, filename: string) {
     this.ensureMediaDirectory();
-    const filePath = this.getMediaFilePath(serverId);
+    const filePath = this.getMediaFilePath(serverId, filename);
 
     return new Promise<string>((resolve, reject) => {
       const stream = fs.createWriteStream(filePath);
@@ -323,8 +323,8 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     });
   }
 
-  private getMediaFilePath(serverId: number) {
-    return path.join(this.mediaDirectory, serverId.toString());
+  private getMediaFilePath(serverId: number, filename: string) {
+    return path.join(this.mediaDirectory, `${serverId.toString()}-${filename}`);
   }
 
   private get apiBase() {


### PR DESCRIPTION
We were omitting the file extension when restoring media from the cloud.  However, it seems like the image source won't treat a gif as a gif unless it has a `.gif` extension.