### PR TITLE
load up last modified collection when active isn't present

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -102,7 +102,17 @@ export class SceneCollectionsService extends Service
     if (this.activeCollection) {
       await this.load(this.activeCollection.id);
     } else if (this.collections.length > 0) {
-      await this.load(this.collections[0].id);
+      let latestId = this.collections[0].id;
+      let latestModified = this.collections[0].modified;
+
+      this.collections.forEach(collection => {
+        if (collection.modified > latestModified) {
+          latestModified = collection.modified;
+          latestId = collection.id;
+        }
+      });
+
+      await this.load(latestId);
     } else {
       await this.create();
     }
@@ -766,7 +776,7 @@ export class SceneCollectionsService extends Service
           this.stateService.ADD_COLLECTION(
             id,
             onServer.name,
-            new Date().toISOString()
+            onServer.last_updated_at
           );
           this.stateService.SET_SERVER_ID(id, onServer.id);
         });


### PR DESCRIPTION
This PR does 2 things:
1) When there isn't an active scene collection set (we just restored from backup or had a corrupted manifest), then default to the last edited scene collection, instead of the first one.
2) Fixed a longstanding bug where after an insert from the server, we will redundantly sync that collection back up to the server on exit.