### PR TITLE
clear cookies on logout

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -209,6 +209,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     await this.sceneCollectionsService.save();
     await this.sceneCollectionsService.safeSync();
     this.LOGOUT();
+    electron.remote.session.defaultSession.clearStorageData({ storages: ['cookies'] });
     this.appService.finishLoading();
   }
 


### PR DESCRIPTION
This will clear the Twitch/Youtube/Mixer login out of the browser session when logging out.  This should fix a whole range of bugs related to account swapping, and should improve security when using SLOBS on a shared workstation.