### PR TITLE
fix(CI): Added yarn.lock check

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: off
 install:
   - ps: Install-Product node 8
   - git submodule update --init --recursive
-  - yarn install
+  - yarn install --frozen-lockfile --check-files
   - yarn install-plugins
   - yarn compile:ci
 


### PR DESCRIPTION
Hi.  This fix will solve your dirty lock file woes.  It will fail the build if `yarn.lock` does not match your dependencies.

https://yarnpkg.com/lang/en/docs/cli/install/