### PR TITLE
Hide chat via absolute position offscreen

### DIFF
--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -15,7 +15,7 @@
 
   <transition name="slide-fade">
     <div
-      v-show="!collapsed"
+      :style="liveDockStyles"
       class="live-dock-expanded-contents">
       <div
         class="live-dock-chevron icon-btn"

--- a/app/components/LiveDock.vue.ts
+++ b/app/components/LiveDock.vue.ts
@@ -38,6 +38,13 @@ export default class LiveDock extends Vue {
   editStreamInfoTooltip = $t('Edit your stream title and description');
   controlRoomTooltip = $t('Go to Youtube Live Dashboard to control your stream');
 
+  get liveDockStyles() {
+    return {
+      position: this.collapsed ? 'absolute' : 'static',
+      left: this.collapsed ? '10000px' : 'auto'
+    };
+  }
+
   mounted() {
     this.elapsedInterval = window.setInterval(() => {
       if (this.streamingStatus === EStreamingState.Live) {


### PR DESCRIPTION
Electron webviews have a known issue where they render improperly and crash sometimes when hidden via CSS using `display: none`.  Instead, we are positioning it offscreen with `position: absolute`.  Hopefully this will resolve some chat-related crashes we have been experiencing.