### PR TITLE
Configure behaviors of toast

### DIFF
--- a/app/components/widget-settings/WidgetSettings.vue.ts
+++ b/app/components/widget-settings/WidgetSettings.vue.ts
@@ -114,7 +114,12 @@ export default class WidgetSettings<TData, TService extends WidgetSettingsServic
   onFailHandler() {
     this.$toasted.show(
       $t('Save failed, something went wrong.'),
-      { position: 'bottom-center', className: 'toast-alert' }
+      {
+        position: 'bottom-center',
+        className: 'toast-alert',
+        duration: 1000,
+        singleton: true
+      }
     );
   }
 }


### PR DESCRIPTION
Toast notification will now automatically close after 1 second and no more than one toast can be open at a time