### PR TITLE
Fix filter compatibility

### DIFF
--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -11,7 +11,6 @@ import namingHelpers from '../util/NamingHelpers';
 import { $t } from 'services/i18n';
 import { EOrderMovement } from 'obs-studio-node';
 
-
 export type TSourceFilterType =
   'mask_filter' |
   'crop_filter' |
@@ -109,19 +108,35 @@ export class SourceFiltersService extends Service {
   getTypesForSource(sourceId: string): ISourceFilterType[] {
     const source = this.sourcesService.getSource(sourceId);
     return this.getTypes().filter(filterType => {
-      return (filterType.audio && source.audio) || (filterType.video && source.video);
+      /* Audio filters can be applied to audio sources. */
+      if (source.audio && filterType.audio) {
+        return true;
+      }
+
+      /* We have either a video filter or source */
+      /* Can't apply asynchronous video filters to non-asynchronous video souces. */
+      if (!source.async && filterType.async) {
+        return false;
+      }
+
+      /* Video filters can be applied to video sources. */
+      if (source.video && filterType.video) {
+        return true;
+      }
+
+      return false;
     });
   }
 
 
   add(sourceId: string, filterType: TSourceFilterType, filterName: string, settings?: Dictionary<TObsValue>) {
     const source = this.sourcesService.getSource(sourceId);
-    const obsFilter = obs.FilterFactory.create(filterType, filterName);
+    const obsFilter = obs.FilterFactory.create(filterType, filterName, settings || {});
+
     source.getObsInput().addFilter(obsFilter);
     // There is now 2 references to the filter at that point
     // We need to release one
     obsFilter.release();
-    if (settings) obsFilter.update(settings);
     return obsFilter;
   }
 

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -25,6 +25,7 @@ export class Source implements ISourceApi {
   type: TSourceType;
   audio: boolean;
   video: boolean;
+  async: boolean;
   muted: boolean;
   width: number;
   height: number;

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -9,6 +9,7 @@ export interface ISource extends IResource {
   type: TSourceType;
   audio: boolean;
   video: boolean;
+  async: boolean;
   muted: boolean;
   width: number;
   height: number;

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -29,6 +29,7 @@ const { ipcRenderer } = electron;
 
 const AudioFlag = obs.ESourceOutputFlags.Audio;
 const VideoFlag = obs.ESourceOutputFlags.Video;
+const AsyncFlag = obs.ESourceOutputFlags.Async;
 const DoNotDuplicateFlag = obs.ESourceOutputFlags.DoNotDuplicate;
 
 export const PROPERTIES_MANAGER_TYPES = {
@@ -101,6 +102,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       // Will be updated periodically
       audio: false,
       video: false,
+      async: false,
       doNotDuplicate: false,
 
       // Unscaled width and height
@@ -319,10 +321,11 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   private updateSourceFlags(source: ISource, flags: number, doNotEmit? : boolean) {
     const audio = !!(AudioFlag & flags);
     const video = !!(VideoFlag & flags);
+    const async = !!(AsyncFlag & flags);
     const doNotDuplicate = !!(DoNotDuplicateFlag & flags);
 
     if ((source.audio !== audio) || (source.video !== video)) {
-      this.UPDATE_SOURCE({ id: source.sourceId, audio, video, doNotDuplicate });
+      this.UPDATE_SOURCE({ id: source.sourceId, audio, video, async, doNotDuplicate });
 
       if (!doNotEmit) this.sourceUpdated.next(source);
     }


### PR DESCRIPTION
Second iteration of the filter compatibility check for asynchronous sources. I'm still not 100% if this will cover all cases, the logic surrounding asynchronous sources is a lot more annoying and confusing than I originally thought. I think the best way to test this is to check each filter and compare to the Qt OBS UI. 