### PR TITLE
Fix row global class bleed

### DIFF
--- a/app/components/StudioControls.vue
+++ b/app/components/StudioControls.vue
@@ -15,6 +15,7 @@
   height: 240px;
   width: 100%;
   padding: 20px 10px;
+  margin: 0;
 }
 </style>
 


### PR DESCRIPTION
I double checked all of the components that use the row class (`AddSource`, `WFormGroup`, `GenericGoal`, and `StudioControls`), it appears that only the StudioControls were affected by the weird margin preset. Might have something to do with the styles being partially unscoped? But resetting the margins also works fine.