### PR TITLE
Debounce the slider to prevent constant updates

### DIFF
--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="slider-container">
   <vue-slider class="slider"
-    @input="value => sliderUpdate(value)"
+    @input="value => updateValue(value)"
     :value="value"
     :disabled="disabled"
     :max="max"
@@ -22,7 +22,6 @@
     :value="value"
     @change="updateValue(parseFloat($event.target.value))"
     @keydown="handleKeydown"
-    ref="inputbox"
   />
 </div>
 </template>

--- a/app/components/shared/Slider.vue
+++ b/app/components/shared/Slider.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="slider-container">
   <vue-slider class="slider"
-    @input="value => updateValue(value)"
+    @input="value => sliderUpdate(value)"
     :value="value"
     :disabled="disabled"
     :max="max"
@@ -22,6 +22,7 @@
     :value="value"
     @change="updateValue(parseFloat($event.target.value))"
     @keydown="handleKeydown"
+    ref="inputbox"
   />
 </div>
 </template>

--- a/app/components/shared/Slider.vue.ts
+++ b/app/components/shared/Slider.vue.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import VueSlider from 'vue-slider-component';
-import { throttle } from 'lodash-decorators';
 import { Component, Prop } from 'vue-property-decorator';
 
 @Component({
@@ -18,7 +17,7 @@ export default class SliderInput extends Vue {
   @Prop() sliderStyle: object;
   @Prop() usePercentages: boolean;
 
-  $refs: { slider: any };
+  $refs: { slider: any, inputbox: any };
 
   mounted() {
     // Hack to prevent transitions from messing up slider width
@@ -27,7 +26,11 @@ export default class SliderInput extends Vue {
     }, 500);
   }
 
-  @throttle(500)
+  sliderUpdate(value: number) {
+    this.$refs.inputbox.value = value;
+    this.updateValue(value);
+  }
+
   updateValue(value: number) {
     this.$emit('input', this.roundNumber(value));
   }

--- a/app/components/shared/Slider.vue.ts
+++ b/app/components/shared/Slider.vue.ts
@@ -17,18 +17,13 @@ export default class SliderInput extends Vue {
   @Prop() sliderStyle: object;
   @Prop() usePercentages: boolean;
 
-  $refs: { slider: any, inputbox: any };
+  $refs: { slider: any };
 
   mounted() {
     // Hack to prevent transitions from messing up slider width
     setTimeout(() => {
       if (this.$refs.slider) this.$refs.slider.refresh();
     }, 500);
-  }
-
-  sliderUpdate(value: number) {
-    this.$refs.inputbox.value = value;
-    this.updateValue(value);
   }
 
   updateValue(value: number) {

--- a/app/components/shared/forms/SliderInput.vue
+++ b/app/components/shared/forms/SliderInput.vue
@@ -7,7 +7,7 @@
       <div class="slider-container">
         <Slider
           @input="value => updateValue(value)"
-          :value="value.value"
+          :value="localValue"
           :disabled="value.enabled == false"
           :max="value.maxVal"
           :min="value.minVal"

--- a/app/components/shared/forms/SliderInput.vue.ts
+++ b/app/components/shared/forms/SliderInput.vue.ts
@@ -1,4 +1,4 @@
-import { throttle } from 'lodash-decorators';
+import { debounce } from 'lodash-decorators';
 import { Component, Prop } from 'vue-property-decorator';
 import { TObsType, Input, ISliderInputValue } from './Input';
 import Slider from '../Slider.vue';
@@ -13,7 +13,7 @@ class SliderInput extends Input<ISliderInputValue> {
   @Prop()
   value: ISliderInputValue;
 
-  @throttle(100)
+  @debounce(100)
   updateValue(value: number) {
     this.emitInput({ ...this.value, value });
   }

--- a/app/components/shared/forms/SliderInput.vue.ts
+++ b/app/components/shared/forms/SliderInput.vue.ts
@@ -10,11 +10,19 @@ class SliderInput extends Input<ISliderInputValue> {
 
   static obsType: TObsType;
 
-  @Prop()
-  value: ISliderInputValue;
+  @Prop() value: ISliderInputValue;
+
+  // Local value is an instaneous value that is updated as the user
+  // moves the slider.  It makes the UI feel more responsive.
+  localValue = this.value.value;
+
+  updateValue(value: number) {
+    this.localValue = value;
+    this.emitValue(value);
+  }
 
   @debounce(100)
-  updateValue(value: number) {
+  emitValue(value: number) {
     this.emitInput({ ...this.value, value });
   }
 


### PR DESCRIPTION
This makes the slider a bit more optimal and smooth, with simple changes. 

This could be used with number input boxes as well (and should be) which should also apply to the formatting applied to the input box. This way, the user can enter whatever they want and only the intended value gets formatted rather than every value in between as well. 

Let me know if anything unorthodox is done here.