### PR TITLE
Update OSN to include updated browser source

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node-fontinfo": "^0.0.2",
     "node-gyp": "^3.6.2",
     "node-libuiohook": "file:./node-libuiohook",
-    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.41/iojs-v2.0.1-signed.tar.gz",
+    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.42/iojs-v2.0.1-signed.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",


### PR DESCRIPTION
An update of OSN to include the new browser source. 
It also includes the browser interaction API though there's some issues surrounding it of which the origins are still not fully discovered.