### PR TITLE
Optimize heavy areas with IPC use

### DIFF
--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -99,8 +99,9 @@ export class SceneItem extends SceneItemNode implements ISceneItemApi {
     return this.source.getObsInput();
   }
 
-  getObsSceneItem(): obs.ISceneItem {
-    return this.getScene().getObsScene().findItem(this.obsSceneItemId);
+  getObsSceneItem(obsScene?: obs.IScene): obs.ISceneItem {
+    if (!obsScene) obsScene = this.getScene().getObsScene();
+    return obsScene.findItem(this.obsSceneItemId);
   }
 
   getSettings(): ISceneItemSettings {
@@ -111,10 +112,9 @@ export class SceneItem extends SceneItemNode implements ISceneItemApi {
     };
   }
 
-  setSettings(patch: IPartialSettings) {
-
+  setSettings(patch: IPartialSettings, scene?: obs.IScene) {
+    const obsSceneItem = this.getObsSceneItem(scene);
     // update only changed settings to reduce the amount of IPC calls
-    const obsSceneItem = this.getObsSceneItem();
     const changed = Utils.getChangedParams(this.sceneItemState, patch);
     const newSettings = merge({}, this.sceneItemState, patch);
 
@@ -150,7 +150,7 @@ export class SceneItem extends SceneItemNode implements ISceneItemApi {
         // value between 0 and 360.
         const effectiveRotation = ((newSettings.transform.rotation % 360) + 360) % 360;
 
-        this.getObsSceneItem().rotation = effectiveRotation;
+        obsSceneItem.rotation = effectiveRotation;
         changed.transform.rotation = effectiveRotation;
       }
 
@@ -164,7 +164,7 @@ export class SceneItem extends SceneItemNode implements ISceneItemApi {
     }
 
     if (changed.visible !== void 0) {
-      this.getObsSceneItem().visible = newSettings.visible;
+      obsSceneItem.visible = newSettings.visible;
     }
 
     this.UPDATE({ sceneItemId: this.sceneItemId, ...changed });
@@ -238,8 +238,8 @@ export class SceneItem extends SceneItemNode implements ISceneItemApi {
     });
   }
 
-  setTransform(transform: IPartialTransform) {
-    this.setSettings({ transform });
+  setTransform(transform: IPartialTransform, scene?: obs.IScene) {
+    this.setSettings({ transform }, scene);
   }
 
   resetTransform() {

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -311,12 +311,14 @@ export class Scene implements ISceneApi {
       if (sourceFolder) sourceFolder.recalculateChildrenOrder();
     }
 
+    const obsScene = this.getObsScene();
+
     itemsToMove.forEach(item => {
       let currentIdx: number;
-      this.getObsScene().getItems().reverse().forEach((obsItem, idx) => {
+      obsScene.getItems().reverse().forEach((obsItem, idx) => {
         if (obsItem.id === item.obsSceneItemId) currentIdx = idx;
       });
-      this.getObsScene().moveItem(currentIdx, item.getItemIndex());
+      obsScene.moveItem(currentIdx, item.getItemIndex());
     });
   }
 

--- a/app/util/DragHandler.ts
+++ b/app/util/DragHandler.ts
@@ -186,9 +186,12 @@ export class DragHandler {
     const deltaX = rect.x - this.draggedSource.transform.position.x;
     const deltaY = rect.y - this.draggedSource.transform.position.y;
 
+    // Optimization to reduce fetching scene multiple times later on
+    const obsScene = this.scenesService.activeScene.getObsScene();
+
     this.selectionService.getItems().forEach(item => {
       const pos = item.transform.position;
-      item.setTransform({ position: { x: pos.x + deltaX, y: pos.y + deltaY } });
+      item.setTransform({ position: { x: pos.x + deltaX, y: pos.y + deltaY } }, obsScene);
     });
   }
 


### PR DESCRIPTION
This was a small optimization that's slightly noticeable when dragging sources around. It prevents fetching the scene as well as the scene item for every single scene item being dragged. This modifies the scene-item api in those hot areas to allow passing an obs object that's already created instead of creating it on the fly. In addition, we use already created objects or cache objects where possible to prevent fetching new ones. 