### PR TITLE
remove node-libuiohook as a submodule and use github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "node-libuiohook"]
-	path = node-libuiohook
-	url = https://github.com/stream-labs/node-libuiohook.git

--- a/README.md
+++ b/README.md
@@ -61,12 +61,6 @@ https://www.python.org/
 
 ## Installation
 
-First, make sure you have initialized git submodules:
-
-```
-git submodule update --init --recursive
-```
-
 Install all node modules via yarn:
 
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ build: off
 
 install:
   - ps: Install-Product node 8
-  - git submodule update --init --recursive
   - yarn install
   - yarn install-plugins
   - yarn compile:ci

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "font-manager": "git+https://github.com/computerquip-streamlabs/font-manager.git",
     "node-fontinfo": "^0.0.2",
     "node-gyp": "^3.6.2",
-    "node-libuiohook": "file:./node-libuiohook",
+    "node-libuiohook": "git+https://github.com/stream-labs/node-libuiohook.git",
     "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.45/iojs-v2.0.4-signed.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6630,8 +6630,9 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-"node-libuiohook@file:./node-libuiohook":
+"node-libuiohook@git+https://github.com/stream-labs/node-libuiohook.git":
   version "0.0.1"
+  resolved "git+https://github.com/stream-labs/node-libuiohook.git#ae16939b061934f392258c1b07eb4e7cdde13fed"
   dependencies:
     cmake-js "^3.4.1"
 


### PR DESCRIPTION
There's no reason for us to overcomplicate things with a git submodule now that this repo is public.  Renovate bot was struggling with this.