### PR TITLE
kill IPC from getUniqueId

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -79,6 +79,7 @@ import { ChatBoxService } from 'services/widget-settings/chat-box';
 import { DonationGoalService } from 'services/widget-settings/donation-goal';
 import { FollowerGoalService } from 'services/widget-settings/follower-goal';
 import { ViewerCountService } from 'services/widget-settings/viewer-count';
+import uuid from 'uuid/v4';
 
 const { ipcRenderer } = electron;
 
@@ -370,7 +371,7 @@ export class ServicesManager extends Service {
     const isPromise = !!(responsePayload && responsePayload.then);
 
     if (isPromise) {
-      const promiseId = ipcRenderer.sendSync('getUniqueId');
+      const promiseId = uuid();
       const promise = responsePayload as PromiseLike<any>;
 
       promise.then(

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -1,24 +1,25 @@
 import Vue from 'vue';
 import { Subject } from 'rxjs/Subject';
 import { Subscription } from 'rxjs/Subscription';
-import { mutation, StatefulService, ServiceHelper } from '../stateful-service';
-import { SourcesService, ISource, Source } from '../sources';
-import { ScenesService } from '../scenes';
+import { mutation, StatefulService, ServiceHelper } from 'services/stateful-service';
+import { SourcesService, ISource, Source } from 'services/sources';
+import { ScenesService } from 'services/scenes';
 import * as obs from '../../../obs-api';
-import Utils from '../utils';
+import Utils from 'services/utils';
 import electron from 'electron';
-import { Inject } from '../../util/injector';
-import { InitAfter } from '../../util/service-observer';
-import { WindowsService } from '../windows';
+import { Inject } from 'util/injector';
+import { InitAfter } from 'util/service-observer';
+import { WindowsService } from 'services/windows';
 import {
   IBitmaskInput, IFormInput, IListInput, INumberInputValue, TFormData,
-} from '../../components/shared/forms/Input';
+} from 'components/shared/forms/Input';
 import {
   IAudioDevice, IAudioServiceApi, IAudioSource, IAudioSourceApi, IAudioSourcesState, IFader,
   IVolmeter
 } from './audio-api';
 import { Observable } from 'rxjs/Observable';
 import { $t } from 'services/i18n';
+import uuid from 'uuid/v4';
 
 const { ipcRenderer } = electron;
 
@@ -160,8 +161,8 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
 
   getDevices(): IAudioDevice[] {
     const devices: IAudioDevice[] = [];
-    const obsAudioInput = obs.InputFactory.create('wasapi_input_capture', ipcRenderer.sendSync('getUniqueId'));
-    const obsAudioOutput = obs.InputFactory.create('wasapi_output_capture', ipcRenderer.sendSync('getUniqueId'));
+    const obsAudioInput = obs.InputFactory.create('wasapi_input_capture', uuid());
+    const obsAudioOutput = obs.InputFactory.create('wasapi_output_capture', uuid());
 
     (obsAudioInput.properties.get('device_id') as obs.IListProperty).details.items
       .forEach((item: { name: string, value: string}) => {

--- a/app/services/jsonrpc/jsonrpc.ts
+++ b/app/services/jsonrpc/jsonrpc.ts
@@ -1,5 +1,5 @@
 import electron from 'electron';
-import { Service } from '../service';
+import { Service } from 'services/service';
 import {
   E_JSON_RPC_ERROR,
   IJsonRpcResponse,
@@ -7,6 +7,7 @@ import {
   IJsonRpcEvent,
   IJsonrpcServiceApi
 } from './jsonrpc-api';
+import uuid from 'uuid/v4';
 
 const { ipcRenderer } = electron;
 
@@ -38,7 +39,7 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
   ): IJsonRpcRequest {
     return {
       jsonrpc: '2.0',
-      id: ipcRenderer.sendSync('getUniqueId'),
+      id: uuid(),
       method,
       params: {
         resource: resourceId,

--- a/app/services/scene-collections/overlays.ts
+++ b/app/services/scene-collections/overlays.ts
@@ -20,6 +20,7 @@ import archiver from 'archiver';
 import https from 'https';
 import { ScenesService } from 'services/scenes';
 import { SelectionService } from 'services/selection';
+import uuid from 'uuid/v4';
 
 const NODE_TYPES = {
   RootNode,
@@ -51,9 +52,7 @@ export class OverlaysPersistenceService extends Service {
     url: string,
     progressCallback?: (progress: IDownloadProgress) => void
   ) {
-    const overlayFilename = `${electron.ipcRenderer.sendSync(
-      'getUniqueId'
-    )}.overlay`;
+    const overlayFilename = `${uuid()}.overlay`;
     const overlayPath = path.join(os.tmpdir(), overlayFilename);
     const fileStream = fs.createWriteStream(overlayPath);
 

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -1,6 +1,6 @@
-import { ServiceHelper, mutation } from '../stateful-service';
+import { ServiceHelper, mutation } from 'services/stateful-service';
 import { ScenesService } from './scenes';
-import { Source, SourcesService, TSourceType } from '../sources';
+import { Source, SourcesService, TSourceType } from 'services/sources';
 import {
   ISceneItem,
   SceneItem,
@@ -12,14 +12,15 @@ import {
   SceneItemFolder,
   ISceneItemNode
 } from './index';
-import Utils from '../utils';
-import * as obs from '../obs-api';
+import Utils from 'services/utils';
+import * as obs from 'services/obs-api';
 import electron from 'electron';
-import { Inject } from '../../util/injector';
+import { Inject } from 'util/injector';
 import { SelectionService, Selection, TNodesList } from 'services/selection';
 import { uniqBy } from 'lodash';
 import { TSceneNodeInfo } from 'services/scene-collections/nodes/scene-items';
 import * as fs from 'fs';
+import uuid from 'uuid/v4';
 const { ipcRenderer } = electron;
 
 
@@ -152,7 +153,7 @@ export class Scene implements ISceneApi {
     if (!this.canAddSource(sourceId)) return null;
 
 
-    const sceneItemId = options.id || ipcRenderer.sendSync('getUniqueId');
+    const sceneItemId = options.id || uuid();
 
     let obsSceneItem: obs.ISceneItem;
     obsSceneItem = this.getObsScene().add(source.getObsInput());
@@ -195,7 +196,7 @@ export class Scene implements ISceneApi {
 
   createFolder(name: string, options: ISceneNodeAddOptions = {}) {
 
-    const id = options.id || ipcRenderer.sendSync('getUniqueId');
+    const id = options.id || uuid();
 
     this.ADD_FOLDER_TO_SCENE({
       id,

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -15,11 +15,10 @@ import {
 import { SourcesService, ISource } from 'services/sources';
 import electron from 'electron';
 import { Subject } from 'rxjs/Subject';
-import { Inject } from '../../util/injector';
-import * as obs from '../obs-api';
-import namingHelpers from '../../util/NamingHelpers';
-import { $t } from 'services/i18n';
-const { ipcRenderer } = electron;
+import { Inject } from 'util/injector';
+import * as obs from 'services/obs-api';
+import namingHelpers from 'util/NamingHelpers';
+import uuid from 'uuid/v4';
 
 export class ScenesService extends StatefulService<IScenesState> implements IScenesServiceApi {
 
@@ -72,7 +71,7 @@ export class ScenesService extends StatefulService<IScenesState> implements ISce
 
   createScene(name: string, options: ISceneCreateOptions = {}) {
     // Get an id to identify the scene on the frontend
-    const id = options.sceneId || ('scene_' + ipcRenderer.sendSync('getUniqueId'));
+    const id = options.sceneId || `scene_${uuid()}`;
     this.ADD_SCENE(id, name);
     const obsScene = obs.SceneFactory.create(id);
     this.sourcesService.addSource(obsScene.source, name);

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -20,6 +20,7 @@ import {
   Source,
   TPropertiesManager
 } from './index';
+import uuid from 'uuid/v4';
 
 
 
@@ -135,9 +136,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
     options: ISourceCreateOptions = {}
   ): Source {
 
-    const id: string =
-      options.sourceId ||
-      (type + '_' + ipcRenderer.sendSync('getUniqueId'));
+    const id: string = options.sourceId || `${type}_${uuid()}`;
 
     if (type === 'browser_source') {
       if (settings.shutdown === void 0) settings.shutdown = true;

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,10 +1,10 @@
 import Vue from 'vue';
 import URI from 'urijs';
 import { defer } from 'lodash';
-import { PersistentStatefulService } from './persistent-stateful-service';
-import { Inject } from '../util/injector';
+import { PersistentStatefulService } from 'services/persistent-stateful-service';
+import { Inject } from 'util/injector';
 import { handleErrors, authorizedHeaders } from 'util/requests';
-import { mutation } from './stateful-service';
+import { mutation } from 'services/stateful-service';
 import electron from 'electron';
 import { HostsService } from './hosts';
 import {
@@ -13,13 +13,14 @@ import {
   TPlatform,
   IPlatformService
 } from './platforms';
-import { CustomizationService } from './customization';
+import { CustomizationService } from 'services/customization';
 import Raven from 'raven-js';
 import { AppService } from 'services/app';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { Subject } from 'rxjs/Subject';
 import Util from 'services/utils';
 import { WindowsService } from 'services/windows';
+import uuid from 'uuid/v4';
 
 // Eventually we will support authing multiple platforms at once
 interface IUserServiceState {
@@ -105,7 +106,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     let userId = localStorage.getItem(localStorageKey);
 
     if (!userId) {
-      userId = electron.ipcRenderer.sendSync('getUniqueId');
+      userId = uuid();
       localStorage.setItem(localStorageKey, userId);
     }
 

--- a/main.js
+++ b/main.js
@@ -496,11 +496,6 @@ ipcMain.on('obs-apiCall', (event, data) => {
   event.returnValue = retVal;
 });
 
-// Used for guaranteeing unique ids for objects in the vuex store
-ipcMain.on('getUniqueId', event => {
-  event.returnValue = uuid();
-});
-
 ipcMain.on('restartApp', () => {
   app.relaunch();
   // Closing the main window starts the shut down sequence


### PR DESCRIPTION
`getUniqueId` used to just be an incrementing id in the main process.  So all windows in the app would ask the main process for unique ids.  A long time ago we switched to fully random v4 UUIDs, but kept asking the main process for these ids.

This change removes the main process from the id generation and instead generates all UUIDs in the process that requires them.  We were using this all over the place, including our child window IPC mechanism.  This should result in a huge amount less IPC.