### PR TITLE
Refactor SourcesShowcase

### DIFF
--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -523,6 +523,7 @@
         <ul class="source-list">
           <li
             v-for="source in availableSources"
+            :key="source.value"
             class="source source--standard"
             :class="{'source--active': inspectedSource === source.value}"
             @click="inspectSource(source.value)"
@@ -536,109 +537,16 @@
         <h4>{{ $t('Widgets') }}</h4>
         <div class="source-list">
           <div
+            v-for="type in iterableWidgetTypes"
+            :key="type"
+            v-show="!widgetPlatform(type) || widgetPlatform(type) === platform"
             class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.Alertbox}"
-            @click="inspectSource(widgetTypes.AlertBox)"
-            @dblclick="selectWidget(widgetTypes.AlertBox)">
-            <div>{{ $t('Alertbox') }}</div><span class="label--essential">{{ $t('Essential') }}</span>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.EventList}"
-            @click="inspectSource(widgetTypes.EventList)"
-            @dblclick="selectWidget(widgetTypes.EventList)">
-            <div>{{ $t('Event List') }}</div><span class="label--essential">{{ $t('Essential') }}</span>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.TheJar}"
-            @click="inspectSource(widgetTypes.TheJar)"
-            @dblclick="selectWidget(widgetTypes.TheJar)">
-            <div>{{ $t('The Jar') }}</div><span class="label--essential">{{ $t('Essential') }}</span>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.DonationGoal}"
-            @click="inspectSource(widgetTypes.DonationGoal)"
-            @dblclick="selectWidget(widgetTypes.DonationGoal)">
-            <div>{{ $t('Donation Goal') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.FollowerGoal}"
-            @click="inspectSource(widgetTypes.FollowerGoal)"
-            @dblclick="selectWidget(widgetTypes.FollowerGoal)">
-            <div>{{ $t('Follower Goal') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            v-show="platform === 'twitch'"
-            :class="{'source--active': inspectedSource === widgetTypes.BitGoal}"
-            @click="inspectSource(widgetTypes.BitGoal)"
-            @dblclick="selectWidget(widgetTypes.BitGoal)">
-            <div>{{ $t('Bit Goal') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            v-show="platform === 'youtube'"
-            :class="{'source--active': inspectedSource === widgetTypes.SubscriptionGoal}"
-            @click="inspectSource(widgetTypes.SubscriptionGoal)"
-            @dblclick="selectWidget(widgetTypes.SubscriptionGoal)">
-            <div>{{ $t('Subscription Goal') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.DonationTicker}"
-            @click="inspectSource(widgetTypes.DonationTicker)"
-            @dblclick="selectWidget(widgetTypes.DonationTicker)">
-            <div>{{ $t('Donation Ticker') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.ChatBox}"
-            @click="inspectSource(widgetTypes.ChatBox)"
-            @dblclick="selectWidget(widgetTypes.ChatBox)">
-            <div>{{ $t('Chatbox') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.StreamBoss}"
-            @click="inspectSource(widgetTypes.StreamBoss)"
-            @dblclick="selectWidget(widgetTypes.StreamBoss)">
-            <div>{{ $t('Stream Boss') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.Credits}"
-            @click="inspectSource(widgetTypes.Credits)"
-            @dblclick="selectWidget(widgetTypes.Credits)">
-            <div>{{ $t('Credits') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.ViewerCount}"
-            @click="inspectSource(widgetTypes.ViewerCount)"
-            @dblclick="selectWidget(widgetTypes.ViewerCount)">
-            <div>{{ $t('Viewer Count') }}</div>
-          </div>
-
-          <div
-            class="source source--widget"
-            :class="{'source--active': inspectedSource === widgetTypes.SpinWheel}"
-            @click="inspectSource(widgetTypes.SpinWheel)"
-            @dblclick="selectWidget(widgetTypes.SpinWheel)">
-            <div>{{ $t('Spin Wheel') }}</div>
+            :class="{'source--active': inspectedSource === widgetTypes[type]}"
+            @click="inspectSource(widgetTypes[type])"
+            @dblclick="selectWidget(widgetTypes[type])"
+          >
+            <div>{{ $t(widgetName(type)) }}</div>
+            <span v-if="essentialWidgetTypes.has(widgetTypes[type])" class="label--essential">{{ $t('Essential') }}</span>
           </div>
 
           <div

--- a/app/components/windows/SourcesShowcase.vue.ts
+++ b/app/components/windows/SourcesShowcase.vue.ts
@@ -33,10 +33,14 @@ export default class SourcesShowcase extends Vue {
   @Inject() windowsService: WindowsService;
 
   widgetTypes = WidgetType;
-
-  iterableWidgetTypes = Object.keys(this.widgetTypes).filter((type: string) => isNaN(Number(type)))
-
   essentialWidgetTypes = new Set([this.widgetTypes.AlertBox, this.widgetTypes.EventList, this.widgetTypes.TheJar]);
+
+  iterableWidgetTypes = Object.keys(this.widgetTypes)
+    .filter((type: string) => isNaN(Number(type)))
+    .sort((a: string, b: string) => {
+      return this.essentialWidgetTypes.has(this.widgetTypes[a]) ? -1 : 1;
+    });
+
 
   selectSource(sourceType: TSourceType, options: ISelectSourceOptions = {}) {
     const managerType = options.propertiesManager || 'default';

--- a/app/components/windows/SourcesShowcase.vue.ts
+++ b/app/components/windows/SourcesShowcase.vue.ts
@@ -34,6 +34,10 @@ export default class SourcesShowcase extends Vue {
 
   widgetTypes = WidgetType;
 
+  iterableWidgetTypes = Object.keys(this.widgetTypes).filter((type: string) => isNaN(Number(type)))
+
+  essentialWidgetTypes = new Set([this.widgetTypes.AlertBox, this.widgetTypes.EventList, this.widgetTypes.TheJar]);
+
   selectSource(sourceType: TSourceType, options: ISelectSourceOptions = {}) {
     const managerType = options.propertiesManager || 'default';
 
@@ -63,6 +67,14 @@ export default class SourcesShowcase extends Vue {
       propertiesManager: 'widget',
       widgetType: type
     });
+  }
+
+  widgetName(type: WidgetType) {
+    return this.widgetsService.getWidgetName(type);
+  }
+
+  widgetPlatform(type: WidgetType) {
+    return this.widgetsService.getWidgetPlatform(type);
   }
 
   inspectedSource: TInspectableSource = null;

--- a/app/services/widgets.ts
+++ b/app/services/widgets.ts
@@ -442,7 +442,6 @@ export class WidgetsService extends Service {
   }
 
   getWidgetPlatform(type: WidgetType): string {
-    console.log(type);
     return WidgetDefinitions[this.getWidgetComponent(type)].platform;
   }
 

--- a/app/services/widgets.ts
+++ b/app/services/widgets.ts
@@ -15,16 +15,17 @@ import { WidgetSettingsService } from './widget-settings/widget-settings';
 import { ServicesManager } from '../services-manager';
 import { authorizedHeaders } from 'util/requests';
 
+// Do not alter the order of this enum, it is coupled to the user's local config
 export enum WidgetType {
   AlertBox = 0,
-  EventList = 1,
-  TheJar = 2,
-  DonationGoal = 3,
+  DonationGoal = 1,
+  FollowerGoal = 2,
+  SubscriberGoal = 3,
   BitGoal = 4,
   DonationTicker = 5,
   ChatBox = 6,
-  FollowerGoal = 7,
-  SubscriberGoal = 8,
+  EventList = 7,
+  TheJar = 8,
   ViewerCount = 9,
   StreamBoss = 10,
   Credits = 11,

--- a/app/services/widgets.ts
+++ b/app/services/widgets.ts
@@ -17,14 +17,14 @@ import { authorizedHeaders } from 'util/requests';
 
 export enum WidgetType {
   AlertBox = 0,
-  DonationGoal = 1,
-  FollowerGoal = 2,
-  SubscriberGoal = 3,
+  EventList = 1,
+  TheJar = 2,
+  DonationGoal = 3,
   BitGoal = 4,
   DonationTicker = 5,
   ChatBox = 6,
-  EventList = 7,
-  TheJar = 8,
+  FollowerGoal = 7,
+  SubscriberGoal = 8,
   ViewerCount = 9,
   StreamBoss = 10,
   Credits = 11,
@@ -155,6 +155,8 @@ export interface IWidget {
 
   // An anchor (origin) point can be specified for the x&y positions
   anchor: AnchorPoint;
+
+  platform?: string;
 }
 
 export const WidgetDefinitions: { [x: number]: IWidget } = {
@@ -215,7 +217,9 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
     x: 0,
     y: 1,
 
-    anchor: AnchorPoint.SouthWest
+    anchor: AnchorPoint.SouthWest,
+
+    platform: 'youtube'
   },
 
   [WidgetType.BitGoal]: {
@@ -230,7 +234,9 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
     x: 0,
     y: 1,
 
-    anchor: AnchorPoint.SouthWest
+    anchor: AnchorPoint.SouthWest,
+
+    platform: 'twitch'
   },
 
   [WidgetType.DonationTicker]: {
@@ -428,6 +434,15 @@ export class WidgetsService extends Service {
 
   getWidgetComponent(type: WidgetType): string {
     return WidgetType[type];
+  }
+
+  getWidgetName(type: WidgetType): string {
+    return WidgetDefinitions[this.getWidgetComponent(type)].name;
+  }
+
+  getWidgetPlatform(type: WidgetType): string {
+    console.log(type);
+    return WidgetDefinitions[this.getWidgetComponent(type)].platform;
   }
 
   getWidgetSettingsService(type: WidgetType): WidgetSettingsService<any> {


### PR DESCRIPTION
Would love to hit the `add-source-info portion` of this as well but that would take a lot more work/architectural changes I think. This is at least a partial solution to getting rid of some of the tight coupling between our widget types being explicitly referenced, the end goal of which is to make it much easier to add or remove widgets by simply changing the enum/definition instead of having to touch many different files.