### PR TITLE
Update browser source

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.3/iojs-v2.0.5-node-fontinfo.tar.gz",
     "node-gyp": "^3.6.2",
     "node-libuiohook": "git+https://github.com/stream-labs/node-libuiohook.git",
-    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz",
+    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6902,9 +6902,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz":
+"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz":
   version "0.0.1"
-  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.47/iojs-v2.0.4-signed.tar.gz#02a38622755a1a896b1b64d401aa0d7839c5981e"
+  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.0.48/iojs-v2.0.4-signed.tar.gz#2e8d301423f96dfff41fc442f2da4dda4f86dcbd"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
This includes a new version of libcef (version 3396) which is compiled
with h.264 and aac support. We should finally be no part with OBS in
as far as the browser-source is concerned.