### PR TITLE
async performance monitor

### DIFF
--- a/main.js
+++ b/main.js
@@ -508,6 +508,12 @@ ipcMain.on('requestSourceAttributes', (e, names) => {
   e.sender.send('notifySourceAttributes', sizes);
 });
 
+ipcMain.on('requestPerformanceStatistics', (e) => {
+  const stats = getObs().OBS_API_getPerformanceStatistics();
+
+  e.sender.send('notifyPerformanceStatistics', stats);
+});
+
 ipcMain.on('streamlabels-writeFile', (e, info) => {
   fs.writeFile(info.path, info.data, err => {
     if (err) {


### PR DESCRIPTION
Gets performance stats async, which prevents blocking the main renderer every 2 seconds doing nothing.