### PR TITLE
Add EventList widget settings

### DIFF
--- a/app/components/shared/inputs/NumberInput.vue
+++ b/app/components/shared/inputs/NumberInput.vue
@@ -8,6 +8,9 @@
         :name="uuid"
         v-validate="validate"
     />
+    <div v-if="metadata && metadata.tooltip" class="w-tooltip">
+      <i class="icon-question icon-btn" v-tooltip="metadata.tooltip" />
+    </div>
     <span class="input-error" v-show="errors.first(uuid)">
       {{ errors.first(uuid) }}
     </span>
@@ -19,6 +22,11 @@
 <style lang="less" scoped>
   .number-input {
     position: relative;
+    display: flex;
+
+    input {
+      width: 220px;
+    }
     .input-error {
       position: absolute;
       white-space: nowrap;

--- a/app/components/widgets/EventList.vue
+++ b/app/components/widgets/EventList.vue
@@ -1,0 +1,59 @@
+<template>
+<widget-window v-if="wData" ref="layout" v-model="tabName">
+
+  <div slot="description">
+    {{ $t('Include your channel\'s most recent events into your stream.') }}
+  </div>
+
+  <div slot="settings" >
+    <form-group :title="$t('Theme')" type="list" v-model="wData.settings.theme" :metadata="{ options: themeMetadata }"/>
+    <form-group :title="$t('Theme Color')" type="color" v-model="wData.settings.theme_color" />
+    <form-group :title="$t('Enable Events')">
+      <bool-input :title="$t('Donations')" v-model="wData.settings.show_donations"/>
+      <bool-input :title="$t('Follows')" v-model="wData.settings.show_follows"/>
+      <bool-input :title="$t('Subscriptions')" v-model="wData.settings.show_subscriptions"/>
+      <bool-input :title="$t('Show Resubs')" v-model="wData.settings.show_resubs"/>
+      <bool-input :title="$t('Show Sub Tiers')" v-model="wData.settings.show_sub_tiers"/>
+      <bool-input :title="$t('Hosts')" v-model="wData.settings.show_hosts"/>
+      <bool-input :title="$t('Bits')" v-model="wData.settings.show_bits"/>
+      <bool-input :title="$t('Raids')" v-model="wData.settings.show_raids"/>
+      <bool-input :title="$t('Merch')" v-model="wData.settings.show_merch"/>
+    </form-group>
+    <form-group :title="$t('Min. Bits')" type="number" v-model="wData.settings.bits_minimum" :metadata="{ tooltip: minBitsTooltip }" />
+    <form-group :title="$t('Max Events')" type="slider" v-model="wData.settings.max_events" :metadata="{ max: 10, interval: 1 }" />
+    <form-group :title="$t('Background Color')" type="color" v-model="wData.settings.background_color" :metadata="{ tooltip: backgroundColorTooltip }" />
+    <form-group :title="$t('Text Color')" type="color" v-model="wData.settings.text_color" :metadata="{ tooltip: textColorTooltip }" />
+    <form-group :title="$t('Font')" type="fontFamily" v-model="wData.settings.font_family" />
+    <form-group :title="$t('Font Size')" type="fontSize" v-model="wData.settings.text_size" :metadata="{ tooltip: fontSizeTooltip }" />
+    <form-group :title="$t('Show Animation')">
+      <animation-input v-model="wData.settings.show_animation" />
+    </form-group>
+    <form-group :title="$t('Hide Animation')">
+      <animation-input v-model="wData.settings.hide_animation" />
+    </form-group>
+    <form-group :title="$t('Animation Speed')" type="slider" v-model="wData.settings.animation_speed" :metadata="{ min: 250, max: 4000, interval: 250 }" />
+    <form-group :title="$t('Fade Time')" type="slider" v-model="wData.settings.fade_time" :metadata="{ max: 60, interval: 1 }" />
+    <form-group :title="$t('Other Options')">
+      <bool-input :title="$t('Flip X')" v-model="wData.settings.flip_x" />
+      <bool-input :title="$t('Flip Y')" v-model="wData.settings.flip_y" />
+      <bool-input :title="$t('Keep Events History')" v-model="wData.settings.keep_history" />
+    </form-group>
+  </div>
+
+  <div slot="HTML" >
+    <code-editor v-model="wData" :metadata="{ type: 'html' }"/>
+  </div>
+
+  <div slot="CSS" >
+    <code-editor v-model="wData" :metadata="{ type: 'css' }"/>
+  </div>
+
+  <div slot="JS" >
+    <code-editor v-model="wData" :metadata="{ type: 'js' }"/>
+  </div>
+
+
+</widget-window>
+</template>
+
+<script lang="ts" src="./EventList.vue.ts"></script>

--- a/app/components/widgets/EventList.vue.ts
+++ b/app/components/widgets/EventList.vue.ts
@@ -1,0 +1,43 @@
+import { Component } from 'vue-property-decorator';
+import {
+  EventListService,
+  IEventListData
+} from 'services/widget-settings/event-list';
+
+import WidgetWindow from 'components/windows/WidgetWindow.vue';
+import WidgetSettings from './WidgetSettings.vue';
+import { inputComponents } from 'components/shared/inputs';
+import { AnimationInput } from './inputs';
+import FormGroup from 'components/shared/inputs/FormGroup.vue';
+import { $t } from 'services/i18n';
+import CodeEditor from './CodeEditor.vue';
+
+@Component({
+  components: {
+    WidgetWindow,
+    FormGroup,
+    CodeEditor,
+    AnimationInput,
+    ...inputComponents
+  }
+})
+export default class EventList extends WidgetSettings<IEventListData, EventListService> {
+  get themeMetadata() {
+    return Object.keys(this.wData.themes).map((theme) => ({
+      title: this.wData.themes[theme].label,
+      value: theme
+    }));
+  }
+
+  textColorTooltip = $t('A hex code for the base text color.');
+
+  backgroundColorTooltip = $t(
+    'A hex code for the widget background. This is for preview purposes only. It will not be shown in your stream.'
+  );
+
+  minBitsTooltip = $t(
+    'The smallest amount of bits a cheer must have for an event to be shown. Setting this to 0 will make every cheer trigger an event.'
+  );
+
+  fontSizeTooltip = $t('The font size in pixels. Reasonable size typically ranges between 24px and 48px.');
+}

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -83,6 +83,7 @@ import { FollowerGoalService } from 'services/widget-settings/follower-goal';
 import { ViewerCountService } from 'services/widget-settings/viewer-count';
 import { StreamBossService } from 'services/widget-settings/stream-boss';
 import { CreditsService } from 'services/widget-settings/credits';
+import { EventListService } from 'services/widget-settings/event-list';
 
 const { ipcRenderer } = electron;
 
@@ -166,6 +167,7 @@ export class ServicesManager extends Service {
     ViewerCountService,
     StreamBossService,
     CreditsService,
+    EventListService,
     MediaGalleryService
   };
 

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -387,6 +387,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
         WidgetType.ChatBox,
         WidgetType.ViewerCount,
         WidgetType.Credits,
+        WidgetType.EventList,
         WidgetType.StreamBoss
       ];
 

--- a/app/services/widget-settings/event-list.ts
+++ b/app/services/widget-settings/event-list.ts
@@ -1,0 +1,92 @@
+import { CODE_EDITOR_TABS, IWidgetData, IWidgetSettings, WidgetSettingsService } from './widget-settings';
+import { WidgetType } from 'services/widgets';
+import { metadata } from 'components/widgets/inputs';
+
+export interface IEventListSettings extends IWidgetSettings {
+  animation_speed: number;
+  background_color: string;
+  bits_minimum: number;
+  brightness: number;
+  fade_time: number;
+  flip_x: boolean;
+  flip_y: boolean;
+  font_family: string;
+  hide_animation: string;
+  host_show_auto_hosts: boolean;
+  host_viewer_minimum: number;
+  hue: number;
+  keep_history: boolean;
+  max_events: number;
+  raid_raider_minimum: number;
+  saturation: number;
+  show_animation: string;
+  show_bits: boolean;
+  show_donations: boolean;
+  show_eldonations: boolean;
+  show_follows: boolean;
+  show_gamewispresubscriptions: boolean;
+  show_gamewispsubscriptions: boolean;
+  show_hosts: boolean;
+  show_justgivingdonations: boolean;
+  show_merch: boolean;
+  show_pledges: boolean;
+  show_raids: boolean;
+  show_redemptions: boolean;
+  show_resubs: boolean;
+  show_smfredemptions: boolean;
+  show_sub_tiers: boolean;
+  show_subscriptions: boolean;
+  show_tiltifydonations: boolean;
+  show_treats: boolean;
+  text_color: string;
+  text_size: number;
+  theme: string;
+  theme_color: string;
+}
+
+export interface IEventListData extends IWidgetData {
+  themes: any;
+  settings: IEventListSettings;
+}
+
+export class EventListService extends WidgetSettingsService<IEventListData> {
+
+  getWidgetType() {
+    return WidgetType.EventList;
+  }
+
+  getVersion() {
+    return 5;
+  }
+
+  getPreviewUrl() {
+    return `https://${ this.getHost() }/widgets/event-list/v1/${this.getWidgetToken()}?simulate=1`;
+  }
+
+  getDataUrl() {
+    return `https://${ this.getHost() }/api/v${ this.getVersion() }/slobs/widget/eventlist`;
+  }
+
+  getMetadata() {
+    return {
+      theme: metadata.list({
+        options: [
+          { title: 'Clean', value: 'standard' },
+          { title: 'Boxed', value: 'boxed' },
+          { title: 'Twitch', value: 'twitch' },
+          { title: 'Old School', value: 'oldschool' },
+          { title: 'Chunky', value: 'chunky' }
+        ]
+      }),
+      message_hide_delay: metadata.slider({
+        min: 0,
+        max: 200
+      })
+    };
+  }
+
+  protected tabs = [
+    { name: 'settings' },
+    ...CODE_EDITOR_TABS
+  ];
+}

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -33,6 +33,7 @@ import FollowerGoal from 'components/widgets/goal/FollowerGoal.vue';
 import ViewerCount from 'components/widgets/ViewerCount.vue';
 import StreamBoss from 'components/widgets/StreamBoss.vue';
 import Credits from 'components/widgets/Credits.vue';
+import EventList from 'components/widgets/EventList.vue';
 
 
 const { ipcRenderer, remote } = electron;
@@ -105,6 +106,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
     ChatBox,
     ViewerCount,
     Credits,
+    EventList,
     StreamBoss
   };
 


### PR DESCRIPTION
One difference from the site is splitting hide and show animation settings into distinct inputs-- did it this way in order to get MVP functionality before the redesign and also avoid making another artisanal input