### PR TITLE
Fix CSS Imports

### DIFF
--- a/app/app.less
+++ b/app/app.less
@@ -1,6 +1,12 @@
 @import "./styles/index";
 @import "./styles/checkboxes";
 @import "./styles/tables";
+@import "./styles/buttons";
+@import "./styles/classes";
+@import "./styles/custom-icons";
+@import "./styles/inputs";
+@import "./styles/sl-vue-tree";
+@import "./styles/tooltips";
 
 body {
   font-family: 'Roboto', sans-serif;

--- a/app/components/Selector.vue
+++ b/app/components/Selector.vue
@@ -95,7 +95,7 @@
 
 .selector-drag-handle {
   cursor: move;
-  .icon-hover;
+  .icon-hover();
 }
 
 .night-theme {

--- a/app/components/pages/Live.vue
+++ b/app/components/pages/Live.vue
@@ -34,7 +34,7 @@
           </div>
 
           <div class="sizer-container">
-            <div class="aspect-ratio--16-9 live-display-wrapper" >
+            <div class="live-display-wrapper" >
               <div class="content" v-if="previewEnabled">
                 <display class="live-display" :drawUI="false" />
               </div>
@@ -82,7 +82,7 @@
   justify-content: flex-start;
   align-items: flex-start;
   position: relative;
-  .border;
+  .border();
   border-top: 0;
   height: calc(~'100% - 29px');
 }
@@ -147,7 +147,7 @@
   justify-content: flex-start;
   align-items: flex-start;
   position: relative;
-  .border;
+  .border();
   border-top: 0;
   height: calc(~'100% - 29px');
 }
@@ -164,6 +164,7 @@
 }
 
 .live-display-wrapper {
+  .aspect-ratio--16-9();
   width: 100%;
 }
 

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -50,7 +50,7 @@
 .main-spacer {
   height: 4px;
   flex: 0 0 4px;
-  .bg--teal;
+  .bg--teal();
 }
 
 .main-page-container {

--- a/app/components/windows/Notifications.vue
+++ b/app/components/windows/Notifications.vue
@@ -49,7 +49,7 @@
   display: grid;
   grid-template-columns: 30px 1fr 130px;
   background: @day-primary;
-  .border;
+  .border();
 
   &.has-action:hover {
     color: @navy;

--- a/app/components/windows/SceneTransitions.vue
+++ b/app/components/windows/SceneTransitions.vue
@@ -153,7 +153,7 @@
 .transition-control {
   margin-left: 10px;
   cursor: pointer;
-  .icon-hover;
+  .icon-hover();
 }
 
 .transition-redundant {

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -60,7 +60,7 @@
   .fa,
   i {
     color: @grey;
-    .transition;
+    .transition();
   }
 
   &:hover,
@@ -79,7 +79,7 @@
   font-size: 14px;
   cursor: pointer;
   margin-left: 10px;
-  .icon-hover;
+  .icon-hover();
 
   &:first-child {
     margin-left: inherit;
@@ -112,8 +112,8 @@
 }
 
 .square-button {
-  .radius;
-  .transition;
+  .radius();
+  .transition();
   display: flex;
   justify-content: center;
   align-items: center;

--- a/app/styles/index.less
+++ b/app/styles/index.less
@@ -1,8 +1,2 @@
 @import "./_colors";
-@import "./buttons";
-@import "./classes";
-@import "./custom-icons";
-@import "./inputs";
 @import "./mixins";
-@import "./sl-vue-tree";
-@import "./tooltips";

--- a/app/styles/mixins.less
+++ b/app/styles/mixins.less
@@ -8,6 +8,46 @@
   left: @left;
 }
 
+.flex() {
+  display: flex;
+}
+
+.flex--center() {
+  align-items: center;
+  justify-content: center;
+}
+
+.flex--wrap() {
+  flex-wrap: wrap;
+}
+
+.flex--space-between() {
+  justify-content: space-between;
+}
+
+.flex--justify-start() {
+  justify-content: flex-start;
+}
+
+.flex--align-start() {
+  align-items: flex-start;
+}
+
+.flex--column() {
+  flex-direction: column;
+}
+
+.flex--grow() {
+  flex-grow: 1;
+}
+
+.flex__column() {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  width: 100%;
+}
+
 // Aspect ratio for responsive height/width
 .aspect-ratio(@width, @height) {
   position: relative;
@@ -28,12 +68,12 @@
   }
 }
 
-.aspect-ratio--16-9 {
+.aspect-ratio--16-9() {
   .aspect-ratio(16,9);
 }
 
 // Backgrounds
-.bg--teal {
+.bg--teal() {
   background-color: @teal;
 }
 
@@ -43,16 +83,16 @@
 }
 
 // Borders
-.border {
+.border() {
   border: 1px solid @day-section;
 }
 
-.night-border {
+.night-border() {
   border: 1px solid @night-section;
 }
 
 // Hovers
-.icon-hover {
+.icon-hover() {
   color: @icon;
   .transition();
 
@@ -61,7 +101,7 @@
   }
 }
 
-.night-icon-hover {
+.night-icon-hover() {
   color: @icon;
   .transition;
 
@@ -70,7 +110,7 @@
   }
 }
 
-.icon--margin {
+.icon--margin() {
   margin-right: 8px;
 }
 
@@ -108,11 +148,11 @@
 }
 
 // Paddings
-.no-padding-left {
+.no-padding-left() {
   padding-left: 0;
 }
 
-.no-padding-right {
+.no-padding-right() {
   padding-right: 0;
 }
 


### PR DESCRIPTION
This makes sure when we import into scoped css files we're only importing things that compile to nothing in LESS. It also makes all mixins explicitly so and makes sure we explicitly reference mixins for clarity. This also results in a much smaller bundle size, dropping nearly 4MB from our app directory