### PR TITLE
Widgets: change the widget window title

### DIFF
--- a/app/components/windows/WidgetWindow.vue.ts
+++ b/app/components/windows/WidgetWindow.vue.ts
@@ -82,7 +82,7 @@ export default class WidgetWindow extends Vue {
   }
 
   get windowTitle() {
-    return this.source ? $t('Properties for %{sourceName}', { sourceName: this.source.name }) : '';
+    return this.source ? $t('Settings for %{sourceName}', { sourceName: this.source.name }) : '';
   }
 
   get tab(): IWidgetTab {


### PR DESCRIPTION
We use "Properties" word for source properties. Widget settings are something completely different. 