### PR TITLE
Remove z-index from tabs

### DIFF
--- a/app/components/Tabs.vue
+++ b/app/components/Tabs.vue
@@ -28,7 +28,6 @@
   background-color: @day-primary;
   box-sizing: border-box;
   position: absolute;
-  z-index: 100;
   width: 100%;
   padding: 0 15px;
   height: 54px;


### PR DESCRIPTION
With the new WidgetWindow settings this isnt necessary