### PR TITLE
Navigate to Editor tab on logout

### DIFF
--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -22,6 +22,7 @@ import Util from 'services/utils';
 import { WindowsService } from 'services/windows';
 import uuid from 'uuid/v4';
 import { OnboardingService } from './onboarding';
+import { NavigationService } from './navigation';
 
 // Eventually we will support authing multiple platforms at once
 interface IUserServiceState {
@@ -35,6 +36,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   @Inject() private sceneCollectionsService: SceneCollectionsService;
   @Inject() private windowsService: WindowsService;
   @Inject() private onboardingService: OnboardingService;
+  @Inject() private navigationService: NavigationService;
 
   @mutation()
   LOGIN(auth: IPlatformAuth) {
@@ -216,6 +218,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     this.appService.startLoading();
     await this.sceneCollectionsService.save();
     await this.sceneCollectionsService.safeSync();
+    // Navigate away from disabled tabs on logout
+    this.navigationService.navigate('Studio');
     this.LOGOUT();
     electron.remote.session.defaultSession.clearStorageData({ storages: ['cookies'] });
     this.appService.finishLoading();


### PR DESCRIPTION
Gets around a logout crash condition and makes the app more consistent-- users should only be able to be on the editor tab when logged out