### PR TITLE
Minimize our JS bundles for production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const CircularDependencyPlugin = require('circular-dependency-plugin');
 const path = require('path');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 const plugins = [];
 
@@ -116,7 +117,8 @@ module.exports = {
   },
 
   optimization: {
-    minimize: false
+    minimize: process.env.NODE_ENV === 'production',
+    minimizer: [new UglifyJsPlugin({ uglifyOptions: { mangle: false } })]
   },
 
   plugins

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,6 @@ module.exports = {
   },
 
   optimization: {
-    minimize: process.env.NODE_ENV === 'production',
     minimizer: [new UglifyJsPlugin({ uglifyOptions: { mangle: false } })]
   },
 


### PR DESCRIPTION
The mangling of filenames was preventing the slobs launch for some reason, by turning this off we sacrifice peak minimizing efficiency but still get a very good ROI

With mangle: 8.05 -> 3.4MB
Without mangle: 8.05 -> 5.13MB