### PR TITLE
Forbid to directly change inputs props

### DIFF
--- a/app/components/shared/inputs/BoolInput.vue.ts
+++ b/app/components/shared/inputs/BoolInput.vue.ts
@@ -3,9 +3,9 @@ import { BaseInput } from './BaseInput';
 
 @Component({})
 export default class BoolInput extends BaseInput<boolean, {}> {
-  @Prop() value: boolean;
 
-  @Prop() title: string;
+  @Prop() readonly value: boolean;
+  @Prop() readonly title: string;
 
   handleClick(e?: MouseEvent) {
     this.emitInput(!this.value, e);

--- a/app/components/shared/inputs/CodeInput.vue.ts
+++ b/app/components/shared/inputs/CodeInput.vue.ts
@@ -14,10 +14,10 @@ import { IInputMetadata } from './index';
 export default class CodeInput extends BaseInput<string, IInputMetadata> {
 
   @Prop({ default: '' })
-  value: string;
+  readonly value: string;
 
   @Prop({ default: () => ({ type: 'html' }) })
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   // codemirror options
   editorOptions = {

--- a/app/components/shared/inputs/ColorInput.vue.ts
+++ b/app/components/shared/inputs/ColorInput.vue.ts
@@ -10,8 +10,8 @@ import { IInputMetadata } from './index';
 export default class ColorInput extends BaseInput<string, IInputMetadata> {
 
 
-  @Prop() value: string;
-  @Prop() metadata: IInputMetadata;
+  @Prop() readonly value: string;
+  @Prop() readonly metadata: IInputMetadata;
 
   pickerVisible = false;
 

--- a/app/components/shared/inputs/FontFamilyInput.vue.ts
+++ b/app/components/shared/inputs/FontFamilyInput.vue.ts
@@ -737,7 +737,7 @@ const fonts = [
   components: { ListInput }
 })
 export default class FontFamilyInput extends BaseInput<string, IInputMetadata> {
-  @Prop() value: string;
+  @Prop() readonly value: string;
 
   fonts = fonts;
 

--- a/app/components/shared/inputs/FontSize.vue.ts
+++ b/app/components/shared/inputs/FontSize.vue.ts
@@ -13,10 +13,10 @@ import { metadata } from 'components/shared/inputs'
 })
 export default class FontSize extends BaseInput<string, IInputMetadata>{
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop()
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   sliderOptions = metadata.slider({min: 8, max: 144});
 

--- a/app/components/shared/inputs/FormGroup.vue.ts
+++ b/app/components/shared/inputs/FormGroup.vue.ts
@@ -11,16 +11,16 @@ import FormInput from './FormInput.vue';
 export default class FormGroup extends BaseInput<any, IInputMetadata> {
 
   @Prop()
-  type: EInputType;
+  readonly type: EInputType;
 
   @Prop()
-  value: undefined;
+  readonly value: undefined;
 
   @Prop()
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   @Prop()
-  title: string;
+  readonly title: string;
 
   get formInputMetadata() {
     const options = this.options;

--- a/app/components/shared/inputs/FormInput.vue.ts
+++ b/app/components/shared/inputs/FormInput.vue.ts
@@ -17,16 +17,16 @@ import { BaseInput } from './BaseInput';
 export default class FormInput extends BaseInput<any, IInputMetadata> {
 
   @Prop()
-  type: EInputType;
+  readonly type: EInputType;
 
   @Prop()
-  value: undefined;
+  readonly value: undefined;
 
   @Prop()
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   @Prop()
-  title: string;
+  readonly title: string;
 
   /**
    * returns a componentName based on the type

--- a/app/components/shared/inputs/FormWrapper.vue.ts
+++ b/app/components/shared/inputs/FormWrapper.vue.ts
@@ -11,16 +11,16 @@ import FormInput from './FormInput.vue';
 export default class FormWrapper extends BaseInput<any, IInputMetadata> {
 
   @Prop()
-  type: EInputType;
+  readonly type: EInputType;
 
   @Prop()
-  value: undefined;
+  readonly value: undefined;
 
   @Prop()
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   @Prop()
-  title: string;
+  readonly title: string;
 
   get formInputMetadata() {
     const options = this.options;

--- a/app/components/shared/inputs/ImageMediaInput.vue.ts
+++ b/app/components/shared/inputs/ImageMediaInput.vue.ts
@@ -9,10 +9,10 @@ import { MediaGalleryInput } from './inputs';
 export default class ImageMediaInput extends BaseInput<string, IMediaGalleryMetadata> {
 
   @Prop({ default: '' })
-  value: string;
+  readonly value: string;
 
   @Prop({ default: {} })
-  metadata: IMediaGalleryMetadata;
+  readonly metadata: IMediaGalleryMetadata;
 
   get imageMetadata() {
     return { ...this.metadata, imageOnly: true };

--- a/app/components/shared/inputs/ImagePickerInput.vue.ts
+++ b/app/components/shared/inputs/ImagePickerInput.vue.ts
@@ -6,8 +6,8 @@ import { IListOption } from './index';
 export default class ImagePickerInput extends BaseInput<string, IListOption<string>> {
 
   @Prop({ default: '' })
-  value: string;
+  readonly value: string;
 
   @Prop({ default: {} })
-  metadata: IListOption<string>;
+  readonly metadata: IListOption<string>;
 }

--- a/app/components/shared/inputs/ListInput.vue.ts
+++ b/app/components/shared/inputs/ListInput.vue.ts
@@ -15,16 +15,16 @@ interface IMultiselectListOption{
 export default class ListInput extends BaseInput<string, IListMetadata<string>> {
 
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop()
-  metadata: IListMetadata<string>;
+  readonly metadata: IListMetadata<string>;
 
   @Prop()
-  title: string;
+  readonly title: string;
 
   @Prop({ default: 'Select Option' })
-  placeholder: string;
+  readonly placeholder: string;
 
 
   onInputHandler(option: IMultiselectListOption) {

--- a/app/components/shared/inputs/MediaGalleryInput.vue.ts
+++ b/app/components/shared/inputs/MediaGalleryInput.vue.ts
@@ -13,8 +13,8 @@ import FormGroup from './FormGroup.vue';
 })
 export default class MediaGalleryInput extends BaseInput<string, IMediaGalleryMetadata>{
   @Inject() mediaGalleryService: MediaGalleryService;
-  @Prop() value: string;
-  @Prop() metadata: IMediaGalleryMetadata;
+  @Prop() readonly value: string;
+  @Prop() readonly metadata: IMediaGalleryMetadata;
 
   url: string = '';
   showUrlUpload = false;

--- a/app/components/shared/inputs/NumberInput.vue.ts
+++ b/app/components/shared/inputs/NumberInput.vue.ts
@@ -6,10 +6,10 @@ import { INumberMetadata } from './index';
 export default class NumberInput extends BaseInput<number | string, INumberMetadata> {
 
   @Prop()
-  value: number | string; // the string type is for empty field
+  readonly value: number | string; // the string type is for empty field
 
   @Prop()
-  metadata: INumberMetadata;
+  readonly metadata: INumberMetadata;
 
   emitInput(eventData: string) {
     if (!isNaN(parseFloat(eventData))) {

--- a/app/components/shared/inputs/SliderInput.vue.ts
+++ b/app/components/shared/inputs/SliderInput.vue.ts
@@ -12,8 +12,8 @@ import { ISliderMetadata } from './index';
 export default class SliderInput extends BaseInput<number, ISliderMetadata>  {
   @Inject() customizationService: CustomizationService;
 
-  @Prop() value: number;
-  @Prop() metadata: ISliderMetadata;
+  @Prop() readonly value: number;
+  @Prop() readonly metadata: ISliderMetadata;
 
   usePercentages: boolean;
   interval: number;

--- a/app/components/shared/inputs/SoundInput.vue.ts
+++ b/app/components/shared/inputs/SoundInput.vue.ts
@@ -14,8 +14,8 @@ import { $t } from 'services/i18n';
 })
 export default class SoundInput extends BaseInput<string, IMediaGalleryMetadata>{
   @Inject() mediaGalleryService: MediaGalleryService;
-  @Prop() value: string;
-  @Prop() metadata: IMediaGalleryMetadata;
+  @Prop() readonly value: string;
+  @Prop() readonly metadata: IMediaGalleryMetadata;
 
   url: string = '';
   showUrlUpload = false;

--- a/app/components/shared/inputs/TextAreaInput.vue.ts
+++ b/app/components/shared/inputs/TextAreaInput.vue.ts
@@ -11,10 +11,10 @@ interface IWTextMetadata extends IInputMetadata {
 export default class TextAreaInput extends BaseInput<string, IWTextMetadata> {
 
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop({ default: () => ({}) })
-  metadata: IWTextMetadata;
+  readonly metadata: IWTextMetadata;
 
 
 }

--- a/app/components/shared/inputs/TextInput.vue.ts
+++ b/app/components/shared/inputs/TextInput.vue.ts
@@ -6,10 +6,10 @@ import { ITextMetadata } from './index';
 export default class TextInput extends BaseInput<string, ITextMetadata> {
 
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop({ default: {} })
-  metadata: ITextMetadata;
+  readonly metadata: ITextMetadata;
 
   getValidations() {
     return {

--- a/app/components/widgets/inputs/AnimationInput.vue.ts
+++ b/app/components/widgets/inputs/AnimationInput.vue.ts
@@ -45,13 +45,13 @@ const OUT_ANIMATIONS = [
 export default class AnimationInput extends BaseInput<string, IAnimationMetadata> {
 
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop()
-  metadata: IInputMetadata;
+  readonly metadata: IInputMetadata;
 
   @Prop()
-  title: string;
+  readonly title: string;
 
 
   get listInputMetadata() {

--- a/app/components/widgets/inputs/ImageLayoutInput.vue.ts
+++ b/app/components/widgets/inputs/ImageLayoutInput.vue.ts
@@ -9,10 +9,10 @@ import ImagePickerInput from '../../shared/inputs/ImagePickerInput.vue';
 export default class ImageLayoutInput extends BaseInput<string, IListMetadata<string>> {
 
   @Prop()
-  value: string;
+  readonly value: string;
 
   @Prop()
-  metadata: IListMetadata<string>;
+  readonly metadata: IListMetadata<string>;
 
   layoutOptions = [
     { description: './media/images/layout-image-side.png', value: 'side' },


### PR DESCRIPTION
We had the only runtime checking for Vue `readonly` props before. Now typescript is checking that 