### PR TITLE
Ensure ModalLayout has a background color

### DIFF
--- a/app/components/ModalLayout.vue
+++ b/app/components/ModalLayout.vue
@@ -41,6 +41,7 @@
   display: flex;
   flex-direction: column;
   color: @day-paragraph;
+  background-color: @white;
 }
 
 .modal-layout-titlebar {


### PR DESCRIPTION
Keeping a transparent background in day mode meant that the spinner was always visible even after the component had loaded