### PR TITLE
cleanup loud sentry events, fix settings

### DIFF
--- a/app/components/windows/Settings.vue.ts
+++ b/app/components/windows/Settings.vue.ts
@@ -34,13 +34,14 @@ import LanguageSettings from 'components/LanguageSettings.vue';
     LanguageSettings
   }
 })
-export default class SceneTransitions extends Vue {
+export default class Settings extends Vue {
   @Inject() settingsService: ISettingsServiceApi;
   @Inject() windowsService: WindowsService;
 
   $refs: { settingsContainer: HTMLElement }
 
-  settingsData = this.settingsService.getSettingsFormData(this.categoryName);
+  categoryName: string = 'General';
+  settingsData: ISettingsSubCategory[] = [];
   icons: Dictionary<string> = {
     General: 'icon-overview',
     Stream: 'fas fa-globe',
@@ -57,12 +58,16 @@ export default class SceneTransitions extends Vue {
     Experimental: 'fas fa-flask'
   };
 
-  get categoryName() {
-    return this.windowsService.state.child.queryParams.categoryName || 'General';
+  mounted() {
+    this.categoryName = this.getInitialCategoryName();
+    this.settingsData = this.settingsService.getSettingsFormData(this.categoryName);
   }
 
-  set categoryName(name) {
-    this.settingsService.showSettings(name);
+  getInitialCategoryName() {
+    if (this.windowsService.state.child.queryParams) {
+      return this.windowsService.state.child.queryParams.categoryName || 'General';
+    }
+    return 'General';
   }
 
   get categoryNames() {

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -118,7 +118,7 @@ export class TwitchService extends Service implements IPlatformService {
     return fetch(request)
       .then(handleErrors)
       .then(response => response.json())
-      .then(json => json.stream.viewers);
+      .then(json => json.stream ? json.stream.viewers : 0);
   }
 
   @requiresToken()


### PR DESCRIPTION
This should save us a few million sentry events, and also fix the weird flashing when switching categories in settings.