### PR TITLE
Add @ExecuteInCurrentWindow decorator

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -536,6 +536,10 @@ export class ServicesManager extends Service {
           return this.applyIpcProxy(target[property]);
         }
 
+        if (Reflect.getMetadata('executeInCurrentWindow', target, property as string)) {
+          return target[property];
+        }
+
         if (typeof target[property] !== 'function' && !(target[property] instanceof Observable)) {
           return target[property];
         }

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -56,6 +56,7 @@ import ChatbotQuotePreferencesWindow
 
 import TipJar from 'components/widgets/TipJar.vue';
 import SponsorBanner from 'components/widgets/SponsorBanner.vue';
+import ExecuteInCurrentWindow from '../util/execute-in-current-window';
 
 const { ipcRenderer, remote } = electron;
 const BrowserWindow = remote.BrowserWindow;
@@ -284,14 +285,17 @@ export class WindowsService extends StatefulService<IWindowsState> {
   }
 
 
+  @ExecuteInCurrentWindow()
   getChildWindowOptions(): IWindowOptions {
     return this.state.child;
   }
 
+  @ExecuteInCurrentWindow()
   getChildWindowQueryParams(): Dictionary<string> {
     return this.getChildWindowOptions().queryParams || {};
   }
 
+  @ExecuteInCurrentWindow()
   getWindowOptions(windowId: string) {
     return this.state[windowId].queryParams || {};
   }

--- a/app/util/execute-in-current-window.ts
+++ b/app/util/execute-in-current-window.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+
+/**
+ * use this decorator to execute service method in the current window
+ */
+export default function ExecuteInCurrentWindow() {
+  return function (target: any, methodName: string, descriptor: PropertyDescriptor) {
+    Reflect.defineMetadata('executeInCurrentWindow', true, target, methodName);
+  };
+}


### PR DESCRIPTION
This decorator allows avoiding IPC request when methods retrieve information from service `state`