### PR TITLE
Add notification when entering a reconnecting state

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -17,7 +17,7 @@ import { UsageStatisticsService } from 'services/usage-statistics';
 import { $t } from 'services/i18n';
 import { StreamInfoService } from 'services/stream-info';
 import { AnnouncementsService } from 'services/announcements';
-import { NotificationsService, ENotificationType } from 'services/notifications';
+import { NotificationsService, ENotificationType, INotification } from 'services/notifications';
 
 enum EOBSOutputType {
   Streaming = 'streaming',
@@ -234,6 +234,10 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   }
 
   private sendReconnectingNotification() {
+    const msg = $t('Stream has disconnected, attempting to reconnect.');
+    const existingReconnectNotif = this.notificationsService.getUnread()
+      .filter((notice: INotification) => notice.message === msg);
+    if (existingReconnectNotif.length !== 0) return;
     this.notificationsService.push({
       type: ENotificationType.WARNING,
       lifeTime: -1,

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -246,6 +246,13 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     });
   }
 
+  private clearReconnectingNotification() {
+    const notice = this.notificationsService.getAll()
+      .find((notice: INotification) => notice.message === $t('Stream has disconnected, attempting to reconnect.'));
+    if (!notice) return;
+    this.notificationsService.markAsRead(notice.id);
+  }
+
   private formattedDurationSince(timestamp: moment.Moment) {
     const duration = moment.duration(moment().diff(timestamp));
     const seconds = padStart(duration.seconds().toString(), 2, '0');
@@ -298,6 +305,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       } else if (info.signal === EOBSOutputSignal.ReconnectSuccess) {
         this.SET_STREAMING_STATUS(EStreamingState.Live);
         this.streamingStatusChange.next(EStreamingState.Live);
+        this.clearReconnectingNotification();
       }
     } else if (info.type === EOBSOutputType.Recording) {
       const time = new Date().toISOString();


### PR DESCRIPTION
Currently kind of bootstrapped a "singleton" functionality to this (if i didn't it would send notifs every second or so until reconnected) but we might want to consider expanding that formally into the notification service if we find another use-case for it.