### PR TITLE
Chatbot widget

### DIFF
--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -27,7 +27,8 @@ const widgetIconMap = {
   [WidgetType.DonationGoal]: 'fas fa-calendar',
   [WidgetType.BitGoal]: 'fas fa-calendar',
   [WidgetType.FollowerGoal]: 'fas fa-calendar',
-  [WidgetType.MediaShare]: 'icon-share'
+  [WidgetType.MediaShare]: 'icon-share',
+  [WidgetType.Chatbot]: 'fas fa-comments'
 };
 
 const sourceIconMap = {

--- a/app/components/custom-source-properties/WidgetProperties.vue
+++ b/app/components/custom-source-properties/WidgetProperties.vue
@@ -5,7 +5,7 @@
       {{ $t('Configure') }}
     </div>
     <div class="input-wrapper">
-      <button v-if="isLoggedIn"  class="button button--default" @click="navigateDashboard">
+      <button v-if="isLoggedIn"  class="button button--default" @click="navigateWidgetSettings">
         {{ $t('Go To Widget Settings') }}
       </button>
       <button v-else class="button button--default" @click="login">

--- a/app/components/custom-source-properties/WidgetProperties.vue.ts
+++ b/app/components/custom-source-properties/WidgetProperties.vue.ts
@@ -5,6 +5,7 @@ import { ISourceApi } from 'services/sources';
 import { IObsListInput } from 'components/obs/inputs/ObsInput';
 import { WidgetDefinitions, IWidget, WidgetType } from 'services/widgets';
 import { NavigationService } from 'services/navigation';
+import { ChatbotCommonService } from 'services/chatbot';
 import { WindowsService } from 'services/windows';
 import { Inject } from 'util/injector';
 import { $t } from 'services/i18n';
@@ -21,6 +22,7 @@ export default class WidgetProperties extends Vue {
   @Inject() navigationService: NavigationService;
   @Inject() windowsService: WindowsService;
   @Inject() userService: UserService;
+  @Inject() chatbotCommonService: ChatbotCommonService;
 
   widgetModel: IObsListInput<string> = null;
 
@@ -33,11 +35,18 @@ export default class WidgetProperties extends Vue {
     this.userService.showLogin();
   }
 
-  navigateDashboard() {
+  navigateWidgetSettings() {
 
     const widgetType = this.source
       .getPropertiesManagerSettings()
-      .widgetType.toString();
+      .widgetType;
+
+    if (widgetType === WidgetType.Chatbot) {
+      // chatbot widget doesnt exist on sl.com, but its own chatbot tab
+      this.navigationService.navigate('Chatbot');
+      this.chatbotCommonService.openSongRequestPreferencesWindow();
+      return;
+    }
 
     const subPage = {
       [WidgetType.AlertBox]: 'alertbox',
@@ -53,7 +62,7 @@ export default class WidgetProperties extends Vue {
       [WidgetType.StreamBoss]: 'streamboss',
       [WidgetType.Credits]: 'credits',
       [WidgetType.SpinWheel]: 'wheel'
-    }[widgetType];
+    }[widgetType.toString()];
 
     this.navigationService.navigate('Dashboard', { subPage });
     this.windowsService.closeChildWindow();

--- a/app/components/page-components/Chatbot/ChatbotModules.vue.ts
+++ b/app/components/page-components/Chatbot/ChatbotModules.vue.ts
@@ -46,7 +46,7 @@ export default class ChatbotModules extends ChatbotBase {
         backgroundUrl: require(`../../../../media/images/chatbot/chatbot-alert--${backgroundUrlSuffix}.png`),
         enabled: this.songRequestCurrentlyEnabled,
         onExpand: () => {
-          this.chatbotCommonService.openSongRequestWindow();
+          this.chatbotCommonService.openSongRequestPreferencesWindow();
         },
         onToggleEnabled: () => {
           this.chatbotApiService.updateSongRequest({

--- a/app/components/page-components/Chatbot/ChatbotModules.vue.ts
+++ b/app/components/page-components/Chatbot/ChatbotModules.vue.ts
@@ -42,7 +42,7 @@ export default class ChatbotModules extends ChatbotBase {
       },
       {
         title: $t('Song Request'),
-        description: $t('Request songs!!'),
+        description: $t('Allow your viewers to to request songs from Youtube and play the songs on stream.'),
         backgroundUrl: require(`../../../../media/images/chatbot/chatbot-alert--${backgroundUrlSuffix}.png`),
         enabled: this.songRequestCurrentlyEnabled,
         onExpand: () => {

--- a/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue
+++ b/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue
@@ -32,6 +32,13 @@
             <span> {{ $t('Queue Settings') }} </span>
             <i class="fas fa-chevron-right window-toggle__icon"></i>
           </div>
+          <div
+            @click="onToggleSongRequestWindowHandler"
+            v-if="isSongRequestCommand"
+          >
+            <span> {{ $t('Song Request Preferences') }} </span>
+            <i class="fas fa-chevron-right window-toggle__icon"></i>
+          </div>
         </div>
       </div>
     </div>

--- a/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
@@ -72,6 +72,13 @@ export default class ChatbotDefaultCommandWindow extends ChatbotWindowsBase {
     )
   }
 
+  get isSongRequestCommand() {
+    return (
+      this.defaultCommandToUpdate.slugName === 'songrequest' &&
+      this.defaultCommandToUpdate.commandName === 'songrequest'
+    )
+  }
+
   get defaultCommandToUpdate() {
     return this.chatbotCommonService.state.defaultCommandToUpdate;
   }

--- a/app/components/page-components/Chatbot/windows/ChatbotSongRequestPreferencesWindow.vue
+++ b/app/components/page-components/Chatbot/windows/ChatbotSongRequestPreferencesWindow.vue
@@ -12,8 +12,7 @@
       </div>
       <div class="small-6 columns position--relative">
         <div class="window-toggle__wrapper">
-          <!-- <div @click="onToggleLinkProtectionWindowHandler"> -->
-          <div>
+          <div @click="onToggleSongRequestWindowHandler">
             <span> {{ $t('Edit Primary Command') }} </span>
             <i class="fas fa-chevron-right window-toggle__icon"></i>
           </div>

--- a/app/components/page-components/Chatbot/windows/ChatbotSongRequestPreferencesWindow.vue
+++ b/app/components/page-components/Chatbot/windows/ChatbotSongRequestPreferencesWindow.vue
@@ -21,22 +21,22 @@
     </div>
   </div>
   <div slot="content" class="chatbot-song-request__container">
-    <div v-if="songRequestPreferencesData">
+    <div v-if="songRequestData">
       <transition name='fade' mode="out-in" appear>
-        <div v-if="selectedTab === 'general' && !!songRequestPreferencesData.settings">
+        <div v-if="selectedTab === 'general' && !!songRequestData.general">
           <VFormGroup
             :title="$t('Max Duration (Value in Seconds)')"
-            v-model="songRequestPreferencesData.settings.max_duration"
-            :metadata="metadata.settings.max_duration"
+            v-model="songRequestData.general.max_duration"
+            :metadata="metadata.general.max_duration"
           />
           <VFormGroup
             :title="$t('Spam Security')"
-            v-model="songRequestPreferencesData.settings.security"
-            :metadata="metadata.settings.security"
+            v-model="songRequestData.general.filter_level"
+            :metadata="metadata.general.filter_level"
           />
         </div>
         <div v-else>
-          <table v-if="songRequestPreferencesData.banned_media && songRequestPreferencesData.banned_media.length > 0">
+          <table v-if="songRequestBannedMedia.length > 0">
             <thead>
               <tr>
                 <th> {{ $t('Video') }} </th>
@@ -46,7 +46,7 @@
             </thead>
             <tbody>
               <tr
-                v-for="media in songRequestPreferencesData.banned_media"
+                v-for="media in songRequestBannedMedia"
                 :key="media.id"
               >
                 <td> {{ media.media_title }} </td>

--- a/app/components/page-components/Chatbot/windows/ChatbotWindowsBase.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotWindowsBase.vue.ts
@@ -14,7 +14,6 @@ Vue.use(VModal);
   }
 })
 export default class ChatbotWindowsBase extends ChatbotBase {
-
   onCancelHandler(): void {
     this.chatbotCommonService.closeChildWindow();
   }
@@ -80,6 +79,27 @@ export default class ChatbotWindowsBase extends ChatbotBase {
           ...queuePreferencesCommand,
           slugName: 'queue',
           commandName: 'join'
+        });
+        break;
+    }
+  }
+
+  onToggleSongRequestWindowHandler() {
+    const currentWindow = this.chatbotCommonService.windowsService.getChildWindowOptions()
+      .componentName;
+
+    switch (currentWindow) {
+      case 'ChatbotDefaultCommandWindow':
+        this.chatbotCommonService.openSongRequestPreferencesWindow();
+        break;
+      case 'ChatbotSongRequestPreferencesWindow':
+        const queuePreferencesCommand = this.chatbotApiService.state
+          .defaultCommandsResponse['songrequest'].songrequest;
+
+        this.chatbotCommonService.openDefaultCommandWindow({
+          ...queuePreferencesCommand,
+          slugName: 'songrequest',
+          commandName: 'songrequest'
         });
         break;
     }

--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -9,6 +9,7 @@ import Selector from 'components/Selector.vue';
 import Display from 'components/shared/Display.vue';
 import { WidgetsService, WidgetType, WidgetDefinitions } from 'services/widgets';
 import { $t } from 'services/i18n';
+import { log } from 'lodash-decorators/utils';
 
 @Component({
   components: { ModalLayout, Selector, Display }

--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -91,6 +91,7 @@ import { EventListService } from 'services/widget-settings/event-list';
 import { TipJarService } from 'services/widget-settings/tip-jar';
 import { SponsorBannerService } from 'services/widget-settings/sponsor-banner';
 import { MediaShareService } from 'services/widget-settings/media-share';
+import { ChatbotService } from 'services/widget-settings/chatbot';
 
 const { ipcRenderer } = electron;
 
@@ -184,6 +185,7 @@ export class ServicesManager extends Service {
     MediaGalleryService,
     AnnouncementsService,
     MediaShareService,
+    ChatbotService,
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/chatbot/chatbot-interfaces.ts
+++ b/app/services/chatbot/chatbot-interfaces.ts
@@ -140,9 +140,9 @@ export interface IQueuePickedResponse {
   data: IQueuedUser[];
 }
 
+// this is from media share
 export interface ISongRequestPreferencesResponse {
   banned_media: IMediaShareBan[];
-  settings: ISongRequestPreferencesData;
 }
 
 export interface ISongRequestResponse {
@@ -410,15 +410,19 @@ export interface IQueuedUser {
 }
 
 // song requests
-export interface ISongRequestPreferencesData {
-  max_duration: number;
-  security: number;
-}
-
 export interface ISongRequestData {
   commands: IDafaultCommandsSlug;
+  general: ISongRequestGeneral;
 }
 
+export interface ISongRequestGeneral {
+  limit: number;
+  max_duration: number;
+  max_requests_per_user: number;
+  skip_votes: number;
+  filter_level: number;
+  music_only: boolean;
+}
 
 // dictionaries
 export enum ChatbotAutopermitEnums {

--- a/app/services/chatbot/chatbot-interfaces.ts
+++ b/app/services/chatbot/chatbot-interfaces.ts
@@ -68,9 +68,7 @@ export interface IChatbotAPIDeleteResponse {
 
 
 export interface IDafaultCommandsResponse {
-  commands: IDafaultCommandsSlug;
-  'link-protection': IDafaultCommandsSlug;
-  giveaway: IDafaultCommandsSlug;
+  [id: string]: IDafaultCommandsSlug;
 }
 
 export interface ICustomCommandsResponse {

--- a/app/services/chatbot/chatbot.ts
+++ b/app/services/chatbot/chatbot.ts
@@ -131,7 +131,6 @@ export class ChatbotApiService extends PersistentStatefulService<IChatbotApiServ
     },
     songRequestPreferencesResponse: {
       banned_media: [],
-      settings: null
     },
     songRequestResponse: {
       enabled: false,

--- a/app/services/chatbot/chatbot.ts
+++ b/app/services/chatbot/chatbot.ts
@@ -134,7 +134,8 @@ export class ChatbotApiService extends PersistentStatefulService<IChatbotApiServ
       settings: null
     },
     songRequestResponse: {
-      enabled: false
+      enabled: false,
+      settings: null
     }
   };
 
@@ -960,7 +961,7 @@ export class ChatbotCommonService extends PersistentStatefulService<IChatbotComm
     });
   }
 
-  openSongRequestWindow() {
+  openSongRequestPreferencesWindow() {
     this.windowsService.showWindow({
       componentName: 'ChatbotSongRequestPreferencesWindow',
       size: {

--- a/app/services/widget-settings/chatbot.ts
+++ b/app/services/widget-settings/chatbot.ts
@@ -1,0 +1,34 @@
+import { IWidgetData, IWidgetSettings, WidgetSettingsService } from './widget-settings';
+import { WidgetType } from 'services/widgets';
+import { clone } from 'lodash';
+import { $t } from 'services/i18n';
+
+export interface IMediaShareData extends IWidgetData {
+}
+
+export class ChatbotService extends WidgetSettingsService<IMediaShareData> {
+
+  getWidgetType() {
+    return WidgetType.MediaShare;
+  }
+
+  getVersion() {
+    return 5;
+  }
+
+  getPreviewUrl() {
+    alert('got preview url');
+    return `https://${ this.getHost() }/widgets/chatbot/v1/${this.getWidgetToken()}?simulate=1`;
+  }
+
+  getDataUrl() {
+    alert('getting data. shouldnt come here');
+    return `https://${this.getHost()}/api/v${this.getVersion()}/slobs/widget/media`;
+  }
+
+  protected tabs: any[] = [
+    // { name: 'settings', title: $t('Settings') },
+    // { name: 'banned_media', title: $t('Banned Media') },
+  ];
+
+}

--- a/app/services/widget-settings/widget-settings.ts
+++ b/app/services/widget-settings/widget-settings.ts
@@ -185,7 +185,8 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData> ext
   }
 
   protected getHost(): string {
-    return this.hostsService.streamlabs;
+    // return this.hostsService.streamlabs;
+    return this.hostsService.beta3;
   }
 
   protected getWidgetToken(): string {

--- a/app/services/widgets/widgets-data.ts
+++ b/app/services/widgets/widgets-data.ts
@@ -26,7 +26,8 @@ export enum WidgetType {
   Credits = 11,
   SpinWheel = 12,
   SponsorBanner = 13,
-  MediaShare = 14
+  MediaShare = 14,
+  Chatbot = 15
 }
 
 
@@ -327,6 +328,20 @@ export const WidgetDefinitions: { [x: number]: IWidget } = {
     y: 0,
 
     anchor: AnchorPoint.North
+  },
+  [WidgetType.Chatbot]: {
+    name: 'Chatbot',
+    url(host, token) {
+      return `https://${host}/widgets/chatbot/v1/${token}`;
+    },
+
+    width: 800,
+    height: 600,
+
+    x: 0.5,
+    y: 0,
+
+    anchor: AnchorPoint.North
   }
 };
 
@@ -475,5 +490,12 @@ export const WidgetDisplayData = (): { [x: number]: IWidgetDisplayData } => ({
     demoVideo: false,
     demoFilename: 'source-sponsor-banner.png',
     supportList: []
-  }
+  },
+  [WidgetType.Chatbot]: {
+    name: $t('Chatbot'),
+    description: $t('Set up chatbot widget to enable chatbot song requests and other features.'),
+    demoVideo: false,
+    demoFilename: 'source-sponsor-banner.png',
+    supportList: []
+  },
 });

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -95,7 +95,7 @@ export class WidgetsService extends Service {
   getWidgetUrl(type: WidgetType) {
     if (!this.userService.isLoggedIn()) return;
     return WidgetDefinitions[type].url(
-      this.hostsService.streamlabs,
+      this.hostsService.beta3,
       this.userService.widgetToken,
       this.userService.platform.type
     );


### PR DESCRIPTION
adding chatbot widget
- all widgets pointing to beta3
- all widget previews pointing to beta3
- chatbot widget `go to widget settings` navigates to `Chatbot` and opens songRequestPreferences
- chatbot song request using songRequest Preferences instead of mediaShare
- Limited testing working on beta3. Chatbot widget plays audio for media `request_type=songRequest`