### PR TITLE
enable source maps in uglifyJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,7 +117,7 @@ module.exports = {
   },
 
   optimization: {
-    minimizer: [new UglifyJsPlugin({ uglifyOptions: { mangle: false } })]
+    minimizer: [new UglifyJsPlugin({ sourceMap: true, uglifyOptions: { mangle: false } })]
   },
 
   plugins


### PR DESCRIPTION
We haven't had mapped stack traces in sentry since this was enabled.