### PR TITLE
main: Do not use connectOrHost if we only want to host

### DIFF
--- a/main.js
+++ b/main.js
@@ -271,7 +271,7 @@ function startApp() {
 
   }
 
-  getObs().IPC.ConnectOrHost("slobs" + uuid());
+  getObs().IPC.host("slobs" + uuid());
   // Initialize various OBS services
   getObs().SetWorkingDirectory(
     path.join(app.getAppPath().replace('app.asar', 'app.asar.unpacked') +


### PR DESCRIPTION
This actually fixes the 5 second launch time, as the host call is the one handling the actual hosting. connectOrHost() first tries to connect, then will attempt to host.