### PR TITLE
Fix tab nav animation

### DIFF
--- a/app/components/windows/WidgetEditor.vue
+++ b/app/components/windows/WidgetEditor.vue
@@ -28,11 +28,11 @@
         <div class="custom-code__alert" :class="{ active: customCodeIsEnabled }" />
       </div>
 
-      <div class="content-container" ref="content">
+      <div class="content-container" :class="{ vertical: currentTopTab === 'code' }">
         <div class="display">
           <display v-if="!animating" :sourceId="widget.previewSourceId" @click="createProjector"/>
         </div>
-        <div class="sidebar" ref="sidebar">
+        <div class="sidebar">
           <div class="subsection" v-if="slots" v-for="slot in slots" :key="slot.value">
             <span class="subsection__title">{{ slot.label }}</span>
             <div class="subsection__content"><slot :name="slot.value" /></div>
@@ -63,7 +63,7 @@
           </div>
         </div>
 
-        <div class="code-editor hidden zero-width" ref="code" v-if="loaded">
+        <div class="code-editor" v-if="loaded">
           <div v-if="customCodeIsEnabled">
             <tabs
               :hideConent="true"
@@ -211,34 +211,54 @@
     display: flex;
     width: 100%;
     height: calc(~"100% - 36px");
+    position: relative;
+    background-color: @day-section;
+    overflow: hidden;
+
+    .code-editor {
+      transform: translate(0, 100%);
+    }
+    .display {
+      transform: scale(0.82, .8) translate(-10%);
+    }
   }
 
   .content-container.vertical {
-    flex-direction: column;
+    .sidebar {
+      transform: translate(100%);
+      transition-delay: 0ms;
+    }
+    .code-editor {
+      transform: translate(0, 0);
+      transition-delay: 300ms;
+    }
+    .display {
+      transform: scale(1, 0.63) translate(0, -29%);
+    }
   }
 
   .display {
     width: 100%;
     height: 100%;
-    flex-shrink: 2;
+    position: absolute;
+    top: 0;
+    left: 0;
     background-color: @day-section;
   }
 
   .sidebar {
-    width: 35%;
+    width: 30%;
     height: 100%;
     font-size: 12px;
+    position: absolute;
+    right: 0;
     display: flex;
     flex-direction: column;
     overflow: hidden;
     border-left: 1px solid @day-editor-border;
     background-color: @day-section;
     .transition();
-  }
-
-  .sidebar.hidden {
-    width: 0;
-    height: 0;
+    transition-delay: 300ms;
   }
 
   .subsection {
@@ -295,19 +315,11 @@
   .code-editor {
     height: 60%;
     width: 100%;
+    position: absolute;
+    bottom: 0;
     border-top: 1px solid @day-editor-border;
     background-color: @day-section;
-    transition: height 275ms;
-  }
-
-  .code-editor.hidden {
-    height: 0;
-    visibility: collapse;
-  }
-
-  .code-editor.zero-width {
-    width: 0;
-    transition: none;
+    .transition();
   }
 
   .custom-code {
@@ -320,6 +332,7 @@
     align-items: center;
     height: 24px;
     .transition();
+    transition-delay: 600ms;
 
     span {
       padding-left: 8px;
@@ -331,6 +344,7 @@
     opacity: 0;
     border-left: none;
     transition: none;
+    transition-delay: 0ms;
   }
 
   .custom-code__divider {
@@ -342,10 +356,12 @@
     height: 24px;
     top: 0;
     background-color: @day-section;
+    transition-delay: 600ms;
   }
 
   .custom-code__divider.hidden {
     border-right: none;
+    transition-delay: 0ms;
   }
 
   .custom-code__alert {
@@ -367,7 +383,7 @@
     .window-container {
       border-color: @night-slider-bg;
     }
-    .display {
+    .display, .content-container {
       background-color: @night-section-bg;
     }
     .custom-code__divider {

--- a/app/components/windows/WidgetEditor.vue
+++ b/app/components/windows/WidgetEditor.vue
@@ -29,7 +29,9 @@
       </div>
 
       <div class="content-container" ref="content">
-        <display class="display" :sourceId="widget.previewSourceId" @click="createProjector"/>
+        <div class="display">
+          <display v-if="!animating" :sourceId="widget.previewSourceId" @click="createProjector"/>
+        </div>
         <div class="sidebar" ref="sidebar">
           <div class="subsection" v-if="slots" v-for="slot in slots" :key="slot.value">
             <span class="subsection__title">{{ slot.label }}</span>
@@ -61,7 +63,7 @@
           </div>
         </div>
 
-        <div class="code-editor hidden" ref="code" v-if="loaded">
+        <div class="code-editor hidden zero-width" ref="code" v-if="loaded">
           <div v-if="customCodeIsEnabled">
             <tabs
               :hideConent="true"
@@ -219,6 +221,7 @@
     width: 100%;
     height: 100%;
     flex-shrink: 2;
+    background-color: @day-section;
   }
 
   .sidebar {
@@ -261,12 +264,15 @@
     text-transform: uppercase;
     background-color: @day-editor-accent;
     border-bottom: 1px solid @day-editor-border;
+    white-space: nowrap;
   }
 
   .subsection__content {
     padding: 8px;
     overflow: hidden;
     overflow-y: auto;
+    width: 100%;
+    min-width: 260px;
   }
 
   .source-property {
@@ -291,13 +297,17 @@
     width: 100%;
     border-top: 1px solid @day-editor-border;
     background-color: @day-section;
-    .transition();
+    transition: height 275ms;
   }
 
   .code-editor.hidden {
     height: 0;
-    width: 0;
     visibility: collapse;
+  }
+
+  .code-editor.zero-width {
+    width: 0;
+    transition: none;
   }
 
   .custom-code {
@@ -356,6 +366,9 @@
   .night-theme {
     .window-container {
       border-color: @night-slider-bg;
+    }
+    .display {
+      background-color: @night-section-bg;
     }
     .custom-code__divider {
       background-color: @night-section;

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -63,6 +63,7 @@ export default class WidgetEditor extends Vue {
   currentCodeTab = 'HTML';
   currentSetting = 'source';
   readonly settingsState = this.widget.getSettingsService().state;
+  animating = false;
 
   get loaded() {
     return !!this.settingsState.data;
@@ -126,19 +127,23 @@ export default class WidgetEditor extends Vue {
 
   updateTopTab(value: string) {
     // We do animations in JS here because flex-direction is not an animate-able attribute
+    this.animating = true;
     if (value === 'code') {
       this.$refs.sidebar.classList.toggle('hidden');
-      setTimeout( () => {
+      setTimeout(() => {
         this.$refs.content.classList.toggle('vertical');
+        this.$refs.code.classList.toggle('zero-width');
         this.$refs.code.classList.toggle('hidden');
       }, 300);
     } else if (this.$refs.content.classList.contains('vertical')) {
       this.$refs.code.classList.toggle('hidden');
-      setTimeout( () => {
+      setTimeout(() => {
+        this.$refs.code.classList.toggle('zero-width');
         this.$refs.content.classList.toggle('vertical');
         this.$refs.sidebar.classList.toggle('hidden');
       }, 300);
     }
+    setTimeout(() => this.animating = false, 600);
     this.currentTopTab = value;
   }
 

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -126,25 +126,10 @@ export default class WidgetEditor extends Vue {
   }
 
   updateTopTab(value: string) {
-    // We do animations in JS here because flex-direction is not an animate-able attribute
     this.animating = true;
-    if (value === 'code') {
-      this.$refs.sidebar.classList.toggle('hidden');
-      setTimeout(() => {
-        this.$refs.content.classList.toggle('vertical');
-        this.$refs.code.classList.toggle('zero-width');
-        this.$refs.code.classList.toggle('hidden');
-      }, 300);
-    } else if (this.$refs.content.classList.contains('vertical')) {
-      this.$refs.code.classList.toggle('hidden');
-      setTimeout(() => {
-        this.$refs.code.classList.toggle('zero-width');
-        this.$refs.content.classList.toggle('vertical');
-        this.$refs.sidebar.classList.toggle('hidden');
-      }, 300);
-    }
-    setTimeout(() => this.animating = false, 600);
     this.currentTopTab = value;
+    // Animation takes 600ms to complete before we can re-render the OBS display
+    setTimeout(() => this.animating = false, 600);
   }
 
   updateCodeTab(value: string) {

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -126,6 +126,7 @@ export default class WidgetEditor extends Vue {
   }
 
   updateTopTab(value: string) {
+    if (value === this.currentTopTab) return;
     this.animating = true;
     this.currentTopTab = value;
     // Animation takes 600ms to complete before we can re-render the OBS display


### PR DESCRIPTION
Temporarily remove rendering of OBS display while in an animating state to improve smoothness of UI

![editor_animation](https://user-images.githubusercontent.com/20602520/45972442-8e953700-bff0-11e8-975d-8fb6ced4c84b.gif)
