### PR TITLE
Fixed typo in Dropped Frames notification

### DIFF
--- a/app/components/windows/Troubleshooter.vue
+++ b/app/components/windows/Troubleshooter.vue
@@ -29,7 +29,7 @@
 
       <ul>
         <li>{{ $t('Check the health of your Internet connection') }}</li>
-        <li>{{ $t('Change your ingest server') }}Change your ingest server</li>
+        <li>{{ $t('Change your ingest server') }}</li>
         <li>{{ $t('If none of these worked, lower your bitrate') }}</li>
       </ul>
 


### PR DESCRIPTION
![829940387004979 pwpdym7py7ohz8bobzyj_height640](https://user-images.githubusercontent.com/5510965/46098229-c8914500-c178-11e8-8b8a-c573d26851cb.png)

This is to fix it showing the same sentence twice in the notification area