### PR TITLE
Fix error handling

### DIFF
--- a/app/components/widgets/WidgetSettings.vue.ts
+++ b/app/components/widgets/WidgetSettings.vue.ts
@@ -92,7 +92,7 @@ export default class WidgetSettings<TData extends IWidgetData, TService extends 
       {
         position: 'bottom-center',
         className: 'toast-alert',
-        duration: 1000,
+        duration: 3000,
         singleton: true
       }
     );

--- a/app/components/widgets/goal/GenericGoal.vue
+++ b/app/components/widgets/goal/GenericGoal.vue
@@ -20,11 +20,11 @@
           <v-form-group v-model="goalCreateOptions.manual_goal_amount" :metadata="metadata.manual_goal_amount"/>
           <v-form-group v-model="goalCreateOptions.ends_at" :metadata="metadata.ends_at"/>
         </validated-form>
+        <button @click="saveGoal()" class="button button--action">{{ $t('Start Goal') }}</button>
       </div>
       <div v-else class="loading-spinner">
         <img src="../../../../media/images/loader.svg" />
       </div>
-      <button @click="saveGoal()" class="button button--action">{{ $t('Start Goal') }}</button>
     </div>
   </validated-form>
 

--- a/app/components/widgets/goal/GenericGoal.vue.ts
+++ b/app/components/widgets/goal/GenericGoal.vue.ts
@@ -46,8 +46,10 @@ export default class GenericGoal extends WidgetSettings<IGoalData, GenericGoalSe
   }
 
   async saveGoal() {
+    this.requestState = 'pending';
     if (await this.$refs.form.validateAndGetErrorsCount()) return;
     await this.service.saveGoal(this.goalCreateOptions);
+    this.requestState = 'success';
   }
 
   resetGoal() {

--- a/app/components/windows/WidgetEditor.vue
+++ b/app/components/windows/WidgetEditor.vue
@@ -16,7 +16,7 @@
         <tabs
           :hideContent="true"
           className="widget-editor__top-tabs"
-          :tabs="[{ value: 'editor', name: $t('Widget Editor') }, { value: 'code', name: $t('HTML CSS') }]"
+          :tabs="topTabs"
           @input="value => updateTopTab(value)"
           :value="currentTopTab"
         />
@@ -54,7 +54,8 @@
             <div class="subsection__content" v-if="currentSetting !== 'source'">
               <slot :name="`${currentSetting}-properties`" v-if="!loadingFailed"/>
               <div v-else>
-                {{ $t('Failed to load settings') }}
+                <div>{{ $t('Failed to load settings') }}</div>
+                <button class="button button--warn retry-button" @click="retryDataFetch()">{{ $t('Retry') }}</button>
               </div>
             </div>
             <div class="subsection__content" v-if="currentSetting === 'source'">
@@ -64,7 +65,7 @@
         </div>
 
         <div class="code-editor" v-if="loaded">
-          <div v-if="customCodeIsEnabled">
+          <div v-if="customCodeIsEnabled && !loadingFailed">
             <tabs
               :hideConent="true"
               className="widget-editor__top-tabs"
@@ -95,6 +96,10 @@
               key="customFields"
               :value="wData"
             />
+          </div>
+          <div v-else>
+            <div>{{ $t('Failed to load settings') }}</div>
+            <button class="button button--warn retry-button" @click="retryDataFetch()">{{ $t('Retry') }}</button>
           </div>
         </div>
 
@@ -377,6 +382,10 @@
 
   .custom-code__alert.active {
     background-color: @teal;
+  }
+
+  .retry-button {
+    margin-top: 16px;
   }
 
   .night-theme {

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -102,7 +102,6 @@ export default class WidgetEditor extends Vue {
   get windowTitle() {
     const source = this.widget.getSource();
     return $t('Settings for ') + source.name;
-
   }
 
   get sourceProperties() {
@@ -117,12 +116,22 @@ export default class WidgetEditor extends Vue {
     this.projectorService.createProjector(this.widget.previewSourceId);
   }
 
+  retryDataFetch() {
+    const service = this.widget.getSettingsService()
+    service.fetchData();
+  }
+
   onPropsInputHandler(properties: TObsFormData, changedIndex: number) {
     const source = this.widget.getSource();
     source.setPropertiesFormData(
       [properties[changedIndex]]
     );
     this.properties = this.widget.getSource().getPropertiesFormData();
+  }
+
+  get topTabs() {
+    const firstTab = [{ value: 'editor', name: $t('Widget Editor') }];
+    return this.apiSettings.customCodeAllowed ? firstTab.concat([{ value: 'code', name: $t('HTML CSS') }]) : firstTab;
   }
 
   updateTopTab(value: string) {

--- a/app/services/widgets/widgets-api.ts
+++ b/app/services/widgets/widgets-api.ts
@@ -76,6 +76,7 @@ export interface IWidgetsServiceApi {
 
 export interface IWidgetSettingsServiceApi {
   getApiSettings(): IWidgetApiSettings;
+  fetchData(): Promise<any>;
   saveSettings(settings: IWidgetSettings): Promise<any>;
   state: IWidgetSettingsGenericState;
 }


### PR DESCRIPTION
Extends timer of a failure to save toast, re-implements the spinner when creating goals, and adds a retry button in case data fails to load in the editor