### PR TITLE
Update obs-studio-node to v0.3.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.2/iojs-v2.0.5-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.5/iojs-v2.0.5-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.2/iojs-v2.0.5-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.20/iojs-v2.0.8-signed.tar.gz",
+    "obs-studio-node": "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.21/iojs-v2.0.8-signed.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6745,9 +6745,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.20/iojs-v2.0.8-signed.tar.gz":
-  version "0.3.18"
-  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.20/iojs-v2.0.8-signed.tar.gz#dc7ab88a15b4af2641074e1fa8ce73a8e20cd5b0"
+"obs-studio-node@https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.21/iojs-v2.0.8-signed.tar.gz":
+  version "0.3.21"
+  resolved "https://github.com/stream-labs/obs-studio-node/releases/download/v0.3.21/iojs-v2.0.8-signed.tar.gz#7b20c39cbbeace721a77d127babf4de5c1d758c0"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
This includes the following changes:
* connectOrHost behaves correctly again, switch to host if you only need the host behavior.
* QSV is included again.
* Facemask is included.
* OBS has been updated to 22.0.3.

To keep performance acceptable, please merge #837 before merging this one.