### PR TITLE
Don't rollback if current version is greater than latest

### DIFF
--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -18,6 +18,7 @@ const fs = require('fs');
 const request = require('request');
 const zlib = require('zlib');
 const cp = require('child_process');
+const semver = require('semver');
 const { BrowserWindow } = require('electron');
 const prequest = util.promisify(request);
 const readFile = util.promisify(fs.readFile);
@@ -212,6 +213,11 @@ async function entry(info) {
 
     if (info.version === latestVersion) {
         console.log('Already latest version!');
+        return false;
+    }
+
+    if (semver.gt(info.version, latestVersion)) {
+        console.log('Latest version is less than current version!');
         return false;
     }
 

--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -211,7 +211,7 @@ async function entry(info) {
         return false;
     }
 
-    if (info.version === latestVersion) {
+    if (semver.eq(info.version, latestVersion)) {
         console.log('Already latest version!');
         return false;
     }


### PR DESCRIPTION
* This also sneaks the semver module into the bootstrap. Since it's now convenient, I use logical version comparison rather than string comparison now.