### PR TITLE
Widget-Sources fixes

### DIFF
--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -589,6 +589,8 @@ export class SceneCollectionsService extends Service
    * Should be called before any loading operations
    */
   private startLoadingOperation() {
+    this.windowsService.closeChildWindow();
+    this.windowsService.closeAllOneOffs();
     this.appService.startLoading();
     this.disableAutoSave();
   }

--- a/app/services/sources/source.ts
+++ b/app/services/sources/source.ts
@@ -176,8 +176,14 @@ export class Source implements ISourceApi {
     // is always up-to-date, and essentially acts
     // as a view into the store.  It also enforces
     // the read-only nature of this data
-    this.sourceState = this.sourcesService.state.sources[sourceId];
-    Utils.applyProxy(this, this.sourcesService.state.sources[sourceId]);
+    const isTemporarySource = !!this.sourcesService.state.temporarySources[sourceId];
+    if (isTemporarySource) {
+      this.sourceState = this.sourcesService.state.temporarySources[sourceId];
+      Utils.applyProxy(this, this.sourcesService.state.temporarySources[sourceId]);
+    } else {
+      this.sourceState = this.sourcesService.state.sources[sourceId];
+      Utils.applyProxy(this, this.sourcesService.state.sources[sourceId]);
+    }
   }
 
   @mutation()

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -77,6 +77,7 @@ export interface ISourceCreateOptions {
   sourceId?: string; // A new ID will be generated if one is not specified
   propertiesManager?: TPropertiesManager;
   propertiesManagerSettings?: Dictionary<any>;
+  isTemporary?: boolean;
 }
 
 export type TSourceType =
@@ -105,6 +106,7 @@ export type TPropertiesManager = 'default' | 'widget' | 'streamlabels';
 
 export interface ISourcesState {
   sources: Dictionary<ISource>;
+  temporarySources: Dictionary<ISource>;
 }
 
 export interface IActivePropertyManager {

--- a/app/services/widgets/widget-source.ts
+++ b/app/services/widgets/widget-source.ts
@@ -51,7 +51,8 @@ export class WidgetSource implements IWidgetSource {
     const previewSourceSettings = {
       ...source.getSettings(),
       shutdown: false,
-      url: apiSettings.previewUrl
+      url: apiSettings.previewUrl,
+      isTemporary: true
     };
 
     const previewSource = this.sourcesService.createSource(

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -134,7 +134,7 @@ export class WidgetsService extends StatefulService<IWidgetSourcesState> impleme
   }
 
   getWidgetSource(sourceId: string): WidgetSource {
-    return this.sourcesService.state.sources[sourceId] ? new WidgetSource(sourceId) : null;
+    return this.state.widgetSources[sourceId] ? new WidgetSource(sourceId) : null;
   }
 
   getWidgetUrl(type: WidgetType) {


### PR DESCRIPTION
- fixed an error with merged scenes while scene collections switching
- close all child-windows before scene collections switching
- store preview-sources separated from regular sources (that prevents to save preview-sources in the config files)