### PR TITLE
Fix OpenVR Capture

### DIFF
--- a/app/services/sources/sources-data.ts
+++ b/app/services/sources/sources-data.ts
@@ -80,7 +80,7 @@ export const SourceDisplayData = (): { [key: string]: ISourceDisplayData } => ({
     demoFilename: 'sources.png',
     supportList: [$t('Works with most of the recent Blackmagic cards.')]
   },
-  open_vr_capture: {
+  openvr_capture: {
     name: $t('OpenVR Capture'),
     description: $t('Directly capture the OpenVR monitoring video buffer of your HMD.'),
     demoFilename: 'vr-capture.png',


### PR DESCRIPTION
Due to a typo of the plugin id the 3rd party OpenVR plugin could not be added properly by users and properties of the plugin would not open.