### PR TITLE
performance stats async

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -325,7 +325,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
           this.UPDATE_SOURCE(size);
         }
         this.updateSourceFlags(source, update.outputFlags);
-      });      
+      });
     }
   }
 

--- a/main.js
+++ b/main.js
@@ -445,18 +445,6 @@ ipcMain.on('restartApp', () => {
   mainWindow.close();
 });
 
-ipcMain.on('requestSourceAttributes', (e, names) => {
-  const sizes = require('obs-studio-node').getSourcesSize(names);
-
-  e.sender.send('notifySourceAttributes', sizes);
-});
-
-ipcMain.on('requestPerformanceStatistics', (e) => {
-  const stats = getObs().OBS_API_getPerformanceStatistics();
-
-  e.sender.send('notifyPerformanceStatistics', stats);
-});
-
 ipcMain.on('streamlabels-writeFile', (e, info) => {
   fs.writeFile(info.path, info.data, err => {
     if (err) {
@@ -473,4 +461,9 @@ ipcMain.on('webContents-preventNavigation', (e, id) => {
 
 ipcMain.on('getMainWindowWebContentsId', e => {
   e.returnValue = mainWindow.webContents.id;
+});
+
+ipcMain.on('requestPerformanceStats', e => {
+  const stats = app.getAppMetrics();
+  e.sender.send('performanceStatsResponse', stats);
 });


### PR DESCRIPTION
We're still trying to figure out why this call is so slow all of sudden.  Our leading theory is that they are writing the deprecation message incredibly frequently and flushing the output buffer.  At least for now we will stop blocking the renderer while we make this call.  Hopefully the electron team resolves this soon or we will have to find another way to get CPU usage metrics.