### PR TITLE
Revise some of the crop distance calc code

### DIFF
--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -271,23 +271,36 @@ export default class StudioEditor extends Vue {
     rect.normalized(() => {
       rect.withAnchor(options.anchor, () => {
         // There's probably a more generic way to do this math
-        if (options.anchor === AnchorPoint.East) {
-          const croppableWidth = rect.width - rect.crop.right - 2;
-          const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
-          rect.crop.left = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.anchor === AnchorPoint.West) {
-          const croppableWidth = rect.width - rect.crop.left - 2;
-          const distance = (croppableWidth * rect.scaleX) + (rect.x - x);
-          rect.crop.right = _.clamp(distance / rect.scaleX, 0, croppableWidth);
-        } else if (options.anchor === AnchorPoint.South) {
-          const croppableHeight = rect.height - rect.crop.bottom - 2;
-          const distance = (croppableHeight * rect.scaleY) - (rect.y - y);
-          rect.crop.top = _.clamp(distance / rect.scaleY, 0, croppableHeight);
-        } else if (options.anchor === AnchorPoint.North) {
-          const croppableHeight = rect.height - rect.crop.top - 2;
-          const distance = (croppableHeight * rect.scaleY) + (rect.y - y);
-          rect.crop.bottom = _.clamp(distance / rect.scaleY, 0, croppableHeight);
+        switch (options.anchor) {
+          case AnchorPoint.East: {
+            const croppableWidth = rect.width - rect.crop.right - 2;
+            const distance = (croppableWidth * rect.scaleX) - (rect.x - x);
+            rect.crop.left = Math.round(_.clamp(distance / rect.scaleX, 0, croppableWidth));
+            break;
+          }
+
+          case AnchorPoint.West: {
+            const croppableWidth = rect.width - rect.crop.left - 2;
+            const distance = (croppableWidth * rect.scaleX) + (rect.x - x);
+            rect.crop.right = Math.round(_.clamp(distance / rect.scaleX, 0, croppableWidth));
+            break;
+          }
+
+          case AnchorPoint.South: {
+            const croppableHeight = rect.height - rect.crop.bottom - 2;
+            const distance = (croppableHeight * rect.scaleY) - (rect.y - y);
+            rect.crop.top = Math.round(_.clamp(distance / rect.scaleY, 0, croppableHeight));
+            break;
+          }
+
+          case AnchorPoint.North: {
+            const croppableHeight = rect.height - rect.crop.top - 2;
+            const distance = (croppableHeight * rect.scaleY) + (rect.y - y);
+            rect.crop.bottom = Math.round(_.clamp(distance / rect.scaleY, 0, croppableHeight));
+            break;
+          }
         }
+
       });
     });
 

--- a/app/components/StudioEditor.vue.ts
+++ b/app/components/StudioEditor.vue.ts
@@ -228,7 +228,6 @@ export default class StudioEditor extends Vue {
 
       if (this.isCropping) {
         this.crop(converted.x, converted.y, options);
-        this.crop(converted.x, converted.y, options);
       } else {
         this.resize(converted.x, converted.y, options);
       }


### PR DESCRIPTION
This fixes the source moving while cropping bug and a typo. It rearranged the code a little bit to space it out and uses a switch/case instead of a if else statement. Initial tests look good (or better at least). 

There still seems to be a bit of glitching when dragging from the top but this might be a weird display bug. It's been pretty difficult to catch in the act even though I can observe it visually (only for a fraction of a second) but it's not too horribly intrusive. 