### PR TITLE
feat(init): display error message & exit if OBS API fails to init

### DIFF
--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -37,5 +37,9 @@
   "Copy": "Copy",
   "Select All": "Select All",
   "Select Option": "Select Option",
-  "Browse": "Browse"
+  "Browse": "Browse",
+  "OBSInit.ErrorTitle": "Initialization Error",
+  "OBSInit.UnknownError": "An unknown error was encountered while initializing OBS.",
+  "OBSInit.ModuleNotFoundError": "DirectX could not be found on your system. Please install the latest version of DirectX for your machine here <https://www.microsoft.com/en-us/download/details.aspx?id=35?> and try again.",
+  "OBSInit.NotSupportedError": "Failed to initialize OBS. Your video drivers may be out of date, or Streamlabs OBS may not be supported on your system."
 }

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -1,10 +1,10 @@
 import uuid from 'uuid/v4';
-import { StatefulService, mutation } from 'services/stateful-service';
+import { mutation, StatefulService } from 'services/stateful-service';
 import { OnboardingService } from 'services/onboarding';
 import { HotkeysService } from 'services/hotkeys';
 import { UserService } from 'services/user';
 import { ShortcutsService } from 'services/shortcuts';
-import { getResource, Inject } from 'util/injector';
+import { Inject } from 'util/injector';
 import electron from 'electron';
 import { TransitionsService } from 'services/transitions';
 import { SourcesService } from 'services/sources';
@@ -22,6 +22,7 @@ import { PatchNotesService } from 'services/patch-notes';
 import { ProtocolLinksService } from 'services/protocol-links';
 import { WindowsService } from 'services/windows';
 import * as obs from '../../../obs-api';
+import { EVideoCodes } from 'obs-studio-node/module';
 import { FacemasksService } from 'services/facemasks';
 import { OutageNotificationsService } from 'services/outage-notifications';
 import { CrashReporterService } from 'services/crash-reporter';
@@ -29,6 +30,7 @@ import { PlatformAppsService } from 'services/platform-apps';
 import { AnnouncementsService } from 'services/announcements';
 import { ObsUserPluginsService } from 'services/obs-user-plugins';
 import { IncrementalRolloutService } from 'services/incremental-rollout';
+import { $t } from '../i18n';
 
 const crashHandler = window['require']('crash-handler');
 
@@ -87,7 +89,20 @@ export class AppService extends StatefulService<IAppState> {
     await this.obsUserPluginsService.initialize();
 
     // Initialize OBS
-    obs.NodeObs.OBS_API_initAPI('en-US', electron.remote.process.env.SLOBS_IPC_USERDATA);
+    const apiResult = obs.NodeObs.OBS_API_initAPI(
+      'en-US',
+      electron.remote.process.env.SLOBS_IPC_USERDATA,
+    );
+
+    if (apiResult !== EVideoCodes.Success) {
+      const message = apiInitErrorResultToMessage(apiResult);
+      showDialog(message);
+
+      crashHandler.unregisterProcess(this.pid);
+      electron.ipcRenderer.send('shutdownComplete');
+
+      return;
+    }
 
     // We want to start this as early as possible so that any
     // exceptions raised while loading the configuration are
@@ -224,3 +239,21 @@ export class AppService extends StatefulService<IAppState> {
     this.state.argv = argv;
   }
 }
+
+export const apiInitErrorResultToMessage = (resultCode: EVideoCodes) => {
+  switch (resultCode) {
+    case EVideoCodes.NotSupported: {
+      return $t('OBSInit.NotSupportedError');
+    }
+    case EVideoCodes.ModuleNotFound: {
+      return $t('OBSInit.ModuleNotFoundError');
+    }
+    default: {
+      return $t('OBSInit.UnknownError');
+    }
+  }
+};
+
+const showDialog = (message: string): void => {
+  electron.remote.dialog.showErrorBox($t('OBSInit.ErrorTitle'), message);
+};

--- a/test/services/app/app.ts
+++ b/test/services/app/app.ts
@@ -1,0 +1,15 @@
+import test from 'ava';
+import { EVideoCodes } from 'obs-studio-node';
+import { apiInitErrorResultToMessage as rtm } from '../../../app/services/app';
+
+test('returns user-friendly error for ModuleNotFound status', t => {
+  t.regex(rtm(EVideoCodes.ModuleNotFound), /DirectX could not be found/);
+});
+
+test('returns user-friendly error for NotSupported status', t => {
+  t.regex(rtm(EVideoCodes.NotSupported), /Failed to initialize OBS/);
+});
+
+test('returns generic error string for Fail, InvalidParam and CurrentlyActive results', t => {
+  t.regex(rtm(EVideoCodes.Fail), /unknown error/);
+});


### PR DESCRIPTION
Display error messages if OBS API fails to initialize. Relies on `EVideoCodes` being returned from initialization function, which should be updated shortly. 

Pending:
- [x] Main window still displays. Ideally we wouldn't render anything but the dialog, correct?

CR:
- [x] Ensure we're not leaking memory
- [x] Is this the correct way to trigger a shutdown

EDIT: English 🙈 