### PR TITLE
feat(platform): add get source by ID to API

### DIFF
--- a/app/services/platform-apps/api/modules/sources.ts
+++ b/app/services/platform-apps/api/modules/sources.ts
@@ -47,7 +47,7 @@ export class SourcesModule extends Module {
     this.sourcesService.sourceUpdated.subscribe(sourceData => {
       const source = this.sourcesService.getSourceById(sourceData.sourceId);
       this.sourceUpdated.next(this.serializeSource(source));
-    })
+    });
     this.sourcesService.sourceRemoved.subscribe(sourceData => {
       this.sourceRemoved.next(sourceData.sourceId);
     });
@@ -70,6 +70,13 @@ export class SourcesModule extends Module {
   @apiMethod()
   getSources() {
     return this.sourcesService.getSources().map(source => this.serializeSource(source));
+  }
+
+  @apiMethod()
+  getSource(_ctx: IApiContext, id: string): ISource | null {
+    const source = this.sourcesService.getSource(id);
+
+    return source ? this.serializeSource(source) : null;
   }
 
   @apiMethod()
@@ -155,7 +162,9 @@ export class SourcesModule extends Module {
 
     const source = this.sourcesService.getSource(patch.id);
 
-    if (patch.name) source.setName(patch.name);
+    if (patch.name) {
+      source.setName(patch.name);
+    }
 
     if (patch.muted != null) {
       this.audioService.getSource(patch.id).setMuted(patch.muted);


### PR DESCRIPTION
This adds a `getSource` method to the sources module, enabling getting a source by ID. 
Null-check curses are casted on the caller. We explicitly acknowledge that `getSource` in the service might return undefined, so we return `null` prior to serializing if that were to be the case.  