### PR TITLE
feat(troubleshooter): inline controls in dropped frames notice

### DIFF
--- a/app/components/windows/Troubleshooter.vue
+++ b/app/components/windows/Troubleshooter.vue
@@ -33,6 +33,13 @@
         <li>{{ $t('If none of these worked, lower your bitrate') }}</li>
       </ul>
 
+      <div class="inline-controls">
+        <p v-if="isStreaming">
+          {{ $t('Stop streaming to access these controls:')}}
+        </p>
+        <GenericFormGroups v-model="streamingSettings" @input="saveStreamingSettings" />
+        <GenericFormGroups v-model="outputSettings" @input="saveOutputSettings" />
+      </div>
     </div>
 
 
@@ -99,14 +106,35 @@
 <script lang="ts" src="./Troubleshooter.vue.ts"></script>
 
 <style lang="less" scoped>
-  @import "../../styles/index";
+@import '../../styles/index';
 
-  .fa-warning {
-    color: @red;
+.fa-warning {
+  color: @red;
+}
+
+p,
+ul {
+  margin-bottom: 15px;
+}
+
+.inline-controls /deep/ .section-title {
+  display: none;
+}
+
+.inline-controls /deep/ .section-content--opened {
+  margin-top: 0;
+}
+
+.inline-controls /deep/ .input-container {
+  display: block;
+
+  .input-label {
+    margin-bottom: 8px;
   }
 
-  p, ul {
-    margin-bottom: 15px;
+  .input-wrapper,
+  .int-input {
+    width: 100%;
   }
-
+}
 </style>

--- a/app/components/windows/Troubleshooter.vue.ts
+++ b/app/components/windows/Troubleshooter.vue.ts
@@ -4,29 +4,81 @@ import { Component } from 'vue-property-decorator';
 import { Inject } from '../../util/injector';
 import ModalLayout from '../ModalLayout.vue';
 import { TIssueCode } from 'services/troubleshooter';
-import { INotificationsServiceApi, INotification } from 'services/notifications';
-import { ISettingsServiceApi } from 'services/settings';
+import { INotification, INotificationsServiceApi } from 'services/notifications';
+import { ISettingsServiceApi, ISettingsSubCategory } from 'services/settings';
 import { WindowsService } from 'services/windows';
+import { StreamingService } from 'services/streaming';
+import { TObsFormData } from '../obs/inputs/ObsInput';
+import GenericFormGroups from '../obs/inputs/GenericFormGroups.vue';
 
 @Component({
-  components: { ModalLayout },
+  components: { ModalLayout, GenericFormGroups },
 })
 export default class Troubleshooter extends Vue {
   @Inject() private notificationsService: INotificationsServiceApi;
   @Inject() private settingsService: ISettingsServiceApi;
   @Inject() private windowsService: WindowsService;
+  @Inject() streamingService: StreamingService;
+
+  streamingSettings: ISettingsSubCategory[] | null = null;
+  outputSettings: ISettingsSubCategory[] | null = null;
 
   issueCode = this.windowsService.getChildWindowQueryParams().issueCode as TIssueCode;
 
+  mounted() {
+    this.getSettings();
+  }
+
   get issue(): INotification {
     return this.notificationsService.getAll().find(notify => notify.code === this.issueCode);
+  }
+
+  getSettings() {
+    if (this.issueCode === 'FRAMES_DROPPED') {
+      [this.streamingSettings, this.outputSettings] = getStreamSettings(
+        this.settingsService.getSettingsFormData,
+      );
+    }
   }
 
   showSettings() {
     this.settingsService.showSettings();
   }
 
+  get isStreaming() {
+    return this.streamingService.isStreaming;
+  }
+
+  saveOutputSettings() {
+    this.settingsService.setSettings('Output', this.outputSettings);
+  }
+
+  saveStreamingSettings() {
+    this.settingsService.setSettings('Stream', this.streamingSettings);
+  }
+
   moment(time: number): string {
     return moment(time).fromNow();
   }
 }
+
+const getStreamSettings = (getSettingsFn: (categoryName: string) => ISettingsSubCategory[]) => {
+  return [
+    getSettingsFn('Stream').map(hideParamsForCategory),
+    getSettingsFn('Output').map(hideParamsForCategory),
+  ];
+};
+
+const paramsToShow = ['server', 'VBitrate', 'ABitrate'];
+
+const hideParamsForCategory = (category: ISettingsSubCategory): ISettingsSubCategory => ({
+  ...category,
+  parameters: hideParams(category.parameters),
+});
+
+const hideParams = (parameters: TObsFormData): TObsFormData => {
+  return parameters.map(parameter => ({
+    ...parameter,
+    visible: paramsToShow.includes(parameter.name),
+  }));
+};

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -46,5 +46,6 @@
   "Refresh Chat": "Refresh Chat",
   "Your chat is currently offline": "Your chat is currently offline",
   "Set path in Settings > Output.": "Set path in Settings > Output.",
-  "Your stream has been scheduled for %{time} from now. If you'd like to make another schedule please enter a different time": "Your stream has been scheduled for %{time} from now. If you'd like to make another schedule please enter a different time"
+  "Your stream has been scheduled for %{time} from now. If you'd like to make another schedule please enter a different time": "Your stream has been scheduled for %{time} from now. If you'd like to make another schedule please enter a different time",
+  "Stop streaming to access these controls:": "Stop streaming to access these controls:"
 }


### PR DESCRIPTION
Add inline controls allowing to change server, edit Video and Audio bitrate inline after receiving (and acting upon) a "Dropped Frames" notification.

Notice the values are saved automatically, as in most of our UI.
Handling values separately, Stream (server) and Output (bitrates) is by design.

~UI is not perfect yet.~

How to trigger bandwidth notification and access this popup:
From main window DevTools:
```javascript
sm.getService('PerformanceMonitorService').instance.pushDroppedFramesNotify(0.2)
```

![capture](https://user-images.githubusercontent.com/133308/48648773-6cdb7f00-e9a5-11e8-92be-9fd20de86550.PNG)
![capture](https://user-images.githubusercontent.com/133308/48721468-d7bfcc80-ebd6-11e8-98e8-182e4168cdb6.PNG)

EDIT: Current UI screenshots + How to trigger dropped frames snippet.

EDIT 2: UI update + screenshot.