### PR TITLE
Change bucket name for release script

### DIFF
--- a/bin/release.js
+++ b/bin/release.js
@@ -16,7 +16,7 @@ const cp = require('child_process');
 /**
  * CONFIGURATION
  */
-const s3Bucket = 'streamlabs-obs';
+const s3Bucket = 'slobs-cdn.streamlabs.com';
 const sentryOrg = 'streamlabs-obs';
 const sentryProject = 'streamlabs-obs';
 


### PR DESCRIPTION
This requires #1052 be pulled in, a release be made with *only* that, and then this be pulled in, and a new, separate release be made. Otherwise, a release will never get put out to the old CDN which contains the update changing the actual CDN.