### PR TITLE
[HOTFIX] Re-enable obs-browser hw accel

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.4/iojs-v2.0.8-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.7/iojs-v2.0.8-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.6/iojs-v2.0.5-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.68-iojs-v2.0.8.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.64-hotfix.1-iojs-v2.0.8.tar.gz",
     "recursive-readdir": "^2.2.2",
     "request": "^2.85.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7758,9 +7758,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.68-iojs-v2.0.8.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.64-hotfix.1-iojs-v2.0.8.tar.gz":
   version "0.3.21"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.68-iojs-v2.0.8.tar.gz#d9b6de737f171ee4cff51acced526e24a516935c"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.3.64-hotfix.1-iojs-v2.0.8.tar.gz#848de791ae32748dbe09e550c0d254a44e7de68c"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
We've reverted CEF a few revisions and re-enabled hardware acceleration. Pending QA.