### PR TITLE
Remove source on removal of widget preview

### DIFF
--- a/app/services/widgets/widget-source.ts
+++ b/app/services/widgets/widget-source.ts
@@ -73,6 +73,7 @@ export class WidgetSource implements IWidgetSource {
 
   destroyPreviewSource() {
     this.widgetsService.stopSyncPreviewSource(this.previewSourceId);
+    this.sourcesService.removeSource(this.previewSourceId);
     this.SET_PREVIEW_SOURCE_ID('');
   }
 


### PR DESCRIPTION
This fixes a major leak when you open and close a widget settings menu.
There's another leak here where if you start slobs and open the widget settings menu, it will leak the first time only. I'm still tracking that down.