### PR TITLE
Implement a helper script to pull AWS from env

### DIFF
--- a/bin/aws-wrapper.js
+++ b/bin/aws-wrapper.js
@@ -1,0 +1,23 @@
+const cp = require('child_process');
+
+const args = process.argv.splice(3);
+const secretKey = process.env['AWS_SECRET_ACCESS_KEY'];
+const accessKey = process.env['AWS_ACCESS_KEY_ID'];
+
+if (!secretKey || !accessKey) {
+	console.log('AWS environment keys missing!');
+	return;
+}
+
+if (args.includes('--secret-access-key') || args.includes('--access-key')) {
+	console.log('AWS environment already given in CLI commands!');
+	console.log('Just call the script directly');
+	return;
+}
+
+args.push('--secret-access-key', secretKey);
+args.push('--access-key', accessKey);
+
+console.log(`Wrapping ${process.argv[2]} with arguments ${args}`)
+
+cp.fork(process.argv[2], args);


### PR DESCRIPTION
This is a simple script. It looks for AWS environment variables containing keys and ids and then pushes them as an argument into a script specified as the third argument. So an example to use this would be:
`node aws-wrapper.js set-latest.js --version test --s3-bucket streamlabs-obs --version-file bob` or
`node aws-wrapper.js set-chance.js --version blash --chance 50 --s3-bucket streamlabs-obs-dev` given your AWS environment is correct. 

Testing this showed me a bug where set-chance.js doesn't require --s3-bucket. Will give a PR for that soon.