### PR TITLE
Fix s3-bucket not being a required argument

### DIFF
--- a/bin/set-chance.js
+++ b/bin/set-chance.js
@@ -16,6 +16,7 @@ function validateArgs(args) {
     }
   };
 
+  argRequired('s3-bucket');
   argRequired('access-key');
   argRequired('secret-access-key');
   argRequired('version');


### PR DESCRIPTION
The script still works as intended without this but it's not as clear as to what's going on (since exception information will be thrown at the console instead of a clean message).