### PR TITLE
Fix query string parsing for slobs banner

### DIFF
--- a/app/services/announcements.ts
+++ b/app/services/announcements.ts
@@ -57,6 +57,8 @@ export class AnnouncementsService extends StatefulService<IAnnouncementsInfo> {
       // splits out params for local links eg PlatformAppStore?appId=<app-id>
       const queryString = newState.link.split('?')[1];
       if (newState.linkTarget === 'slobs' && queryString) {
+        newState.link = newState.link.split('?')[0];
+        newState.params = {};
         queryString.split(',').forEach((query: string) => {
           const [ key, value ] = query.split('=');
           newState.params[key] = value;


### PR DESCRIPTION
This will allow admins on the website to create a banner with a link such as `Dashboard?subPage=facemasks` or `PlatformAppStore?appId=2` and the button will take you there.