### PR TITLE
fix(platform): disable cleanURLs that causes redirects in some instances

### DIFF
--- a/app/services/platform-apps/dev-server.ts
+++ b/app/services/platform-apps/dev-server.ts
@@ -11,8 +11,9 @@ export class DevServer {
   listen() {
     this.server = http.createServer((request, response) =>
       handler(request, response, {
-        public: this.directory
-      })
+        public: this.directory,
+        cleanUrls: false,
+      }),
     );
 
     this.server.listen(this.port);


### PR DESCRIPTION
In some instances (or most, only my test app seems to work for some reason) `serve-handler` rewrites URLs to be pretty and this strips the query string. This commit fixes that.