### PR TITLE
fix: mutating actions results in hotkey bugs

### DIFF
--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -353,20 +353,18 @@ export class HotkeysService extends StatefulService<IHotkeysServiceState> {
 
     obsHotkeys.filter(isSupportedHotkey).forEach(hotkey => {
       const action = getActionFromName(hotkey.HotkeyName);
-      if (!action) {
-        return;
-      }
+      if (action && action.name) {
+        const key = `${action.name}-${hotkey.ObjectName}`;
 
-      const key = `${action.name}-${hotkey.ObjectName}`;
-
-      if (!addedHotkeys.has(key)) {
-        hotkeys.push({
-          [idPropFor(hotkey)]: hotkey.ObjectName,
-          actionName: action.name,
-          bindings: [] as IBinding[],
-          hotkeyId: hotkey.HotkeyId,
-        });
-        addedHotkeys.add(key);
+        if (!addedHotkeys.has(key)) {
+          hotkeys.push({
+            [idPropFor(hotkey)]: hotkey.ObjectName,
+            actionName: action.name,
+            bindings: [] as IBinding[],
+            hotkeyId: hotkey.HotkeyId,
+          });
+          addedHotkeys.add(key);
+        }
       }
     });
 
@@ -636,13 +634,17 @@ const getMigrationMapping = (actionName: string) => {
   }[normalizeActionName(actionName)];
 };
 
-const getActionFromName = (actionName: string) =>
-  ACTIONS[actionName] || ACTIONS[getMigrationMapping(actionName)];
+const getActionFromName = (actionName: string) => ({
+  ...(ACTIONS[actionName] || ACTIONS[getMigrationMapping(actionName)]),
+});
 
-const isSupportedHotkey = (hotkey: OBSHotkey) =>
-  hotkey.ObjectType === obs.EHotkeyObjectType.Source &&
-  getActionFromName(hotkey.HotkeyName) &&
-  idPropFor(hotkey);
+const isSupportedHotkey = (hotkey: OBSHotkey) => {
+  const action = getActionFromName(hotkey.HotkeyName);
+
+  return (
+    hotkey.ObjectType === obs.EHotkeyObjectType.Source && action && action.name && idPropFor(hotkey)
+  );
+};
 
 const isSceneItem = (hotkey: OBSHotkey) => !!getScenesService().getSceneItem(hotkey.ObjectName);
 


### PR DESCRIPTION
As we're mutating the action object returned when we try to fetch an action by name, previous commit failed to realize the implications of this, and this resulted in several hotkey bugs.

ref: https://app.asana.com/0/734380881425048/947809648402930/f

This commit fixes it by returning a new object. It was chosen to apply the fix on the method rather than on callers for simplicity.

Please verify that the following issues are fixed:

- [ ] No matter which Scene you have the Hotkeys set to, it will default to working ONLY on the BOTTOM Scene.
- [ ] Hotkeys for Mic/Aux Mute and Unmute mutes Desktop Audio Device not the Mic/Aux Device
