### PR TITLE
fix(chatbot): fallthrough switch

### DIFF
--- a/app/services/chatbot/chatbot.ts
+++ b/app/services/chatbot/chatbot.ts
@@ -424,6 +424,7 @@ export class ChatbotApiService extends PersistentStatefulService<IChatbotApiServ
         switch (slug) {
           case 'chat-notifications':
             this.UPDATE_CHAT_ALERTS(response as IChatAlertsResponse);
+            break;
           case 'caps-protection':
             this.UPDATE_CAPS_PROTECTION(response as ICapsProtectionResponse);
             break;


### PR DESCRIPTION
Missing break statement causes fallthrough, I believe this is unintentional.