### PR TITLE
refactor: deprecated start streaming

### DIFF
--- a/app/components/windows/EditStreamInfo.vue.ts
+++ b/app/components/windows/EditStreamInfo.vue.ts
@@ -309,7 +309,7 @@ export default class EditStreamInfo extends Vue {
   }
 
   goLive() {
-    this.streamingService.startStreaming();
+    this.streamingService.toggleStreaming();
     this.navigationService.navigate('Live');
     this.windowsService.closeChildWindow();
   }


### PR DESCRIPTION
`startStreaming` is deprecated. This removes its last usage and adds a note about removing the method altogether.