### PR TITLE
refactor: inline vars

### DIFF
--- a/.idea/streamlabs-obs.iml
+++ b/.idea/streamlabs-obs.iml
@@ -4,6 +4,7 @@
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludeFolder url="file://$MODULE_DIR$/docs/theme" />
       <excludeFolder url="file://$MODULE_DIR$/test-dist" />
       <excludeFolder url="file://$MODULE_DIR$/vendor" />
     </content>

--- a/app/components/AppPlatformDeveloperSettings.vue.ts
+++ b/app/components/AppPlatformDeveloperSettings.vue.ts
@@ -52,11 +52,10 @@ export default class AppPlatformDeveloperSettings extends Vue {
     this.loading = true;
 
     try {
-      const error = await this.platformAppsService.installUnpackedApp(
+      this.error = await this.platformAppsService.installUnpackedApp(
         this.appPathValue,
         this.appTokenValue,
       );
-      this.error = error;
     } catch (e) {
       this.error =
         'There was an error loading this app, please try again ' +
@@ -71,8 +70,7 @@ export default class AppPlatformDeveloperSettings extends Vue {
     this.error = '';
 
     try {
-      const error = await this.platformAppsService.reloadApp(this.currentlyLoadedUnpackedApp.id);
-      this.error = error;
+      this.error = await this.platformAppsService.reloadApp(this.currentlyLoadedUnpackedApp.id);
     } catch (e) {
       this.error =
         'There was an error loading this app, please try again ' +

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -3,12 +3,12 @@ import Vue from 'vue';
 import { Prop } from 'vue-property-decorator';
 import * as obs from '../../../../obs-api';
 import {
-  isListProperty,
   isEditableListProperty,
-  isNumberProperty,
-  isTextProperty,
   isFontProperty,
+  isListProperty,
+  isNumberProperty,
   isPathProperty,
+  isTextProperty,
 } from '../../../util/properties-type-guards';
 import { $t } from 'services/i18n/index';
 
@@ -357,10 +357,9 @@ export function getPropertiesFormData(obsSource: obs.ISource): TObsFormData {
     // handle property details
 
     if (isListProperty(obsProp)) {
-      const options: IObsListOption<any>[] = obsProp.details.items.map(option => {
+      (formItem as IObsListInput<TObsValue>).options = obsProp.details.items.map(option => {
         return { value: option.value, description: option.name };
       });
-      (formItem as IObsListInput<TObsValue>).options = options;
     }
 
     if (isNumberProperty(obsProp)) {

--- a/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { Component, Watch, Prop } from 'vue-property-decorator';
-import { IObsInput, ObsInput, IObsFont } from './ObsInput';
+import { Component, Prop, Watch } from 'vue-property-decorator';
+import { IObsFont, IObsInput, ObsInput } from './ObsInput';
 import { Multiselect } from 'vue-multiselect';
 import ObsFontSizeSelector from './ObsFontSizeSelector.vue';
 import fontManager from 'font-manager';
@@ -92,12 +92,11 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
   }
 
   getFlagsFromFont(font: IFontDescriptor) {
-    const flags =
+    return (
       (font.italic ? EFontStyle.Italic : 0) |
       (font.oblique ? EFontStyle.Italic : 0) |
-      (font.weight > 400 ? EFontStyle.Bold : 0);
-
-    return flags;
+      (font.weight > 400 ? EFontStyle.Bold : 0)
+    );
   }
 
   setStyle(font: IFontDescriptor) {

--- a/app/components/page-components/Chatbot/ChatbotBase.vue.ts
+++ b/app/components/page-components/Chatbot/ChatbotBase.vue.ts
@@ -47,36 +47,28 @@ export default class ChatbotBase extends Vue {
     return ChatbotPermissionsEnums;
   }
 
-  get chatbotPermissions() {
-    const permissions = Object.keys(ChatbotPermissionsEnums).reduce(
-      (a: IListOption<number>[], b: string) => {
-        if (typeof ChatbotPermissionsEnums[b] === 'number') {
-          a.push({
-            title: b.split('_').join(' '),
-            value: ChatbotPermissionsEnums[b],
-          });
-        }
-        return a;
-      },
-      [],
-    );
-    return permissions;
+  get chatbotPermissions(): IListOption<number>[] {
+    return Object.keys(ChatbotPermissionsEnums).reduce((a: IListOption<number>[], b: string) => {
+      if (typeof ChatbotPermissionsEnums[b] === 'number') {
+        a.push({
+          title: b.split('_').join(' '),
+          value: ChatbotPermissionsEnums[b],
+        });
+      }
+      return a;
+    }, []);
   }
 
-  get chatbotAutopermitOptions() {
-    const permissions = Object.keys(ChatbotAutopermitEnums).reduce(
-      (a: IListOption<number>[], b: string) => {
-        if (typeof ChatbotAutopermitEnums[b] === 'number') {
-          a.push({
-            title: b.split('_').join(' '),
-            value: ChatbotAutopermitEnums[b],
-          });
-        }
-        return a;
-      },
-      [],
-    );
-    return permissions;
+  get chatbotAutopermitOptions(): IListOption<number>[] {
+    return Object.keys(ChatbotAutopermitEnums).reduce((a: IListOption<number>[], b: string) => {
+      if (typeof ChatbotAutopermitEnums[b] === 'number') {
+        a.push({
+          title: b.split('_').join(' '),
+          value: ChatbotAutopermitEnums[b],
+        });
+      }
+      return a;
+    }, []);
   }
 
   get chatbotResponseTypes() {

--- a/app/components/page-components/Chatbot/ChatbotModTools.vue.ts
+++ b/app/components/page-components/Chatbot/ChatbotModTools.vue.ts
@@ -18,9 +18,9 @@ export default class ChatbotModTools extends ChatbotBase {
     this.chatbotApiService.fetchWordProtection();
   }
 
-  get modules() {
+  get modules(): IChatbotModule[] {
     const backgroundUrlSuffix = this.nightMode ? 'night' : 'day';
-    const modules: IChatbotModule[] = [
+    return [
       {
         title: $t('Caps Protection'),
         description: $t('Restrict viewers from spamming all caps messages to chat.'),
@@ -84,7 +84,6 @@ export default class ChatbotModTools extends ChatbotBase {
         },
       },
     ];
-    return modules;
   }
 
   get capsProtection() {

--- a/app/components/page-components/Chatbot/ChatbotModules.vue.ts
+++ b/app/components/page-components/Chatbot/ChatbotModules.vue.ts
@@ -16,12 +16,12 @@ export default class ChatbotModules extends ChatbotBase {
     this.chatbotApiService.fetchSongRequest();
   }
 
-  get modules() {
+  get modules(): IChatbotModule[] {
     const backgroundUrlSuffix = this.nightMode ? 'night' : 'day';
     const comingSoonText = $t(
       'Streamlabs is diligently working on the next release of Chatbot. Stay tuned. We have more features on the way.',
     );
-    const modules: IChatbotModule[] = [
+    return [
       {
         title: $t('Chat Alerts'),
         description: $t(
@@ -67,7 +67,6 @@ export default class ChatbotModules extends ChatbotBase {
         comingSoon: true,
       },
     ];
-    return modules;
   }
 
   get chatAlerts() {

--- a/app/components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue.ts
+++ b/app/components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue.ts
@@ -1,26 +1,26 @@
 import { cloneDeep } from 'lodash';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import { $t } from 'services/i18n';
 import {
-  ICapsProtectionResponse,
-  ISymbolProtectionResponse,
-  ILinkProtectionResponse,
-  IWordProtectionResponse,
-  ICapsProtectionData,
-  ISymbolProtectionData,
-  ILinkProtectionData,
-  IWordProtectionData,
   ChatbotSettingSlug,
+  ICapsProtectionData,
+  ICapsProtectionResponse,
+  ILinkProtectionData,
+  ILinkProtectionResponse,
+  ISymbolProtectionData,
+  ISymbolProtectionResponse,
+  IWordProtectionData,
+  IWordProtectionResponse,
 } from 'services/chatbot';
 
 import {
   EInputType,
+  IInputMetadata,
   IListMetadata,
-  ITextMetadata,
   INumberMetadata,
   ISliderMetadata,
-  IInputMetadata,
+  ITextMetadata,
 } from 'components/shared/inputs';
 
 interface IChatbotPunishmentMetadata {
@@ -147,8 +147,8 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
   }
 
   // metadata
-  generalMetadata(protectionType: string) {
-    const generalMetadata: IProtectionGeneralMetadata = {
+  generalMetadata(protectionType: string): IProtectionGeneralMetadata {
+    return {
       punishment: {
         type: {
           type: EInputType.list,
@@ -183,12 +183,10 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
         placeholder: this.placeholder(protectionType, 'message'),
       },
     };
-
-    return generalMetadata;
   }
 
-  advancedMetadata(protectionType: string) {
-    const advancedMetadata: IProtectionAdvancedMetadata = {
+  advancedMetadata(protectionType: string): IProtectionAdvancedMetadata {
+    return {
       minimum: {
         required: true,
         type: EInputType.number,
@@ -213,11 +211,10 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
         tooltip: this.placeholder(protectionType, 'percent'),
       },
     };
-    return advancedMetadata;
   }
 
-  get linkCommandsMetadata() {
-    const linkCommandsMetadata: ILinkProtectionCommandsMetadata = {
+  get linkCommandsMetadata(): ILinkProtectionCommandsMetadata {
+    return {
       permit: {
         command: {
           required: true,
@@ -244,11 +241,10 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
         },
       },
     };
-    return linkCommandsMetadata;
   }
 
-  get wordBlacklistItemMetadata() {
-    const wordBlacklistItemMetadata: IWordProtectionBlacklistItem = {
+  get wordBlacklistItemMetadata(): IWordProtectionBlacklistItem {
+    return {
       text: {
         required: true,
         type: EInputType.text,
@@ -272,11 +268,10 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
         },
       },
     };
-    return wordBlacklistItemMetadata;
   }
 
-  get metadata() {
-    const metadata: IProtectionMetadata = {
+  get metadata(): IProtectionMetadata {
+    return {
       caps: {
         general: this.generalMetadata('caps'),
         advanced: this.advancedMetadata('caps'),
@@ -304,7 +299,6 @@ export default class ChatbotAlertsBase extends ChatbotWindowsBase {
         new_blacklist_item: this.wordBlacklistItemMetadata,
       },
     };
-    return metadata;
   }
 
   onResetSlugHandler(slug: ChatbotSettingSlug) {

--- a/app/components/page-components/Chatbot/windows/ChatbotCustomCommandWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotCustomCommandWindow.vue.ts
@@ -6,13 +6,13 @@ import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
 import { ITab } from 'components/Tabs.vue';
 import { $t } from 'services/i18n';
 
-import { ICustomCommand, IChatbotErrorResponse } from 'services/chatbot';
+import { IChatbotErrorResponse, ICustomCommand } from 'services/chatbot';
 
 import {
   EInputType,
   IListMetadata,
-  ITextMetadata,
   INumberMetadata,
+  ITextMetadata,
 } from 'components/shared/inputs';
 
 @Component({
@@ -84,31 +84,28 @@ export default class ChatbotCustomCommandWindow extends ChatbotWindowsBase {
     placeholder: $t('The phrase that will appear after a user enters the command'),
   };
 
-  get permissionMetadata() {
-    const permissionMetadata: IListMetadata<number> = {
+  get permissionMetadata(): IListMetadata<number> {
+    return {
       required: true,
       type: EInputType.list,
       options: this.chatbotPermissions,
     };
-    return permissionMetadata;
   }
 
-  get replyTypeMetadata() {
-    const replyTypeMetadata: IListMetadata<string> = {
+  get replyTypeMetadata(): IListMetadata<string> {
+    return {
       required: true,
       type: EInputType.list,
       options: this.chatbotResponseTypes,
     };
-    return replyTypeMetadata;
   }
 
-  get cooldownsMetadata() {
-    const timerMetadata: INumberMetadata = {
+  get cooldownsMetadata(): INumberMetadata {
+    return {
       type: EInputType.number,
       placeholder: $t('Cooldown (Value in Seconds)'),
       min: 0,
     };
-    return timerMetadata;
   }
 
   onSelectTabHandler(tab: string) {

--- a/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
@@ -7,7 +7,7 @@ import ChatbotAliases from 'components/page-components/Chatbot/shared/ChatbotAli
 import { metadata as metadataHelper } from 'components/widgets/inputs';
 import { $t } from 'services/i18n';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
-import { IListMetadata, ITextMetadata, EInputType } from 'components/shared/inputs';
+import { EInputType, IListMetadata } from 'components/shared/inputs';
 
 @Component({
   components: {
@@ -151,12 +151,11 @@ export default class ChatbotDefaultCommandWindow extends ChatbotWindowsBase {
     };
   }
 
-  get responseTypeMetadata() {
-    const responseTypeMetadata: IListMetadata<string> = {
+  get responseTypeMetadata(): IListMetadata<string> {
+    return {
       type: EInputType.list,
       options: this.chatbotResponseTypes,
     };
-    return responseTypeMetadata;
   }
 
   // methods

--- a/app/components/page-components/Chatbot/windows/ChatbotNewAlertModalWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotNewAlertModalWindow.vue.ts
@@ -194,8 +194,8 @@ export default class ChatbotNewAlertModalWindow extends ChatbotAlertsBase {
     return amount === null || !message;
   }
 
-  get metadata() {
-    const metadata: INewAlertMetadata = {
+  get metadata(): INewAlertMetadata {
+    return {
       follow: {
         newMessage: {
           message: {
@@ -346,11 +346,10 @@ export default class ChatbotNewAlertModalWindow extends ChatbotAlertsBase {
         },
       },
     };
-    return metadata;
   }
 
-  get initialNewAlertState() {
-    const initialState: INewAlertData = {
+  get initialNewAlertState(): INewAlertData {
+    return {
       follow: {
         newMessage: {
           message: null,
@@ -408,7 +407,6 @@ export default class ChatbotNewAlertModalWindow extends ChatbotAlertsBase {
         },
       },
     };
-    return initialState;
   }
 
   bindOnSubmitAndCheckIfEdited(event: any) {

--- a/app/components/page-components/Chatbot/windows/ChatbotWordProtectionList.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotWordProtectionList.vue.ts
@@ -2,11 +2,11 @@ import { Component, Prop } from 'vue-property-decorator';
 import ChatbotBase from 'components/page-components/Chatbot/ChatbotBase.vue';
 
 import {
+  EInputType,
   IInputMetadata,
-  ITextMetadata,
   IListMetadata,
   INumberMetadata,
-  EInputType,
+  ITextMetadata,
 } from '../../../shared/inputs';
 
 import { IWordProtectionBlackListItem, NEW_WORD_PROTECTION_LIST_MODAL_ID } from 'services/chatbot';
@@ -35,14 +35,7 @@ export default class ChatbotLinkProtectionList extends ChatbotBase {
   editIndex: number = -1;
 
   get metadata() {
-    const metadata: {
-      text: ITextMetadata;
-      punishment: {
-        duration: INumberMetadata;
-        type: IListMetadata<string>;
-      };
-      is_regex: IInputMetadata;
-    } = {
+    return {
       text: {
         required: true,
         type: EInputType.text,
@@ -67,7 +60,6 @@ export default class ChatbotLinkProtectionList extends ChatbotBase {
         title: 'This word / phrase contains a regular expression.',
       },
     };
-    return metadata;
   }
 
   get NEW_WORD_PROTECTION_LIST_MODAL_ID() {

--- a/app/services/media-backup.ts
+++ b/app/services/media-backup.ts
@@ -1,4 +1,4 @@
-import { StatefulService, mutation } from 'services/stateful-service';
+import { mutation, StatefulService } from 'services/stateful-service';
 import path from 'path';
 import fs from 'fs';
 import request from 'request';
@@ -142,8 +142,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
     }
 
     if (this.validateSyncLock(localId, syncLock)) {
-      const serverId = data.id;
-      file.serverId = serverId;
+      file.serverId = data.id;
       file.status = EMediaFileStatus.Synced;
       this.UPDATE_FILE(localId, file);
       return file;
@@ -255,7 +254,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
       file,
     };
 
-    const data = await new Promise<{ id: number }>((resolve, reject) => {
+    return await new Promise<{ id: number }>((resolve, reject) => {
       const req = request.post(
         {
           formData,
@@ -271,8 +270,6 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
         },
       );
     });
-
-    return data;
   }
 
   private getFileData(id: number) {

--- a/app/services/media-gallery/media-gallery.ts
+++ b/app/services/media-gallery/media-gallery.ts
@@ -173,14 +173,13 @@ export class MediaGalleryService extends Service {
   private async fetchFileLimits(): Promise<IMediaGalleryLimits> {
     const req = this.formRequest('api/v5/slobs/user/filelimits');
     try {
-      const fileSize = await fetch(req).then((rawRes: any) => {
+      return await fetch(req).then((rawRes: any) => {
         const resp = rawRes.json();
         return {
           maxUsage: resp.body.max_allowed_upload_usage,
           maxFileSize: resp.body.max_allowed_upload_fize_size,
         };
       });
-      return fileSize;
     } catch (e) {
       return {
         maxUsage: DEFAULT_MAX_USAGE,

--- a/app/services/platform-apps/api/modules/display.ts
+++ b/app/services/platform-apps/api/modules/display.ts
@@ -1,4 +1,4 @@
-import { Module, apiMethod, EApiPermissions, IApiContext } from './module';
+import { apiMethod, EApiPermissions, IApiContext, Module } from './module';
 import { Display } from 'services/video';
 import uuid from 'uuid/v4';
 import electron from 'electron';
@@ -48,15 +48,13 @@ export class DisplayModule extends Module {
       webviewPosition: { x: 0, y: 0 },
     };
 
-    const sub = ctx.webviewTransform.subscribe(transform => {
+    this.displays[displayId].webviewSubscription = ctx.webviewTransform.subscribe(transform => {
       const displayEntry = this.displays[displayId];
       displayEntry.webviewVisible = transform.visible;
       displayEntry.webviewPosition = transform.pos;
 
       this.updateDisplay(displayEntry);
     });
-
-    this.displays[displayId].webviewSubscription = sub;
 
     electron.remote.webContents.fromId(ctx.webContentsId).on('destroyed', () => {
       this.destroyDisplay(displayId);

--- a/app/services/platform-apps/api/modules/scenes.ts
+++ b/app/services/platform-apps/api/modules/scenes.ts
@@ -1,12 +1,12 @@
 import {
-  Module,
-  EApiPermissions,
-  apiMethod,
   apiEvent,
-  NotImplementedError,
+  apiMethod,
+  EApiPermissions,
   IApiContext,
+  Module,
+  NotImplementedError,
 } from './module';
-import { ScenesService, Scene, TSceneNode } from 'services/scenes';
+import { Scene, ScenesService, TSceneNode } from 'services/scenes';
 import { Inject } from 'util/injector';
 import { Subject } from 'rxjs';
 
@@ -164,26 +164,22 @@ export class ScenesModule extends Module {
 
   private serializeNode(node: TSceneNode) {
     if (node.isFolder()) {
-      const folder: ISceneItemFolder = {
+      return {
         id: node.id,
         type: ESceneNodeType.Folder,
         name: node.name,
         childrenIds: node.childrenIds,
-      };
-
-      return folder;
+      } as ISceneItemFolder;
       // tslint:disable-next-line:no-else-after-return TODO
     } else if (node.isItem()) {
-      const item: ISceneItem = {
+      return {
         id: node.id,
         type: ESceneNodeType.SceneItem,
         sourceId: node.sourceId,
         visible: node.visible,
         locked: node.locked,
         transform: node.transform,
-      };
-
-      return item;
+      } as ISceneItem;
     }
   }
 }

--- a/app/services/scene-collections/nodes/overlays/text.ts
+++ b/app/services/scene-collections/nodes/overlays/text.ts
@@ -2,8 +2,6 @@ import { Node } from '../node';
 import { SceneItem } from 'services/scenes';
 import { FontLibraryService } from 'services/font-library';
 import { Inject } from 'util/injector';
-import * as fi from 'node-fontinfo';
-import { EFontStyle } from 'obs-studio-node';
 import path from 'path';
 
 interface ISchema {
@@ -27,8 +25,7 @@ export class TextNode extends Node<ISchema, IContext> {
     // storing a full path that could possibly leak information
     // about a person's computer.
     if (settings['custom_font']) {
-      const file = path.parse(settings['custom_font']).base;
-      settings['custom_font'] = file;
+      settings['custom_font'] = path.parse(settings['custom_font']).base;
     }
 
     settings['file'] = '';

--- a/app/services/scene-collections/nodes/overlays/transition.ts
+++ b/app/services/scene-collections/nodes/overlays/transition.ts
@@ -1,5 +1,5 @@
 import { Node } from '../node';
-import { TransitionsService, ETransitionType } from 'services/transitions';
+import { ETransitionType, TransitionsService } from 'services/transitions';
 import { Inject } from 'util/injector';
 import { uniqueId } from 'lodash';
 import path from 'path';
@@ -56,8 +56,7 @@ export class TransitionNode extends Node<ISchema, IContext> {
     this.transitionsService.deleteAllTransitions();
 
     if (this.data.type === 'obs_stinger_transition') {
-      const filePath = path.join(context.assetsPath, this.data.settings.path);
-      this.data.settings.path = filePath;
+      this.data.settings.path = path.join(context.assetsPath, this.data.settings.path);
     }
 
     this.transitionsService.createTransition(this.data.type, 'Global Transition', {

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -1,14 +1,9 @@
-import { StatefulService, mutation } from 'services/stateful-service';
-import {
-  ISceneCollectionsManifestEntry,
-  ISceneCollectionSchema,
-  ISceneCollectionsServiceApi,
-} from '.';
+import { mutation, StatefulService } from 'services/stateful-service';
+import { ISceneCollectionsManifestEntry } from '.';
 import Vue from 'vue';
 import fs from 'fs';
 import path from 'path';
 import electron from 'electron';
-import { ISceneCollectionsResponse } from './server-api';
 import { FileManagerService } from 'services/file-manager';
 import { Inject } from 'util/injector';
 
@@ -75,7 +70,7 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
     if (!Array.isArray(obj.collections)) return;
 
     // Filter out collections we can't recover, and fix ones we can
-    const filtered = obj.collections.filter(coll => {
+    obj.collections = obj.collections.filter(coll => {
       // If there is no id, this is unrecoverable
       if (coll.id == null) return false;
 
@@ -86,7 +81,6 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
       return true;
     });
 
-    obj.collections = filtered;
     return obj;
   }
 

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -1,16 +1,16 @@
 import { uniq } from 'lodash';
 import electron from 'electron';
-import { mutation, StatefulService, ServiceHelper } from 'services/stateful-service';
+import { mutation, ServiceHelper, StatefulService } from 'services/stateful-service';
 import {
+  IPartialTransform,
+  ISceneItem,
+  ISceneItemNode,
+  ISceneItemSettings,
   Scene,
   SceneItem,
-  ScenesService,
-  ISceneItem,
-  ISceneItemSettings,
-  IPartialTransform,
-  TSceneNode,
-  ISceneItemNode,
   SceneItemFolder,
+  ScenesService,
+  TSceneNode,
   TSceneNodeModel,
 } from 'services/scenes';
 import { $t } from 'services/i18n';
@@ -512,8 +512,7 @@ export class Selection implements ISelection {
     const selectedNodes = this.getRootNodes();
     const nodesFolders = selectedNodes.map(node => node.parentId || null);
     const nodesHaveTheSameParent = uniq(nodesFolders).length === 1;
-    const canGroupIntoFolder = selectedNodes.length > 1 && nodesHaveTheSameParent;
-    return canGroupIntoFolder;
+    return selectedNodes.length > 1 && nodesHaveTheSameParent;
   }
 
   getSources(): Source[] {

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -2,8 +2,8 @@ import { Service } from 'services/service';
 import { UserService } from 'services/user';
 import { Inject } from 'util/injector';
 import { HostsService } from 'services/hosts';
-import { handleResponse, authorizedHeaders } from 'util/requests';
-import { WebsocketService, TSocketEvent } from 'services/websocket';
+import { authorizedHeaders, handleResponse } from 'util/requests';
+import { TSocketEvent, WebsocketService } from 'services/websocket';
 import uuid from 'uuid/v4';
 import fs from 'fs';
 import path from 'path';
@@ -153,13 +153,11 @@ export class StreamlabelsService extends Service {
       this.writeFileForStat(statname);
     }
 
-    const subscription: IStreamlabelSubscription = {
+    return {
       statname,
       id: subscriptionId,
       path: this.getStreamlabelsPath(this.subscriptions[statname].filename),
     };
-
-    return subscription;
   }
 
   /**

--- a/test/helpers/form-monkey.ts
+++ b/test/helpers/form-monkey.ts
@@ -207,11 +207,10 @@ export class FormMonkey {
     await sleep(500); // slider has an initialization delay
 
     const dotSelector = `${sliderInputSelector} .vue-slider-dot`;
-    const sliderWidth = await this.client.getElementSize(
+    let moveOffset = await this.client.getElementSize(
       `${sliderInputSelector} .vue-slider-wrap`,
       'width',
     );
-    let moveOffset = sliderWidth;
 
     // reset slider to 0 position
     await this.client.moveToObject(dotSelector);

--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -124,11 +124,7 @@ async function checkChance(info, version) {
 
     log.info(`You rolled ${roll}`);
 
-    if (roll <= chance) {
-        return true;
-    }
-
-    return false;
+    return (roll <= chance);
 }
 
 /* Note that latest-updater.exe never changes


### PR DESCRIPTION
Inline variables. Specify return types explicitly in the cases where the variable seems to exist only to annotate. 
General idea: creating a variable and immediately returning it could be replaced by just returning its value.