### PR TITLE
refactor: remove self assignment

### DIFF
--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -47,7 +47,6 @@ export class ScenesService extends StatefulService<IScenesState> implements ISce
       nodes: [],
     });
     this.state.displayOrder.push(id);
-    this.state.activeSceneId = this.state.activeSceneId;
   }
 
   @mutation()


### PR DESCRIPTION
This variable assigns to itself. I can't think of any JavaScript magic that might make this to have an effect, to begin with. If it does, please review and let's make it more explicit as to why.