### PR TITLE
refactor: simplify conditionals

### DIFF
--- a/app/components/NotificationsArea.vue.ts
+++ b/app/components/NotificationsArea.vue.ts
@@ -48,11 +48,7 @@ export default class NotificationsArea extends Vue {
     this.sizeCheckIntervalId = window.setInterval(() => {
       if (!this.$refs.notificationsContainer) return;
 
-      if (this.$refs.notificationsContainer.offsetWidth < 150) {
-        this.showExtendedNotifications = false;
-      } else {
-        this.showExtendedNotifications = true;
-      }
+      this.showExtendedNotifications = this.$refs.notificationsContainer.offsetWidth >= 150;
     }, 1000);
   }
 

--- a/app/components/TopNav.vue.ts
+++ b/app/components/TopNav.vue.ts
@@ -162,10 +162,6 @@ export default class TopNav extends Vue {
   responsiveClass = false;
 
   handleResize() {
-    if (this.topNav.clientWidth < 1200) {
-      this.responsiveClass = true;
-    } else {
-      this.responsiveClass = false;
-    }
+    this.responsiveClass = this.topNav.clientWidth < 1200;
   }
 }

--- a/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsSystemFontSelector.vue.ts
@@ -160,13 +160,10 @@ export default class ObsSystemFontSelector extends ObsInput<IObsInput<IObsFont>>
   }
 
   get selectedFont() {
-    return _.find(this.selectedFamily.fonts, font => {
-      if (this.value.value.flags !== this.getFlagsFromFont(font)) {
-        return false;
-      }
-
-      return true;
-    });
+    return _.find(
+      this.selectedFamily.fonts,
+      font => this.value.value.flags === this.getFlagsFromFont(font),
+    );
   }
 
   get fontsByFamily() {

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -35,11 +35,7 @@ export default class Studio extends Vue {
       if (this.studioMode) {
         const rect = this.$refs.studioModeContainer.getBoundingClientRect();
 
-        if (rect.width / rect.height > 16 / 9) {
-          this.stacked = false;
-        } else {
-          this.stacked = true;
-        }
+        this.stacked = rect.width / rect.height <= 16 / 9;
       }
     }, 1000);
   }

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -95,11 +95,7 @@ export default class Main extends Vue {
   mainContentsRight = false;
 
   get leftDock() {
-    if (this.customizationService.state.leftDock) {
-      this.mainContentsRight = true;
-    } else {
-      this.mainContentsRight = false;
-    }
+    this.mainContentsRight = this.customizationService.state.leftDock;
     return this.customizationService.state.leftDock;
   }
 
@@ -178,18 +174,10 @@ export default class Main extends Vue {
   windowSizeHandler() {
     this.windowWidth = window.innerWidth;
 
-    if (this.windowWidth < 1100) {
-      this.hasLiveDock = false;
-    } else {
-      this.hasLiveDock = true;
-    }
+    this.hasLiveDock = this.windowWidth >= 1100;
   }
 
   handleResize() {
-    if (this.$refs.mainMiddle.clientWidth < 1200) {
-      this.compactView = true;
-    } else {
-      this.compactView = false;
-    }
+    this.compactView = this.$refs.mainMiddle.clientWidth < 1200;
   }
 }

--- a/app/components/windows/MediaGallery.vue.ts
+++ b/app/components/windows/MediaGallery.vue.ts
@@ -61,8 +61,7 @@ export default class MediaGallery extends Vue {
 
     return this.galleryInfo.files.filter(file => {
       if (this.category !== 'stock' && file.isStock) return false;
-      if (this.type && file.type !== this.type) return false;
-      return true;
+      return !(this.type && file.type !== this.type);
     });
   }
 

--- a/app/components/windows/SourcesShowcase.vue.ts
+++ b/app/components/windows/SourcesShowcase.vue.ts
@@ -145,8 +145,7 @@ export default class SourcesShowcase extends Vue {
       .getAvailableSourcesTypesList()
       .filter(type => {
         if (type.value === 'text_ft2_source') return false;
-        if (type.value === 'scene' && this.scenesService.scenes.length <= 1) return false;
-        return true;
+        return !(type.value === 'scene' && this.scenesService.scenes.length <= 1);
       })
       .map(listItem => {
         return {

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -124,11 +124,7 @@ export class ObsImporterService extends Service {
         this.importMixerSources(configJSON);
         this.importTransitions(configJSON);
 
-        if (this.scenesService.scenes.length === 0) {
-          return false;
-        }
-
-        return true;
+        return this.scenesService.scenes.length !== 0;
       },
     });
   }

--- a/app/services/onboarding.ts
+++ b/app/services/onboarding.ts
@@ -55,8 +55,7 @@ const ONBOARDING_STEPS: Dictionary<IOnboardingStep> = {
 
   ObsImport: {
     isEligible: service => {
-      if (service.options.isLogin) return false;
-      return true;
+      return !service.options.isLogin;
     },
     next: 'SelectWidgets',
   },
@@ -71,8 +70,7 @@ const ONBOARDING_STEPS: Dictionary<IOnboardingStep> = {
 
   OptimizeBrandDevice: {
     isEligible: service => {
-      if (service.options.isLogin) return false;
-      return true;
+      return !service.options.isLogin;
     },
     next: 'OptimizeA',
   },

--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -64,8 +64,7 @@ export class SourcesNode extends Node<ISchema, {}> {
       if (source.channel) return true;
 
       // prevent sources without linked sceneItems to be saved
-      if (!linkedSourcesIds.includes(source.sourceId)) return false;
-      return true;
+      return linkedSourcesIds.includes(source.sourceId);
     });
   }
 

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -828,8 +828,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
       const filtered = files.filter(file => {
         if (file.match(/\.bak$/)) return false;
         const name = file.replace(/\.[^/.]+$/, '');
-        if (!name) return false;
-        return true;
+        return !!name;
       });
 
       for (const file of filtered) {

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -148,11 +148,7 @@ export class SelectionService extends StatefulService<ISelectionState>
       .getObsScene()
       .getItems()
       .forEach(obsSceneItem => {
-        if (activeObsIds.includes(obsSceneItem.id)) {
-          obsSceneItem.selected = true;
-        } else {
-          obsSceneItem.selected = false;
-        }
+        obsSceneItem.selected = activeObsIds.includes(obsSceneItem.id);
       });
 
     this.updated.next(this.state);

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -115,13 +115,17 @@ export class SourceFiltersService extends Service {
       }
 
       /* We have either a video filter or source */
-      /* Can't apply asynchronous video filters to non-asynchronous video souces. */
+      /* Can't apply asynchronous video filters to non-asynchronous video sources. */
       if (!source.async && filterType.async) {
         return false;
       }
 
       /* Video filters can be applied to video sources. */
-      return source.video && filterType.video;
+      if (source.video && filterType.video) {
+        return true;
+      }
+
+      return false;
     });
   }
 

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -121,11 +121,7 @@ export class SourceFiltersService extends Service {
       }
 
       /* Video filters can be applied to video sources. */
-      if (source.video && filterType.video) {
-        return true;
-      }
-
-      return false;
+      return source.video && filterType.video;
     });
   }
 

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -299,10 +299,7 @@ export class WidgetsService extends StatefulService<IWidgetSourcesState>
     widgetItem = scene.getItems().find(item => {
       const source = item.getSource();
       if (source.getPropertiesManagerType() !== 'widget') return false;
-      if (source.getPropertiesManagerSettings().widgetType !== widget.type) {
-        return false;
-      }
-      return true;
+      return source.getPropertiesManagerSettings().widgetType === widget.type;
     });
 
     // Otherwise, create a new one

--- a/app/util/DragHandler.ts
+++ b/app/util/DragHandler.ts
@@ -207,7 +207,11 @@ export class DragHandler {
       return false;
     }
 
-    return b.offset + b.length >= a.offset;
+    if (b.offset + b.length < a.offset) {
+      return false;
+    }
+
+    return true;
   }
 
   private getNearestEdgeDistance(sourceEdge: IEdge, targetEdges: IEdge[]) {

--- a/app/util/DragHandler.ts
+++ b/app/util/DragHandler.ts
@@ -207,11 +207,7 @@ export class DragHandler {
       return false;
     }
 
-    if (b.offset + b.length < a.offset) {
-      return false;
-    }
-
-    return true;
+    return b.offset + b.length >= a.offset;
   }
 
   private getNearestEdgeDistance(sourceEdge: IEdge, targetEdges: IEdge[]) {

--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -124,7 +124,7 @@ async function checkChance(info, version) {
 
     log.info(`You rolled ${roll}`);
 
-    return (roll <= chance);
+    return roll <= chance;
 }
 
 /* Note that latest-updater.exe never changes


### PR DESCRIPTION
Simplify conditionals across the code base. Includes, but not limited, to:

* Direct assignment instead of branch assignment.
* Return boolean expressions directly.
* No unnecessary `else` after return.