### PR TITLE
ci: use bare lint command for now

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ build: off
 install:
   - ps: Install-Product node 8 x64
   - yarn install --frozen-lockfile --check-files
-  - yarn lint:ci
+  - yarn lint
   - yarn compile:ci
 
 test_script:


### PR DESCRIPTION
Use bare lint as stderr output is not displaying for tslint on AppVeyor (might be some env var or term detection). We're not using the output file of results anyway, let's revisit if we do find a way to make these available on AppVeyor.