### PR TITLE
Add Mixer events to the AlertBox

### DIFF
--- a/app/services/widgets/settings/alert-box/alert-box-api.ts
+++ b/app/services/widgets/settings/alert-box/alert-box-api.ts
@@ -605,6 +605,12 @@ interface IAlertBoxTreatSettings {
   treat_variations: IAlertBoxVariation[];
 }
 
+export interface IAlertBoxMixerSettings
+  extends IAlertBoxFollowSettings,
+    IAlertBoxSubSettings,
+    IAlertBoxResubSettings,
+    IAlertBoxHostSettings {}
+
 export interface IAlertBoxApiSettings
   extends IAlertBoxGeneralSettings,
     IAlertBoxSubSettings,
@@ -624,7 +630,9 @@ export interface IAlertBoxApiSettings
     IAlertBoxGamewsipSettings,
     IAlertBoxJustGivingSettings,
     IAlertBoxPatreonSettings,
-    IAlertBoxTiltifySettings {}
+    IAlertBoxTiltifySettings {
+  mixer_account?: IAlertBoxMixerSettings;
+}
 
 // SLOBS GENERAL SETTINGS
 export interface IAlertBoxSetting {

--- a/app/services/widgets/settings/alert-box/alert-box-api.ts
+++ b/app/services/widgets/settings/alert-box/alert-box-api.ts
@@ -9,6 +9,9 @@ interface IAlertBoxGeneralSettings extends IWidgetSettings {
   prime_sub_enabled: boolean;
   moderation_delay: number;
   unlimited_media_moderation_delay: boolean;
+  automatically_reset_session: boolean;
+  censor_streamer_recent_events: boolean;
+  display_mtg_codes: boolean;
 
   // SHOW MESSAGES
   show_bits_message: boolean;

--- a/app/services/widgets/settings/alert-box/index.ts
+++ b/app/services/widgets/settings/alert-box/index.ts
@@ -361,14 +361,17 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
     return (
       this.userService.platform.type === 'mixer' &&
       (['follow', 'host', 'resub', 'sub'].includes(prefix) ||
-        ['auto_host_enabled', 'recent_events_host_min_viewer_count', 'show_resub_message'].includes(
-          key,
-        ))
+        [
+          'auto_host_enabled',
+          'recent_events_host_min_viewer_count',
+          'show_resub_message',
+          'background_color',
+        ].includes(key))
     );
   }
 
   private flattenSettings(settings: IAlertBoxSettings): IAlertBoxApiSettings {
-    const settingsObj = {} as IAlertBoxApiSettings;
+    const settingsObj = { mixer_account: {} } as IAlertBoxApiSettings;
     Object.keys(settings).forEach(setting => {
       const prefix = Object.keys(API_NAME_MAP).find(key => API_NAME_MAP[key] === setting);
       if (prefix && prefix !== 'resub') {
@@ -383,9 +386,6 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
             : this.unshapeVariation(defaultVariation, bitsPrefix);
         Object.keys(flattenedDefault).forEach(key => {
           if (this.isMixerKey(prefix, key)) {
-            if (!settingsObj.mixer_account) {
-              settingsObj.mixer_account = {} as IAlertBoxMixerSettings;
-            }
             settingsObj.mixer_account[key] = flattenedDefault[key];
           } else {
             settingsObj[key] = flattenedDefault[key];

--- a/app/services/widgets/settings/alert-box/index.ts
+++ b/app/services/widgets/settings/alert-box/index.ts
@@ -4,6 +4,7 @@ import { WIDGET_INITIAL_STATE } from '../widget-settings';
 import { InheritMutations } from 'services/stateful-service';
 import {
   IAlertBoxApiSettings,
+  IAlertBoxMixerSettings,
   IAlertBoxSetting,
   IAlertBoxSettings,
   IAlertBoxVariation,
@@ -134,7 +135,9 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
     type: WidgetType;
   }): IAlertBoxData {
     const { settings, ...rest } = data;
-    const newSettings = this.transformSettings(settings);
+    const newSettings = settings.mixer_account
+      ? this.transformSettings({ ...settings, ...settings.mixer_account })
+      : this.transformSettings(settings);
     return { ...rest, settings: newSettings };
   }
 
@@ -354,6 +357,16 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
     };
   }
 
+  private isMixerKey(prefix: string, key: string) {
+    return (
+      this.userService.platform.type === 'mixer' &&
+      (['follow', 'host', 'resub', 'sub'].includes(prefix) ||
+        ['auto_host_enabled', 'recent_events_host_min_viewer_count', 'show_resub_message'].includes(
+          key,
+        ))
+    );
+  }
+
   private flattenSettings(settings: IAlertBoxSettings): IAlertBoxApiSettings {
     const settingsObj = {} as IAlertBoxApiSettings;
     Object.keys(settings).forEach(setting => {
@@ -368,7 +381,16 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
           prefix === 'sub'
             ? this.unshapeSubs(defaultVariation)
             : this.unshapeVariation(defaultVariation, bitsPrefix);
-        Object.keys(flattenedDefault).forEach(key => (settingsObj[key] = flattenedDefault[key]));
+        Object.keys(flattenedDefault).forEach(key => {
+          if (this.isMixerKey(prefix, key)) {
+            if (!settingsObj.mixer_account) {
+              settingsObj.mixer_account = {} as IAlertBoxMixerSettings;
+            }
+            settingsObj.mixer_account[key] = flattenedDefault[key];
+          } else {
+            settingsObj[key] = flattenedDefault[key];
+          }
+        });
       } else if (prefix !== 'resub') {
         settingsObj[setting] = settings[setting];
       }

--- a/app/services/widgets/settings/alert-box/index.ts
+++ b/app/services/widgets/settings/alert-box/index.ts
@@ -357,21 +357,8 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
     };
   }
 
-  private isMixerKey(prefix: string, key: string) {
-    return (
-      this.userService.platform.type === 'mixer' &&
-      (['follow', 'host', 'resub', 'sub'].includes(prefix) ||
-        [
-          'auto_host_enabled',
-          'recent_events_host_min_viewer_count',
-          'show_resub_message',
-          'background_color',
-        ].includes(key))
-    );
-  }
-
   private flattenSettings(settings: IAlertBoxSettings): IAlertBoxApiSettings {
-    const settingsObj = { mixer_account: {} } as IAlertBoxApiSettings;
+    const settingsObj = {} as IAlertBoxApiSettings;
     Object.keys(settings).forEach(setting => {
       const prefix = Object.keys(API_NAME_MAP).find(key => API_NAME_MAP[key] === setting);
       if (prefix && prefix !== 'resub') {
@@ -385,11 +372,7 @@ export class AlertBoxService extends WidgetSettingsService<IAlertBoxData> {
             ? this.unshapeSubs(defaultVariation)
             : this.unshapeVariation(defaultVariation, bitsPrefix);
         Object.keys(flattenedDefault).forEach(key => {
-          if (this.isMixerKey(prefix, key)) {
-            settingsObj.mixer_account[key] = flattenedDefault[key];
-          } else {
-            settingsObj[key] = flattenedDefault[key];
-          }
+          settingsObj[key] = flattenedDefault[key];
         });
       } else if (prefix !== 'resub') {
         settingsObj[setting] = settings[setting];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "0.11.8",
+  "version": "0.11.9-preview.0",
   "main": "main.js",
   "engines": {
     "node": ">= 8 < 12",


### PR DESCRIPTION
mixer events are for some reason triaged under a `mixer_account` key in the fetch but the api expects a flat structure in the POST monkaS