### PR TITLE
Fixes for Intel 

### DIFF
--- a/app/services/auto-config/brand-device.ts
+++ b/app/services/auto-config/brand-device.ts
@@ -13,6 +13,7 @@ import { ScenesService } from '../scenes';
 import { IpcServerService } from '../ipc-server';
 import { AudioService } from '../audio';
 import { PrefabsService } from 'services/prefabs';
+import { UserService } from '../user';
 
 interface IBrandDeviceUrls {
   system_sku: string;
@@ -55,6 +56,7 @@ export class BrandDeviceService extends StatefulService<IBrandDeviceState> {
   @Inject() private audioService: AudioService;
   @Inject() private ipcServerService: IpcServerService;
   @Inject() private prefabsService: PrefabsService;
+  @Inject() private userService: UserService;
 
   serviceEnabled() {
     return true;
@@ -122,7 +124,8 @@ export class BrandDeviceService extends StatefulService<IBrandDeviceState> {
         await downloadFile(deviceUrls.record_encoder_url, `${cacheDir}/recordEncoder.json`);
       }
 
-      if (deviceUrls.overlay_url) {
+      // user have to be logged-in for correct widgets setup from the overlay file
+      if (deviceUrls.overlay_url && this.userService.isLoggedIn()) {
         const overlayPath = `${tempDir}/slobs-brand-device.overlay`;
         await downloadFile(deviceUrls.overlay_url, overlayPath);
         await this.sceneCollectionsService.loadOverlay(overlayPath, deviceName);

--- a/app/services/auto-config/brand-device.ts
+++ b/app/services/auto-config/brand-device.ts
@@ -4,16 +4,16 @@ import * as obs from '../../../obs-api';
 import { execSync } from 'child_process';
 import { mutation, StatefulService } from '../stateful-service';
 import { Inject } from '../../util/injector';
-import { HostsService } from '../hosts';
+import { HostsService } from 'services/hosts';
 import { InitAfter } from '../../util/service-observer';
 import { downloadFile } from '../../util/requests';
 import { AppService } from 'services/app';
 import { SceneCollectionsService } from 'services/scene-collections';
-import { ScenesService } from '../scenes';
-import { IpcServerService } from '../ipc-server';
-import { AudioService } from '../audio';
+import { ScenesService } from 'services/scenes';
+import { IpcServerService } from 'services/ipc-server';
+import { AudioService } from 'services/audio';
 import { PrefabsService } from 'services/prefabs';
-import { UserService } from '../user';
+import { UserService } from 'services/user';
 
 interface IBrandDeviceUrls {
   system_sku: string;

--- a/app/services/hardware/hardware.ts
+++ b/app/services/hardware/hardware.ts
@@ -33,6 +33,10 @@ export class HardwareService extends StatefulService<IHardwareServiceState> {
     return this.state.devices;
   }
 
+  getDshowDevice(id: string) {
+    return this.state.dshowDevices.find(device => device.id === id);
+  }
+
   getDeviceByName(name: string) {
     return this.state.devices.find(device => device.description === name);
   }

--- a/app/services/prefabs/prefabs.ts
+++ b/app/services/prefabs/prefabs.ts
@@ -2,12 +2,13 @@ import { PersistentStatefulService } from 'services/persistent-stateful-service'
 import { ISourceAddOptions, SourcesService, TSourceType, Source } from 'services/sources';
 import { ScenesService, TSceneNode, TSceneNodeType } from 'services/scenes';
 import { Inject } from '../../util/injector';
-import { mutation, ServiceHelper } from '../stateful-service';
+import { mutation, ServiceHelper } from 'services/stateful-service';
 import uuid from 'uuid/v4';
 import { TObsValue } from 'components/obs/inputs/ObsInput';
 import Utils from '../utils';
 import Vue from 'vue';
-import { HardwareService } from '../hardware';
+import { HardwareService } from 'services/hardware';
+
 interface IPrefabSourceCreateOptions {
   name: string;
   description?: string;


### PR DESCRIPTION
Fixes the issue when it's impossible to add multiple `CaptureCard` sources
Allow installing device overlay only for authorized users. Otherwise, widgets will not be correctly setup.