### PR TITLE
feat(troubleshooter): add control to start/stop streaming

### DIFF
--- a/app/components/windows/Troubleshooter.vue
+++ b/app/components/windows/Troubleshooter.vue
@@ -1,6 +1,7 @@
 <template>
 <modal-layout :showControls="false" :customControls="true">
   <div slot="controls">
+    <start-streaming-button v-if="issue.code === 'FRAMES_DROPPED'"></start-streaming-button>
     <button
         class="button button--action"
         @click="showSettings"
@@ -34,9 +35,9 @@
       </ul>
 
       <div class="inline-controls">
-        <p v-if="isStreaming">
+        <h4 v-if="isStreaming">
           {{ $t('Stop streaming to access these controls:')}}
-        </p>
+        </h4>
         <GenericFormGroups v-model="streamingSettings" @input="saveStreamingSettings" />
         <GenericFormGroups v-model="outputSettings" @input="saveOutputSettings" />
       </div>

--- a/app/components/windows/Troubleshooter.vue.ts
+++ b/app/components/windows/Troubleshooter.vue.ts
@@ -10,9 +10,10 @@ import { WindowsService } from 'services/windows';
 import { StreamingService } from 'services/streaming';
 import { TObsFormData } from '../obs/inputs/ObsInput';
 import GenericFormGroups from '../obs/inputs/GenericFormGroups.vue';
+import StartStreamingButton from '../StartStreamingButton.vue';
 
 @Component({
-  components: { ModalLayout, GenericFormGroups },
+  components: { ModalLayout, GenericFormGroups, StartStreamingButton },
 })
 export default class Troubleshooter extends Vue {
   @Inject() private notificationsService: INotificationsServiceApi;


### PR DESCRIPTION
In order to be able to change the settings inline while you're streaming we need to provide the ability to end the stream from the window itself, otherwise, the controls are useless unless the user is accessing the notification at a later time when they're offline.

This commit also adds emphasis to the message that the stream needs to be stopped to access these controls.