### PR TITLE
feat: use promises to catch updater spawn errors

### DIFF
--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -293,14 +293,11 @@ async function entry(info) {
     
     const updaterStartCommand = `start \"\"  \"${updaterPath}\" `  
     
-    updaterArgs.push('&& echo update_started_fine_app_can_be_closed');  
-
     log.info(updaterArgs);
 
     const update_spawned = cp.spawn(`${updaterStartCommand}`, updaterArgs, {
         cwd: info.tempDir,
         detached: false,
-        //stdio: 'ignore',
         shell: true
     });
     
@@ -315,21 +312,13 @@ async function entry(info) {
         update_spawned.on('error', resolve);
     });
     
-    const primiseDataError = new Promise(resolve => {
-        update_spawned.stderr.on('data', resolve);
-    });
-
-    const primiseDataOut = new Promise(resolve => {
-        update_spawned.stdout.on('data', resolve);
-    });
-
     //wait for something to happen
-    const promise = await Promise.race([primiseError, primiseExit, primiseDataOut, primiseDataError]); 
+    const promise = await Promise.race([primiseError, primiseExit]);  
     log.info('Updater spawn promise ' + `result \"${promise}\"`);
     
     update_spawned.unref();
 
-    if(`${promise}`.startsWith("update_started_fine_app_can_be_closed") )  //hardcoded string "update_started_fine_app_can_be_closed" 
+    if(`${promise}` == "0" ) 
     {
         return true;  
     } else {

--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -290,9 +290,9 @@ async function entry(info) {
         updaterArgs.push('-p');
         updaterArgs.push(statusWindow.webContents.getOSProcessId().toString());
     }
-    
-    const updaterStartCommand = `start \"\"  \"${updaterPath}\" `  
-    
+
+    const updaterStartCommand = `start \"\"  \"${updaterPath}\" `
+
     log.info(updaterArgs);
 
     const update_spawned = cp.spawn(`${updaterStartCommand}`, updaterArgs, {
@@ -300,8 +300,8 @@ async function entry(info) {
         detached: false,
         shell: true
     });
-    
-    log.info('updater process ' + `pid ${update_spawned.pid}`);  
+
+    log.info('updater process ' + `pid ${update_spawned.pid}`);
 
     //make promises for app exit , error , data and some timeout
     const primiseExit = new Promise(resolve => {
@@ -311,19 +311,14 @@ async function entry(info) {
     const primiseError = new Promise(resolve => {
         update_spawned.on('error', resolve);
     });
-    
+
     //wait for something to happen
-    const promise = await Promise.race([primiseError, primiseExit]);  
+    const promise = await Promise.race([primiseError, primiseExit]);
     log.info('Updater spawn promise ' + `result \"${promise}\"`);
-    
+
     update_spawned.unref();
 
-    if(`${promise}` == "0" ) 
-    {
-        return true;  
-    } else {
-        return false; 
-    }
+    return `${promise}` === "0";
 }
 
 module.exports = async (info) => {


### PR DESCRIPTION
What changed. 
1) Added promises to catch errors, and also to catch successful-ish updater start. 

2) Spawn now is not starting updater directly. It start windows shell command `start` which start updater asynchronously. And only after `start` success the second command will be called. It is 'echo' command what send text message which we catch with promise as sign of success. 

3) remove explicit set of `stdio` . To get message from running app we need default stdio configuration. 

4) `detached: true` changed to calling unref later.  

What fails of updater start was checked:
* UAC block( user cancel start of updater or permit it )
* non existing updater filename 
* user does not have rights to execute updater or access to folder with updater
* updater not an executable file( for example: from server was downloaded not an updater file but some 404 page file ) 

To make testing with different conditions more easily a test app was created: 
https://github.com/summeroff/spawn_catch_test

