### PR TITLE
fix(windows): avoid creating window bigger than current display res

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -203,6 +203,22 @@ export class WindowsService extends StatefulService<IWindowsState> {
     // This prevents "snapping" behavior when navigating settings
     if (options.componentName !== this.state.child.componentName) options.center = true;
 
+    // Override `options.size` when what is passed in is bigger than the current display
+    if (options.size) {
+      const { width: screenWidth, height: screenHeight } = electron.screen.getDisplayMatching(
+        this.windows.main.getBounds(),
+      ).workAreaSize;
+
+      const SCREEN_PERCENT = 0.75;
+
+      if (options.size.width > screenWidth || options.size.height > screenHeight) {
+        options.size = {
+          width: screenWidth * SCREEN_PERCENT,
+          height: screenHeight * SCREEN_PERCENT,
+        };
+      }
+    }
+
     ipcRenderer.send('window-showChildWindow', options);
     this.updateChildWindowOptions(options);
   }


### PR DESCRIPTION
Avoid creating a child window that is bigger than the current display's resolution. Tested on `1024x768`. 