### PR TITLE
style: disable no-boolean-literal-compare

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
     // TODO: fix instances instead
     "no-increment-decrement": false,
     // This is no longer required on refactor/mutation-names branch TODO: remove
-    "function-name": false
+    "function-name": false,
+    "no-boolean-literal-compare": false
   }
 }
 


### PR DESCRIPTION
Disable this rule to prevent regressions. Upon discussion, some booleans are overloaded, where `true`, `false`, and `undefined` account for different things, and falsy/truthy checks aren't enough.