### PR TITLE
fix(widgets): control bounds for Event List & Viewer Count font size

### DIFF
--- a/app/components/widgets/EventList.vue
+++ b/app/components/widgets/EventList.vue
@@ -19,7 +19,12 @@
   <validated-form slot="font-properties" @input="save()" v-if="loaded">
     <v-form-group :title="$t('Text Color')" type="color" v-model="wData.settings.text_color" :metadata="{ tooltip: textColorTooltip }" />
     <v-form-group :title="$t('Font')" type="fontFamily" v-model="wData.settings.font_family" :metadata="{ tooltip: fontFamilyTooltip }" />
-    <v-form-group :title="$t('Font Size')" type="fontSize" v-model="wData.settings.text_size" :metadata="{ tooltip: fontSizeTooltip }" />
+    <v-form-group
+      :title="$t('Font Size')"
+      type="fontSize"
+      v-model="wData.settings.text_size"
+      :metadata="{ tooltip: fontSizeTooltip, min: 10, max: 80 }"
+    />
   </validated-form>
 
   <validated-form slot="visual-properties" @input="save()" v-if="loaded">

--- a/app/components/widgets/ViewerCount.vue
+++ b/app/components/widgets/ViewerCount.vue
@@ -12,7 +12,7 @@
     <validated-form slot="font-properties" @input="save()" v-if="loaded">
       <v-form-group title="Font" type="fontFamily" v-model="wData.settings.font" :metadata="{ tooltip: fontFamilyTooltip }"/>
       <v-form-group title="Text Color" type="color" v-model="wData.settings.font_color"/>
-      <v-form-group title="Font Size" type="fontSize" v-model="wData.settings.font_size"/>
+      <v-form-group title="Font Size" type="fontSize" v-model="wData.settings.font_size" :metadata="{ min: 10, max: 100 }" />
     </validated-form>
   </widget-editor>
 </template>


### PR DESCRIPTION
Prevent the user from being able to set a font size that's going to subsequently fail
validation. Controls now have min and max bounds, as follows:

* Event List: 10-80.
* Viewer Count: 10-100.