### PR TITLE
ci: upsource build status

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,10 @@
 build: off
 
 install:
+  # unfortunately, `commitId` in hooks is abbreviated and we can't work with that for Upsource
+  # set a custom message as the full commit ID. This *has* to be the first job given the way
+  # our service is designed, please don't move.
+  - ps: Add-AppveyorMessage $env:APPVEYOR_REPO_COMMIT
   - ps: Install-Product node 8 x64
   - yarn install --frozen-lockfile --check-files
   - yarn lint
@@ -23,6 +27,10 @@ test_script:
 notifications:
   - provider: GitHubPullRequest
     template: "{{#failed}}:x: build failed{{/failed}} {{#jobs}} {{#messages}} {{message}} {{/messages}} {{/jobs}}"
+  # Build status to Upsource
+  - provider: Webhook
+    url: https://n2svzw3n4f.execute-api.us-east-1.amazonaws.com/dev/hooks/appveyor
+    on_build_status_changed: true
 
 cache:
   - plugins


### PR DESCRIPTION
Allow AppVeyor to push build status to Upsource. We needed a custom integration as the payload customization is not enough due to various reasons, so we built a small service for that purpose.

See https://github.com/stream-labs/appveyor-to-upsource for details.

Screenshot (this also shows on commit list):

![capture](https://user-images.githubusercontent.com/133308/50939085-36176780-1430-11e9-97cb-591dfc26acd3.PNG)
