### PR TITLE
fix(styles): scene selector style

### DIFF
--- a/app/components/SceneSelector.vue
+++ b/app/components/SceneSelector.vue
@@ -80,5 +80,9 @@
 
 .scene-collections__dropdown {
   min-width: 200px;
+
+  & /deep/ .popper {
+    text-align: left;
+  }
 }
 </style>


### PR DESCRIPTION
`vue-popper` upgrade + added styles caused scenes in the Scene switcher popup to be centered.