### PR TITLE
feat(platform): download app assets to workaround OBS issues

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -99,6 +99,7 @@ import { MediaShareService } from 'services/widgets/settings/media-share';
 import { ChatbotWidgetService } from 'services/widgets/settings/chatbot';
 import { AlertBoxService } from 'services/widgets/settings/alert-box';
 import { SpinWheelService } from 'services/widgets/settings/spin-wheel';
+import { PlatformAppAssetsService } from 'services/platform-apps/platform-app-assets-service';
 
 const { ipcRenderer } = electron;
 
@@ -206,6 +207,7 @@ export class ServicesManager extends Service {
     HardwareService,
     PrefabsService,
     Prefab,
+    PlatformAppAssetsService,
   };
 
   private instances: Dictionary<Service> = {};

--- a/app/services/media-backup.ts
+++ b/app/services/media-backup.ts
@@ -2,12 +2,11 @@ import { mutation, StatefulService } from 'services/stateful-service';
 import path from 'path';
 import fs from 'fs';
 import request from 'request';
-import crypto from 'crypto';
 import { Inject } from 'util/injector';
 import { HostsService } from 'services/hosts';
 import { UserService } from 'services/user';
 import electron from 'electron';
-import { isUrl } from '../util/requests';
+import { getChecksum, isUrl } from 'util/requests';
 
 const uuid = window['require']('uuid/v4');
 
@@ -198,7 +197,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
         let checksum: string;
 
         try {
-          checksum = await this.withRetry(() => this.getChecksum(fileToCheck));
+          checksum = await this.withRetry(() => getChecksum(fileToCheck));
         } catch (e) {
           // This is not a fatal error, we can download a new copy
           console.warn(`[Media Backup] Error calculating checksum: ${e}`);
@@ -246,7 +245,7 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
   }
 
   private async uploadFile(filePath: string) {
-    const checksum = await this.getChecksum(filePath);
+    const checksum = await getChecksum(filePath);
     const file = fs.createReadStream(filePath);
 
     const formData = {
@@ -288,17 +287,6 @@ export class MediaBackupService extends StatefulService<IMediaBackupState> {
           }
         },
       );
-    });
-  }
-
-  private getChecksum(filePath: string) {
-    return new Promise<string>((resolve, reject) => {
-      const file = fs.createReadStream(filePath);
-      const hash = crypto.createHash('md5');
-
-      file.on('data', data => hash.update(data));
-      file.on('end', () => resolve(hash.digest('hex')));
-      file.on('error', e => reject(e));
     });
   }
 

--- a/app/services/platform-apps/api/modules/scene-transitions.ts
+++ b/app/services/platform-apps/api/modules/scene-transitions.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'path';
 import { getType } from 'mime';
 import { apiMethod, EApiPermissions, IApiContext, Module } from './module';
 import {
@@ -8,6 +8,7 @@ import {
 } from 'services/transitions';
 import { Inject } from 'util/injector';
 import { PlatformAppsService } from '../../index';
+import { PlatformAppAssetsService } from 'services/platform-apps/platform-app-assets-service';
 
 type AudioFadeStyle = 'fadeOut' | 'crossFade';
 
@@ -81,9 +82,11 @@ export class SceneTransitionsModule extends Module {
 
   permissions = [EApiPermissions.SceneTransitions];
 
-  @Inject() transitionsService: TransitionsService;
+  @Inject() private transitionsService: TransitionsService;
 
-  @Inject() platformAppsService: PlatformAppsService;
+  @Inject() private platformAppsService: PlatformAppsService;
+
+  @Inject() private platformAppAssetsService: PlatformAppAssetsService;
 
   /**
    * Create a scene transition
@@ -101,10 +104,15 @@ export class SceneTransitionsModule extends Module {
   async createTransition(ctx: IApiContext, options: TransitionOptions): Promise<ITransition> {
     if (options.type === 'stinger') {
       const appId = ctx.app.id;
-      const { url } = options;
+      const { url: originalUrl } = options;
 
-      if (!this.isVideo(url)) {
+      if (!this.isVideo(originalUrl)) {
         throw new Error('Invalid file specified, you must provide a video file.');
+      }
+
+      if (!this.platformAppAssetsService.hasAsset(appId, originalUrl)) {
+        // TODO: avoid mutation
+        options.url = await this.platformAppAssetsService.addPlatformAppAsset(appId, originalUrl);
       }
 
       const { shouldLock = false, name, ...settings } = options;
@@ -114,11 +122,21 @@ export class SceneTransitionsModule extends Module {
         ...settings,
       } as TransitionOptions);
 
-      return this.transitionsService.createTransition(
+      const transition = this.transitionsService.createTransition(
         ETransitionType.Stinger,
         name,
         transitionOptions,
       );
+
+      this.platformAppAssetsService.linkAsset(
+        appId,
+        options.url,
+        originalUrl,
+        'transition',
+        transition.id,
+      );
+
+      return transition;
     }
 
     throw new Error('Not Implemented');
@@ -271,7 +289,7 @@ export class SceneTransitionsModule extends Module {
       },
       settings: {
         ...settings,
-        path: this.platformAppsService.getAssetUrl(appId, options.url),
+        path: options.url,
       },
     };
   }

--- a/app/services/platform-apps/platform-app-assets-service.ts
+++ b/app/services/platform-apps/platform-app-assets-service.ts
@@ -1,0 +1,294 @@
+import Vue from 'vue';
+import electron from 'electron';
+import path from 'path';
+import util from 'util';
+import mkdirpModule from 'mkdirp';
+import { tmpdir } from 'os';
+import fs from 'fs';
+import { mutation } from '../stateful-service';
+import { PersistentStatefulService } from '../persistent-stateful-service';
+import { ILoadedApp, PlatformAppsService } from './index';
+import { TransitionsService } from '../transitions';
+import { Inject } from 'util/injector';
+import { downloadFileAlt, getChecksum } from 'util/requests';
+import { InitAfter } from 'util/service-observer';
+
+const mkdirp = util.promisify(mkdirpModule);
+const mkdtemp = util.promisify(fs.mkdtemp);
+const copyFile = util.promisify(fs.copyFile);
+
+type Checksum = string;
+
+// prettier-ignore
+type ResourceType = |
+  'transition';
+
+/**
+ * Maintains a lookup table of asset filenames to checksum mappings, grouped by app ID.
+ *
+ * @see {AssetsMap}
+ */
+export interface AssetsServiceState {
+  [appId: string]: AssetsMap;
+}
+
+export interface AssetsMap {
+  // asset filename -> asset
+  [assetFilename: string]: Asset;
+}
+
+export interface Asset {
+  checksum: Checksum;
+  resourceId?: string;
+  resourceType?: ResourceType;
+  originalUrl?: string;
+}
+
+export interface AssetUpdateInfo extends Asset {
+  oldFile: string;
+  newFile: string;
+  newChecksum: string;
+  assetName: string;
+}
+
+/**
+ * Manage and download assets provided by platform apps.
+ *
+ * This is initially designed to download stinger transition files
+ */
+@InitAfter('PlatformAppsService')
+export class PlatformAppAssetsService extends PersistentStatefulService<AssetsServiceState> {
+  @Inject() private platformAppsService: PlatformAppsService;
+  @Inject() private transitionsService: TransitionsService;
+
+  static defaultState: AssetsServiceState = {};
+
+  init() {
+    super.init();
+
+    this.platformAppsService.appLoad.subscribe((app: ILoadedApp) => {
+      this.updateAppAssets(app.id);
+    });
+  }
+
+  /**
+   * Get a specific asset
+   *
+   * @param appId Application ID
+   * @param assetName Asset filename
+   */
+  getAsset(appId: string, assetName: string): Asset | null {
+    const appAssets = this.state[appId];
+
+    return appAssets ? appAssets[assetName] : null;
+  }
+
+  /**
+   * Returns whether we have downloaded an asset before
+   *
+   * @param appId Application ID
+   * @param assetName Asset filename
+   */
+  hasAsset(appId: string, assetName: string) {
+    return !!this.getAsset(appId, assetName);
+  }
+
+  /**
+   * Add a platform app asset, download and calculate checksum
+   *
+   * @param appId Application ID
+   * @param assetUrl Original asset URL
+   * @returns Path to the downloaded asset on disk
+   * @see {ADD_ASSET}
+   */
+  async addPlatformAppAsset(appId: string, assetUrl: string) {
+    const originalUrl = this.platformAppsService.getAssetUrl(appId, assetUrl);
+
+    const assetsDir = await this.getAssetsTargetDirectory(appId);
+    const filePath = path.join(assetsDir, path.basename(originalUrl));
+
+    await downloadFileAlt(originalUrl, filePath);
+
+    const checksum = await getChecksum(filePath);
+
+    this.ADD_ASSET(appId, assetUrl, checksum);
+
+    return filePath;
+  }
+
+  /**
+   * Update app assets
+   *
+   * Downloads every app asset to tmp, compares the checksums, and if changed
+   * unsets the resource where it's being used, prior to moving it to its original location
+   * and updating the checksum
+   *
+   * @param appId: Application ID
+   */
+  async updateAppAssets(appId: string) {
+    const assets = this.state[appId];
+    if (!assets) {
+      return;
+    }
+
+    const files = Object.keys(assets).map(assetName => {
+      const { checksum: oldChecksum, originalUrl } = assets[assetName];
+      return {
+        assetName,
+        oldChecksum,
+        originalUrl,
+      };
+    });
+
+    const tmpDir = await mkdtemp(path.join(tmpdir(), `slobs-${appId}-`));
+
+    const assetsToUpdate = await Promise.all(
+      files.map(async asset => {
+        const tmpFile = path.join(tmpDir, asset.assetName);
+
+        await downloadFileAlt(asset.originalUrl, tmpFile);
+
+        return {
+          ...assets[asset.assetName],
+          assetName: asset.assetName,
+          newChecksum: await getChecksum(tmpFile),
+          oldFile: path.join(await this.getAssetsTargetDirectory(appId), asset.assetName),
+          newFile: tmpFile,
+        };
+      }),
+    ).then(([...assets]) => assets.filter(asset => asset.checksum !== asset.newChecksum));
+
+    assetsToUpdate.forEach(async asset => {
+      await this.updateAssetResource(appId, asset);
+    });
+  }
+
+  /**
+   * Get the directory where we should place downloaded files for this app
+   *
+   * @param appId Application ID
+   */
+  async getAssetsTargetDirectory(appId: string): Promise<string> {
+    return ensureAssetsDir(this.getApp(appId));
+  }
+
+  /**
+   * Associate an asset with a resource (such as a transition)
+   *
+   * @param appId Application ID
+   * @param assetUrl The asset name
+   * @param originalUrl The original relative url
+   * @param resourceType Type of resource, currently only transitions supported
+   * @param resourceId ID of the resource
+   * @see {LINK_ASSET}
+   */
+  linkAsset(
+    appId: string,
+    assetUrl: string,
+    originalUrl: string,
+    resourceType: ResourceType,
+    resourceId: string,
+  ): void {
+    this.LINK_ASSET(
+      appId,
+      assetUrl,
+      this.platformAppsService.getAssetUrl(appId, originalUrl),
+      resourceType,
+      resourceId,
+    );
+  }
+
+  @mutation()
+  private ADD_ASSET(appId: string, assetName: string, checksum: string): void {
+    if (!this.state[appId]) {
+      Vue.set(this.state, appId, {});
+    }
+
+    Vue.set(this.state[appId], assetName, { checksum });
+  }
+
+  @mutation()
+  private LINK_ASSET(
+    appId: string,
+    assetUrl: string,
+    originalUrl: string,
+    resourceType: ResourceType,
+    resourceId: string,
+  ) {
+    const assetName = path.basename(assetUrl);
+    const asset = this.getAsset(appId, assetName);
+
+    if (asset) {
+      Vue.set(asset, 'resourceId', resourceId);
+      Vue.set(asset, 'resourceType', resourceType);
+      Vue.set(asset, 'originalUrl', originalUrl);
+    }
+  }
+
+  private updateChecksum(appId: string, assetName: string, checksum: Checksum) {
+    this.UPDATE_CHECKSUM(appId, assetName, checksum);
+  }
+
+  @mutation()
+  private UPDATE_CHECKSUM(appId: string, assetId: string, checksum: Checksum): void {
+    this.state[appId][assetId].checksum = checksum;
+  }
+
+  private getApp(appId: string): ILoadedApp {
+    const app = this.platformAppsService.getApp(appId);
+
+    if (!app) {
+      throw new Error(`Invalid app: ${appId}`);
+    }
+
+    return app;
+  }
+
+  /**
+   * Update an asset by releasing its resource, copying the file to the old location
+   * and updating the checksum
+   * @param appId Application ID
+   * @param asset Update information for the asset
+   */
+  private async updateAssetResource(appId: string, asset: AssetUpdateInfo) {
+    if (asset.resourceType !== 'transition') {
+      throw new Error('Not implemented');
+    }
+
+    this.updateTransitionPath(asset.resourceId, '');
+
+    await copyFile(asset.newFile, asset.oldFile);
+
+    this.updateTransitionPath(asset.resourceId, asset.oldFile);
+
+    this.updateChecksum(appId, asset.assetName, asset.newChecksum);
+  }
+
+  private updateTransitionPath(transitionId: string, path: string) {
+    const settings = this.transitionsService
+      .getPropertiesFormData(transitionId)
+      .map(setting => (setting.name === 'path' ? { ...setting, path } : setting));
+
+    this.transitionsService.setPropertiesFormData(transitionId, settings);
+  }
+}
+
+/**
+ * Ensure the App instance has an assets key and that the assets directory exist
+ *
+ * @param app App instance
+ * @returns Assets directory path for this app
+ */
+const ensureAssetsDir = async (app: ILoadedApp): Promise<string> => {
+  const appAssetsDir = path.join(
+    // prettier-ignore
+    electron.remote.app.getPath('userData'),
+    'Media',
+    'Apps',
+    app.id,
+  );
+
+  await mkdirp(appAssetsDir);
+
+  return appAssetsDir;
+};

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/humps": "^1.1.2",
     "@types/lodash": "4.14.115",
     "@types/mime": "^2.0.0",
+    "@types/mkdirp": "^0.5.2",
     "@types/node": "8.10.23",
     "@types/request": "2.47.1",
     "@types/socket.io-client": "1.4.32",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mkdirp@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"
+  integrity sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node@*":
   version "8.0.48"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.48.tgz#4e7da6e849d9e50be5865effaa55b1870ae4eede"


### PR DESCRIPTION
Download platform app assets to workaround OBS issues when using URLs directly (i.e stinger transitions).

Download location is `<SLOBS Cache Dir>/Media/Apps/<App ID>`. 

On app load, we check asset checksums to figure out if they've changed since the last time we copied them, if so, we download a temp file, workaround OBS locking by setting the resource owner's property to blank, and then overwrite the previous file.