### PR TITLE
Setup Sentry as the target for crashes

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -48,10 +48,10 @@ if (isProduction) {
   electron.crashReporter.start({
     productName: 'streamlabs-obs',
     companyName: 'streamlabs',
+    ignoreSystemCrashHandler: true,
     submitURL:
-      'https://streamlabs.sp.backtrace.io:6098/post?' +
-      'format=minidump&' +
-      'token=e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
+      'https://sentry.io/api/1283430/minidump/' +
+      '?sentry_key=01fc20f909124c8499b4972e9a5253f2',
     extra: {
       version: slobsVersion,
       processType: 'renderer',

--- a/app/app.ts
+++ b/app/app.ts
@@ -50,8 +50,7 @@ if (isProduction) {
     companyName: 'streamlabs',
     ignoreSystemCrashHandler: true,
     submitURL:
-      'https://sentry.io/api/1283430/minidump/' +
-      '?sentry_key=01fc20f909124c8499b4972e9a5253f2',
+      'https://sentry.io/api/1283430/minidump/?sentry_key=01fc20f909124c8499b4972e9a5253f2',
     extra: {
       version: slobsVersion,
       processType: 'renderer',

--- a/main.js
+++ b/main.js
@@ -137,10 +137,10 @@ function startApp() {
     crashReporter.start({
       productName: 'streamlabs-obs',
       companyName: 'streamlabs',
+      ignoreSystemCrashHandler: true,
       submitURL:
-        'https://streamlabs.sp.backtrace.io:6098/post?' +
-        'format=minidump&' +
-        'token=e3f92ff3be69381afe2718f94c56da4644567935cc52dec601cf82b3f52a06ce',
+        'https://sentry.io/api/1283430/minidump/' +
+        '?sentry_key=01fc20f909124c8499b4972e9a5253f2',
       extra: {
         version: pjson.version,
         processType: 'main'


### PR DESCRIPTION
Basically a revert from https://github.com/stream-labs/streamlabs-obs/pull/928/files
This also applies for the `renderer` process (see `app.ts`)