### PR TITLE
Fix ViewerCount settings failing to save

### DIFF
--- a/app/components/widgets/ViewerCount.vue
+++ b/app/components/widgets/ViewerCount.vue
@@ -1,6 +1,6 @@
 <template>
 <widget-editor :navItems="navItems">
-    <validated-form slot="manage-count-properties" @input="save()" v-if="loaded">
+    <validated-form slot="manage-count-properties" @input="save()" v-if="loaded" key="manage-count-properties">
       <v-form-group title="Enabled Streams">
         <bool-input title="Twitch Viewers" v-model="wData.settings.twitch "/>
         <bool-input title="Youtube Viewers" v-model="wData.settings.youtube"/>
@@ -9,7 +9,7 @@
       <v-form-group title="Background Color" type="color" v-model="wData.settings.background_color" />
     </validated-form>
 
-    <validated-form slot="font-properties" @input="save()" v-if="loaded">
+    <validated-form slot="font-properties" @input="save()" v-if="loaded" key="font-properties">
       <v-form-group title="Font" type="fontFamily" v-model="wData.settings.font" :metadata="{ tooltip: fontFamilyTooltip }"/>
       <v-form-group title="Text Color" type="color" v-model="wData.settings.font_color"/>
       <v-form-group title="Font Size" type="fontSize" v-model="wData.settings.font_size" :metadata="{ min: 10, max: 100 }" />

--- a/app/services/widgets/settings/viewer-count.ts
+++ b/app/services/widgets/settings/viewer-count.ts
@@ -56,6 +56,7 @@ export class ViewerCountService extends WidgetSettingsService<IViewerCountData> 
         mixer: { enabled: settings.mixer },
         twitch: { enabled: settings.twitch },
       },
+      font_size: settings.font_size.replace(/\D/g, ''),
     };
   }
 }


### PR DESCRIPTION
This is a bandaid but I really can't tell where we're appending `px` to the font_size property at all... I have a sneaking suspicion that the site API might be doing it