### PR TITLE
Fix allowing empty on lists

### DIFF
--- a/app/components/shared/inputs/ListInput.vue.ts
+++ b/app/components/shared/inputs/ListInput.vue.ts
@@ -47,6 +47,7 @@ export default class ListInput extends BaseInput<string, IListMetadata<string>> 
     });
 
     if (option) return option;
+    if (!!this.getOptions().allowEmpty) return null;
     return options[0];
   }
 


### PR DESCRIPTION
No longer defaults to first option if allowEmpty is true