### PR TITLE
Fix input margins and alignment

### DIFF
--- a/app/components/obs/inputs/ObsBitMaskInput.vue
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue
@@ -1,30 +1,31 @@
 <template>
-<div class="input-container" :class="{disabled: value.enabled === false}">
-  <div class="input-label" v-if="value.showDescription !== false"></div>
-  <div class="input-wrapper">
-    <div v-for="(flag, index) in flags" class="checkbox">
-      <input
-        type="checkbox"
-        :checked="flag"
-        :disabled="value.enabled == false"
-        @change="event => onChangeHandler(index, !!event.target['checked'])"
-      />
-      <label>{{ index + 1 }}</label>
-    </div>
+<h-form-group>
+  <div class="row">
+    <bool-input
+      v-for="(flag, index) in flags"
+      :key="index"
+      :value="flag"
+      :disabled="value.enabled == false"
+      @input="value => onChangeHandler(index, !!value)"
+      :title="index + 1"
+    />
   </div>
-</div>
+</h-form-group>
 </template>
 
 <script lang="ts" src="./ObsBitMaskInput.vue.ts"></script>
 
 <style lang="less" scoped>
-
-  .input-wrapper {
-    width: auto;
+  .row {
+    margin-bottom: 0;
   }
 
-  .checkbox {
+  .row > div {
     width: auto;
     margin-right: 15px;
+
+    /deep/ .checkbox {
+      margin-bottom: 0;
+    }
   }
 </style>

--- a/app/components/obs/inputs/ObsBitMaskInput.vue.ts
+++ b/app/components/obs/inputs/ObsBitMaskInput.vue.ts
@@ -1,8 +1,10 @@
 import { Component, Prop, Watch } from 'vue-property-decorator';
 import { ObsInput, TObsType, IObsBitmaskInput } from './ObsInput';
-import { EBit, default as Utils } from '../../../services/utils';
+import { EBit, default as Utils } from 'services/utils';
+import HFormGroup from 'components/shared/inputs/HFormGroup.vue';
+import { BoolInput } from 'components/shared/inputs/inputs';
 
-@Component
+@Component({ components: { HFormGroup, BoolInput } })
 class ObsBitMaskInput extends ObsInput<IObsBitmaskInput> {
   static obsType: TObsType;
 

--- a/app/components/shared/inputs/BoolInput.vue
+++ b/app/components/shared/inputs/BoolInput.vue
@@ -6,7 +6,7 @@
         type="checkbox"
         :checked="value"
       />
-      <label>{{ options.title }}</label>
+      <label>{{ options.title || '&nbsp;' }}</label>
     </div>
   </div>
 <!-- </div> -->

--- a/app/components/shared/inputs/HFormGroup.vue
+++ b/app/components/shared/inputs/HFormGroup.vue
@@ -18,7 +18,7 @@
         </div>
       </div>
 
-      <div class="input-footer">
+      <div class="input-footer" v-if="options.description || inputErrors.length">
         <div class="whisper" v-if="options.description && !inputErrors.length">
           {{ options.description }}
         </div>

--- a/app/components/windows/AdvancedAudio.vue
+++ b/app/components/windows/AdvancedAudio.vue
@@ -25,12 +25,14 @@
           :key="`${audioSource.name}${formInput.name}`"
           :class="'column-' + formInput.name"
         >
-          <component
-              v-if="propertyComponentForType(formInput.type)"
-              :is="propertyComponentForType(formInput.type)"
-              :value="formInput"
-              @input="value => onInputHandler(audioSource, formInput.name, value.value)"
-          />
+          <div class="advanced-audio-input">
+            <component
+                v-if="propertyComponentForType(formInput.type)"
+                :is="propertyComponentForType(formInput.type)"
+                :value="formInput"
+                @input="value => onInputHandler(audioSource, formInput.name, value.value)"
+            />
+          </div>
         </td>
       </tr>
 
@@ -55,6 +57,15 @@ tr {
     &:nth-child(1) {
       white-space: nowrap;
     }
+  }
+}
+
+.advanced-audio-input {
+  .alignable-input {
+    margin-bottom: 0;
+  }
+  .alignable-input /deep/ .input-body {
+    width: 100%;
   }
 }
 </style>

--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -166,7 +166,7 @@ export class AudioService extends StatefulService<IAudioSourcesState> implements
       componentName: 'AdvancedAudio',
       title: $t('Advanced Audio Settings'),
       size: {
-        width: 1200,
+        width: 1295,
         height: 600,
       },
     });


### PR DESCRIPTION
Some inputs were misaligned in the audio settings and ghost elements in the form group were spacing things much more than necessary or expected

Also migrates ObsBitMaskInput as a wrapper, i know using index as a key is not reliable but I don't see an alternative here as each value of the array is a boolean

before
![image](https://user-images.githubusercontent.com/20602520/51634383-fa3cd180-1f08-11e9-8964-627c67232f7b.png)

after
![image](https://user-images.githubusercontent.com/20602520/51634527-4e47b600-1f09-11e9-959c-7c845f293e23.png)
