### PR TITLE
fix(settings): show cache dir opens actual directory

### DIFF
--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -35,7 +35,7 @@ export default class ExtraSettings extends Vue {
   }
 
   showCacheDir() {
-    electron.remote.shell.showItemInFolder(electron.remote.app.getPath('userData'));
+    electron.remote.shell.openItem(electron.remote.app.getPath('userData'));
   }
 
   deleteCacheDir() {


### PR DESCRIPTION
Instead of opening `%APPDATA%` and highlighting the `slobs-client` directory, this change actually opens the folder with the default file manager, which should help with UX and bug reports/support.