### PR TITLE
chore(onboarding): use generic msg as we support more services #trivial

### DIFF
--- a/app/components/pages/onboarding_steps/Connect.vue
+++ b/app/components/pages/onboarding_steps/Connect.vue
@@ -8,7 +8,7 @@
         {{ $t('We are improving our backend systems. As part of the migration process, we will need to you log in again. If you have any questions, you can') }}
         <a @click="contactSupport">$t('contact support.')</a>
       </div>
-      <div class="onboarding-desc" v-else>{{ $t('Sign in with your Twitch or Youtube account to get started with Streamlabs') }}</div>
+      <div class="onboarding-desc" v-else>{{ $t('Sign in with your streaming account to get started with Streamlabs') }}</div>
       <div class="signup-buttons">
         <button
           class="button button--twitch"

--- a/app/i18n/en-US/onboarding.json
+++ b/app/i18n/en-US/onboarding.json
@@ -1,7 +1,7 @@
 {
   "We are improving our backend systems. As part of the migration process, we will need to you log in again. If you have any questions, you can": "We are improving our backend systems. As part of the migration process, we will need to you log in again. If you have any questions, you can",
   "contact support.": "contact support.",
-  "Sign in with your Twitch or Youtube account to get started with Streamlabs": "Sign in with your Twitch or Youtube account to get started with Streamlabs",
+  "Sign in with your streaming account to get started with Streamlabs": "Sign in with your streaming account to get started with Streamlabs",
   "Select an OBS profile to import": "Select an OBS profile to import",
   "Import from OBS": "Import from OBS",
   "Start Fresh": "Start Fresh",


### PR DESCRIPTION
Replaces the "Sign in with Twitch or Youtube account" with "Sign in with your service account".
Translations other than English would need updating. 