### PR TITLE
fix: multiple deletion message

### DIFF
--- a/app/i18n/en-US/scenes.json
+++ b/app/i18n/en-US/scenes.json
@@ -17,6 +17,7 @@
   "Create Output Projector": "Create Output Projector",
   "Studio Mode": "Studio Mode",
   "Are you sure you want to remove %{sceneName}?": "Are you sure you want to remove %{sceneName}?",
+  "Are you sure you want to remove these %{count} items?": "Are you sure you want to remove these %{count} items?",
   "Disable Performance Mode": "Disable Performance Mode",
   "Scene Collections": "Scene Collections",
   "The building blocks of your scene. Also contains widgets.": "The building blocks of your scene. Also contains widgets.",

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -100,11 +100,17 @@ export class SelectionService extends StatefulService<ISelectionState>
     if (!lastSelected) return;
 
     const name = lastSelected.name;
+    const selectionLength = this.getSelection().getIds.call(this).length;
+    const message =
+      selectionLength > 1
+        ? $t('Are you sure you want to remove these %{count} items?', { count: selectionLength })
+        : $t('Are you sure you want to remove %{sceneName}?', { sceneName: name });
+
     electron.remote.dialog.showMessageBox(
       electron.remote.getCurrentWindow(),
       {
+        message,
         type: 'warning',
-        message: $t('Are you sure you want to remove %{sceneName}?', { sceneName: name }),
         buttons: [$t('Cancel'), $t('OK')],
       },
       ok => {


### PR DESCRIPTION
When deleting multiple sources at once, the message only shows one source's name (technically, the last selected source), which is incorrect and misleading as the user might think they're deleting just one source.

This changes the message to "Are you sure you want to remove these N items?" if multiple sources are selected.