### PR TITLE
Fix slider resetting when going above default max value

### DIFF
--- a/app/components/obs/inputs/ObsFontSizeSelector.vue.ts
+++ b/app/components/obs/inputs/ObsFontSizeSelector.vue.ts
@@ -13,7 +13,7 @@ export default class ObsFontSizeSelector extends ObsInput<number> {
   }
 
   get metadata() {
-    return { data: this.fontSizePresets, piecewise: true, piecewiseLabel: true };
+    return { data: this.fontSizePresets, piecewise: true, piecewiseLabel: true, max: 288, min: 9 };
   }
 
   get fontSizePresets() {


### PR DESCRIPTION
Default max for vue-slider is 100 but we allow font size to go up to 288