### PR TITLE
Change facebook page locally on update

### DIFF
--- a/app/components/windows/EditStreamInfo.vue.ts
+++ b/app/components/windows/EditStreamInfo.vue.ts
@@ -332,6 +332,7 @@ export default class EditStreamInfo extends Vue {
   }
 
   setFacebookPageId(value: string) {
+    this.pageModel = value;
     this.userService.postFacebookPage(value);
   }
 

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -290,7 +290,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       body: JSON.stringify({ page_id: pageId, page_type: 'page' }),
     });
     try {
-      fetch(request);
+      fetch(request).then(() => this.updatePlatformChannelId(pageId));
     } catch {
       console.error(new Error('Could not set Facebook page'));
     }


### PR DESCRIPTION
When switching pages users would still be streaming to the initial page selected when they opened the edit stream info window, this is because we were caching the page locally and not updating it when a user changed pages