### PR TITLE
Initialize localValue on slider inputs to default before a value is set

### DIFF
--- a/app/components/shared/inputs/SliderInput.vue.ts
+++ b/app/components/shared/inputs/SliderInput.vue.ts
@@ -20,7 +20,7 @@ export default class SliderInput extends BaseInput<number, ISliderMetadata> {
   interval: number;
   isFullyMounted = false;
 
-  localValue = this.value;
+  localValue = this.value || 0;
 
   $refs: { slider: any };
 


### PR DESCRIPTION
I guess when a new filter is created sliders are initialized with an `undefined` value