### PR TITLE
fix(settings): hide stream info confirm setting while logged out

### DIFF
--- a/app/components/ExtraSettings.vue
+++ b/app/components/ExtraSettings.vue
@@ -26,7 +26,7 @@
   <div class="section">
     <div class="section-content">
       <bool-input
-        v-if="!isFacebook"
+        v-if="isLoggedIn && !isFacebook"
         v-model="streamInfoUpdate"
         name="stream_info_udpate"
         :metadata="{ title: $t('Confirm stream title and game before going live') }"

--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -75,12 +75,16 @@ export default class ExtraSettings extends Vue {
     this.windowsService.closeChildWindow();
   }
 
+  get isLoggedIn() {
+    return this.userService.isLoggedIn();
+  }
+
   get isTwitch() {
-    return this.userService.isLoggedIn() && this.userService.platform.type === 'twitch';
+    return this.isLoggedIn && this.userService.platform.type === 'twitch';
   }
 
   get isFacebook() {
-    return this.userService.isLoggedIn() && this.userService.platform.type === 'facebook';
+    return this.isLoggedIn && this.userService.platform.type === 'facebook';
   }
 
   get isRecordingOrStreaming() {


### PR DESCRIPTION
This setting is unintuitive given how when logged out the stream confirmation dialog would not appear regardless of it being enabled. We hide this setting for unauthenticated users now.