### PR TITLE
fix(property-mgr): font fallback attempt fails to init new object

### DIFF
--- a/app/services/sources/properties-managers/default-manager.ts
+++ b/app/services/sources/properties-managers/default-manager.ts
@@ -136,10 +136,12 @@ export class DefaultManager extends PropertiesManager {
     const fontInfo = fi.getFontInfo(fontPath);
 
     if (!fontInfo) {
-      // Fall back to Arial
+      // Fallback to Arial
       newSettings['custom_font'] = null;
-      newSettings['font']['face'] = 'Arial';
-      newSettings['font']['flags'] = 0;
+      newSettings['font'] = {
+        face: 'Arial',
+        flags: 0,
+      };
       this.obsSource.update(newSettings);
       return;
     }


### PR DESCRIPTION
Attempting to fallback the font fails to initialize a new object to contain the settings. We inline declaration as there doesn't seem to be any prior dataflow. 