### PR TITLE
Fix missing temp source on update

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -143,7 +143,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   private UPDATE_SOURCE(sourcePatch: TPatch<ISource>) {
     if (this.state.sources[sourcePatch.id]) {
       Object.assign(this.state.sources[sourcePatch.id], sourcePatch);
-    } else {
+    } else if (this.state.temporarySources[sourcePatch.id]) {
       Object.assign(this.state.temporarySources[sourcePatch.id], sourcePatch);
     }
   }


### PR DESCRIPTION
This sentry bug has a huge volume, but I'm not sure how we should handle the case where a temporary source isn't found.

Sentry entry: https://sentry.io/streamlabs-obs/streamlabs-obs/issues/838582567/