### PR TITLE
fix(twitch): avoid update tags with no permission

### DIFF
--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -160,13 +160,9 @@ export class TwitchService extends Service implements IPlatformService {
       body: JSON.stringify(data),
     });
 
-    // prettier-ignore
-    return Promise.all([
-      fetch(request).then(handleResponse),
-      this.setStreamTags(tags).catch(e => {
-        console.error('Failed to update tags', e);
-      }),
-    ]).then(_ => true);
+    return Promise.all([fetch(request).then(handleResponse), this.setStreamTags(tags)]).then(
+      _ => true,
+    );
   }
 
   searchGames(searchString: string): Promise<IGame[]> {
@@ -198,7 +194,13 @@ export class TwitchService extends Service implements IPlatformService {
   }
 
   @requiresToken()
-  setStreamTags(tags: TTwitchTag[]) {
+  async setStreamTags(tags: TTwitchTag[]) {
+    const hasPermission = await this.hasScope('user:edit:broadcast');
+
+    if (!hasPermission) {
+      return false;
+    }
+
     return updateTags(this.getRawHeaders(true, true))(tags)(this.twitchId);
   }
 


### PR DESCRIPTION
Do not attempt to update tags if the user doesn't have the `user:edit:broadcast` permission. Race conditions/general timing makes this check necessary as we might not have done a check prior to attempting to send channel info.