### PR TITLE
refactor(streaming): platform capabilities

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -1,5 +1,12 @@
 import { StatefulService, mutation } from '../stateful-service';
-import { IPlatformService, IPlatformAuth, IChannelInfo, IGame } from '.';
+import {
+  IPlatformService,
+  IPlatformAuth,
+  IChannelInfo,
+  IGame,
+  TPlatformCapability,
+  TPlatformCapabilityMap,
+} from '.';
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
@@ -35,6 +42,13 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
   @Inject() hostsService: HostsService;
   @Inject() settingsService: SettingsService;
   @Inject() userService: UserService;
+
+  capabilities = new Set<TPlatformCapability>([
+    'chat',
+    'user-info',
+    'viewer-count',
+    'stream-schedule',
+  ]);
 
   authWindowOptions: Electron.BrowserWindowConstructorOptions = { width: 800, height: 800 };
 
@@ -280,5 +294,12 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
       });
     });
     this.settingsService.setSettings('Stream', settings);
+  }
+
+  // TODO: dedup
+  supports<T extends TPlatformCapability>(
+    capability: T,
+  ): this is TPlatformCapabilityMap[T] & IPlatformService {
+    return this.capabilities.has(capability);
   }
 }

--- a/app/services/platforms/mixer.ts
+++ b/app/services/platforms/mixer.ts
@@ -1,6 +1,13 @@
 import { Service } from '../service';
 import { StatefulService, mutation } from '../stateful-service';
-import { IPlatformService, IPlatformAuth, IChannelInfo, IGame } from '.';
+import {
+  IPlatformService,
+  IPlatformAuth,
+  IChannelInfo,
+  IGame,
+  TPlatformCapability,
+  TPlatformCapabilityMap,
+} from '.';
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
@@ -16,6 +23,8 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
   @Inject() hostsService: HostsService;
   @Inject() settingsService: SettingsService;
   @Inject() userService: UserService;
+
+  capabilities = new Set<TPlatformCapability>(['chat', 'viewer-count']);
 
   authWindowOptions: Electron.BrowserWindowConstructorOptions = {
     width: 800,
@@ -192,5 +201,12 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
 
   beforeGoLive() {
     return Promise.resolve();
+  }
+
+  // TODO: dedup
+  supports<T extends TPlatformCapability>(
+    capability: T,
+  ): this is TPlatformCapabilityMap[T] & IPlatformService {
+    return this.capabilities.has(capability);
   }
 }

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -1,5 +1,12 @@
 import { Service } from 'services/service';
-import { IPlatformService, IPlatformAuth, IChannelInfo, IGame } from '.';
+import {
+  IPlatformService,
+  IPlatformAuth,
+  IChannelInfo,
+  IGame,
+  TPlatformCapability,
+  TPlatformCapabilityMap,
+} from '.';
 import { HostsService } from 'services/hosts';
 import { SettingsService } from 'services/settings';
 import { Inject } from 'util/injector';
@@ -35,6 +42,14 @@ export class TwitchService extends Service implements IPlatformService {
   @Inject() settingsService: SettingsService;
   @Inject() userService: UserService;
   @Inject() streamInfoService: StreamInfoService;
+
+  capabilities = new Set<TPlatformCapability>([
+    'chat',
+    'scope-validation',
+    'tags',
+    'user-info',
+    'viewer-count',
+  ]);
 
   authWindowOptions: Electron.BrowserWindowConstructorOptions = {
     width: 600,
@@ -188,12 +203,12 @@ export class TwitchService extends Service implements IPlatformService {
   }
 
   @requiresToken()
-  getAllTags() {
+  getAllTags(): Promise<TTwitchTag[]> {
     return getAllTags(this.getRawHeaders(true));
   }
 
   @requiresToken()
-  getStreamTags() {
+  getStreamTags(): Promise<TTwitchTag[]> {
     return getStreamTags(this.twitchId, this.getRawHeaders(true, true));
   }
 
@@ -229,7 +244,7 @@ export class TwitchService extends Service implements IPlatformService {
       .then(json => json.results[0].hits);
   }
 
-  async hasScope(scope: TTwitchOAuthScope): Promise<boolean> {
+  hasScope(scope: TTwitchOAuthScope): Promise<boolean> {
     return fetch('https://id.twitch.tv/oauth2/validate', {
       headers: this.getHeaders(true),
     })
@@ -260,6 +275,12 @@ export class TwitchService extends Service implements IPlatformService {
     });
 
     return headers;
+  }
+
+  supports<T extends TPlatformCapability>(
+    capability: T,
+  ): this is TPlatformCapabilityMap[T] & IPlatformService {
+    return this.capabilities.has(capability);
   }
 
   async beforeGoLive() {}

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -1,6 +1,12 @@
 import { Service } from '../service';
 import { StatefulService, mutation } from '../stateful-service';
-import { IPlatformService, IChannelInfo, IPlatformAuth } from '.';
+import {
+  IPlatformService,
+  IChannelInfo,
+  IPlatformAuth,
+  TPlatformCapability,
+  TPlatformCapabilityMap,
+} from '.';
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
@@ -19,6 +25,8 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
   @Inject() hostsService: HostsService;
   @Inject() settingsService: SettingsService;
   @Inject() userService: UserService;
+
+  capabilities = new Set<TPlatformCapability>(['chat', 'stream-schedule']);
 
   static initialState: IYoutubeServiceState = {
     liveStreamingEnabled: true,
@@ -287,5 +295,12 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
 
   beforeGoLive() {
     return Promise.resolve();
+  }
+
+  // TODO: dedup
+  supports<T extends TPlatformCapability>(
+    capability: T,
+  ): this is TPlatformCapabilityMap[T] & IPlatformService {
+    return this.capabilities.has(capability);
   }
 }


### PR DESCRIPTION
Fine-grained specification of platform capabilities. Initial work, as further refactor into existing code isn't done yet. 

This provides a way for platforms to specify what capabilities they support, relieving our `IPlatformService` of optional functions as code grows and eliminating type casts when accessed dynamically through `getPlatformService`.

On the documentation side, we'd have a clearer view as to what we support for each platform, which could also tie into Platform apps.

Supported capabilities:

* `chat`: Display and interact with chat.
* `tags`: Fetch and set stream tags.
* `user-info`: Fetch and set user info.
* `viewer-count`: Fetch viewer count.
* `schedule-stream`: Schedule streams for a later date.
* `scope-validation`: Ability to check whether we're authorized to perform actions that require a given scope.

Usage example:

``` javascript
const platform = getPlatformService(...)
if (platform.supports('tags') {
  // platform is IPlatformService & IPlatformCapabilityTags on this branch
} else {
 // platform is just IPlatformService
}
```

Future abstractions such as this would be possible now:

```javascript
runIfSupports('tags', this.getAllTags)
```

Or decorators, pick your poison :D.

Capability list by platform:

* Twitch:
  - `chat`
  - `scope-validation`
  - `tags`
  - `user-info`
  - `viewer-count`
* Mixer:
  - `chat`
  - `viewer-count`
* Facebook:
  - `chat`
  - `user-info`
  - `viewer-count`
  - `stream-schedule`
* Youtube:
  - `chat`
  - `stream-schedule`

Feel free to add to this list.
