### PR TITLE
refactor: set Preview's error sample rate to 1

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -26,6 +26,7 @@ import electronLog from 'electron-log';
 const { ipcRenderer, remote } = electron;
 const slobsVersion = remote.process.env.SLOBS_VERSION;
 const isProduction = process.env.NODE_ENV === 'production';
+const isPreview = !!remote.process.env.SLOBS_PREVIEW;
 
 window['obs'] = window['require']('obs-studio-node');
 
@@ -65,7 +66,7 @@ if (
   Sentry.init({
     dsn: sentryDsn,
     release: slobsVersion,
-    sampleRate: 0.1,
+    sampleRate: isPreview ? 1.0 : 0.1,
     beforeSend: event => {
       // Because our URLs are local files and not publicly
       // accessible URLs, we simply truncate and send only


### PR DESCRIPTION
Set Sentry's sample rate to `1.0` if we're on Preview.