### PR TITLE
Check for face mask plugin dll after checking if face masks are enabled

### DIFF
--- a/app/services/facemasks.ts
+++ b/app/services/facemasks.ts
@@ -152,7 +152,6 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
   }
 
   notifyPluginMissing() {
-    this.SET_ACTIVE(false);
     const ok = electron.remote.dialog.showMessageBox(electron.remote.getCurrentWindow(), {
       type: 'warning',
       message: $t('Unable to find face mask plugin. You will not be able to use Face Masks'),
@@ -264,6 +263,7 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
     }
 
     if (!this.checkForPlugin()) {
+      this.SET_ACTIVE(false);
       this.notifyPluginMissing();
       return;
     }

--- a/app/services/facemasks.ts
+++ b/app/services/facemasks.ts
@@ -117,7 +117,7 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
   startup() {
     this.fetchFacemaskSettings()
       .then(response => {
-        this.handleFacemaskSettings(response);
+        this.checkFacemaskSettings(response);
       })
       .catch(err => {
         this.SET_ACTIVE(false);
@@ -255,30 +255,25 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
     return this.settings.enabled && availableDeviceSelected;
   }
 
-  handleFacemaskSettings(settings: IFacemaskSettings) {
+  checkFacemaskSettings(settings: IFacemaskSettings) {
     this.settings = settings;
-    if (settings.enabled) {
-      this.handleFacemasksEnabled();
-    } else {
+
+    if (!settings.enabled) {
       this.SET_ACTIVE(false);
+      return;
     }
-  }
 
-  handleFacemasksEnabled() {
-    if (this.checkForPlugin()) {
-      this.applyFacemaskSettings();
-    } else {
+    if (!this.checkForPlugin()) {
       this.notifyPluginMissing();
+      return;
     }
-  }
 
-  applyFacemaskSettings() {
-    const uuids = this.settings.facemasks.map((mask: IFacemask) => {
+    const uuids = settings.facemasks.map((mask: IFacemask) => {
       return { uuid: mask.uuid, intro: mask.is_intro };
     });
 
-    if (this.settings.device.name && this.settings.device.value) {
-      this.SET_DEVICE(this.settings.device.name, this.settings.device.value);
+    if (settings.device.name && settings.device.value) {
+      this.SET_DEVICE(settings.device.name, settings.device.value);
       this.setupFilter();
     } else {
       this.SET_ACTIVE(false);
@@ -293,7 +288,7 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
 
     Promise.all(downloads)
       .then(responses => {
-        this.ensureModtimes(this.settings.facemasks);
+        this.ensureModtimes(settings.facemasks);
       })
       .catch(err => {
         console.log(err);

--- a/app/services/facemasks.ts
+++ b/app/services/facemasks.ts
@@ -115,17 +115,13 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
   }
 
   startup() {
-    if (this.checkForPlugin()) {
-      this.fetchFacemaskSettings()
-        .then(response => {
-          this.checkFacemaskSettings(response);
-        })
-        .catch(err => {
-          this.SET_ACTIVE(false);
-        });
-    } else {
-      this.notifyPluginMissing();
-    }
+    this.fetchFacemaskSettings()
+      .then(response => {
+        this.checkFacemaskSettings(response);
+      })
+      .catch(err => {
+        this.SET_ACTIVE(false);
+      });
   }
 
   activate() {
@@ -262,32 +258,36 @@ export class FacemasksService extends PersistentStatefulService<IFacemasksServic
   checkFacemaskSettings(settings: IFacemaskSettings) {
     this.settings = settings;
     if (settings.enabled) {
-      const uuids = settings.facemasks.map((mask: IFacemask) => {
-        return { uuid: mask.uuid, intro: mask.is_intro };
-      });
-
-      if (settings.device.name && settings.device.value) {
-        this.SET_DEVICE(settings.device.name, settings.device.value);
-        this.setupFilter();
-      } else {
-        this.SET_ACTIVE(false);
-      }
-
-      const missingMasks = uuids.filter(mask => this.checkDownloaded(mask.uuid));
-      const downloads = missingMasks.map(mask =>
-        this.downloadAndSaveModtime(mask.uuid, mask.intro, false),
-      );
-
-      this.setDownloadProgress(missingMasks.map(mask => mask.uuid));
-
-      Promise.all(downloads)
-        .then(responses => {
-          this.ensureModtimes(settings.facemasks);
-        })
-        .catch(err => {
-          console.log(err);
-          this.notifyFailure();
+      if (this.checkForPlugin()) {
+        const uuids = settings.facemasks.map((mask: IFacemask) => {
+          return { uuid: mask.uuid, intro: mask.is_intro };
         });
+
+        if (settings.device.name && settings.device.value) {
+          this.SET_DEVICE(settings.device.name, settings.device.value);
+          this.setupFilter();
+        } else {
+          this.SET_ACTIVE(false);
+        }
+
+        const missingMasks = uuids.filter(mask => this.checkDownloaded(mask.uuid));
+        const downloads = missingMasks.map(mask =>
+          this.downloadAndSaveModtime(mask.uuid, mask.intro, false),
+        );
+
+        this.setDownloadProgress(missingMasks.map(mask => mask.uuid));
+
+        Promise.all(downloads)
+          .then(responses => {
+            this.ensureModtimes(settings.facemasks);
+          })
+          .catch(err => {
+            console.log(err);
+            this.notifyFailure();
+          });
+      } else {
+        this.notifyPluginMissing();
+      }
     } else {
       this.SET_ACTIVE(false);
     }


### PR DESCRIPTION
Users who do not have face masks enabled were seeing the error message that should appear when your plugin dll is missing. Now we will check for the plugin dll after confirming a user has face masks enabled.