### PR TITLE
Use a global video context to retrieve skipped frames and encoded frames

### DIFF
--- a/app/services/performance-monitor/performance-monitor.ts
+++ b/app/services/performance-monitor/performance-monitor.ts
@@ -67,8 +67,8 @@ export class PerformanceMonitorService extends StatefulService<IMonitorState> {
     const currentStats: IMonitorState = {
       framesLagged: obs.Global.laggedFrames,
       framesRendered: obs.Global.totalFrames,
-      framesSkipped: obs.VideoFactory.getGlobal().skippedFrames,
-      framesEncoded: obs.VideoFactory.getGlobal().totalFrames,
+      framesSkipped: obs.Video.skippedFrames,
+      framesEncoded: obs.Video.encodedFrames,
     };
 
     const {


### PR DESCRIPTION
Video is by default a global object now, this PR is necessary to make this one works https://github.com/stream-labs/obs-studio-node/pull/246