### PR TITLE
send useOptimizedProfile to `stream_start` flag if it's true

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -367,11 +367,16 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           console.error('Error fetching stream encoder info: ', e);
         }
 
-        this.usageStatisticsService.recordEvent('stream_start', {
+        const eventMetadata: Dictionary<any> = {
           ...streamEncoderInfo,
           game,
-          useOptimizedProfile: this.videoEncodingOptimizationService.state.useOptimizedProfile,
-        });
+        };
+
+        if (this.videoEncodingOptimizationService.state.useOptimizedProfile) {
+          eventMetadata.useOptimizedProfile = true;
+        }
+
+        this.usageStatisticsService.recordEvent('stream_start', eventMetadata);
       } else if (info.signal === EOBSOutputSignal.Starting) {
         this.SET_STREAMING_STATUS(EStreamingState.Starting, time);
         this.streamingStatusChange.next(EStreamingState.Starting);


### PR DESCRIPTION
@h4r5h4 reported some limitations for collecting statistics:
>we do partial matching which means it will match `useOptimizedProfile":false`
even if you are searching for `useOptimizedProfile":true`

here is a fix