### PR TITLE
fix: scene transitions API after deletion

### DIFF
--- a/app/services/platform-apps/api/modules/scene-transitions.ts
+++ b/app/services/platform-apps/api/modules/scene-transitions.ts
@@ -110,10 +110,10 @@ export class SceneTransitionsModule extends Module {
         throw new Error('Invalid file specified, you must provide a video file.');
       }
 
-      if (!this.platformAppAssetsService.hasAsset(appId, originalUrl)) {
-        // TODO: avoid mutation
-        options.url = await this.platformAppAssetsService.addPlatformAppAsset(appId, originalUrl);
-      }
+      // TODO: avoid mutation
+      options.url = this.platformAppAssetsService.hasAsset(appId, originalUrl)
+        ? (await this.platformAppAssetsService.getAssetDiskInfo(appId, originalUrl)).filePath
+        : await this.platformAppAssetsService.addPlatformAppAsset(appId, originalUrl);
 
       const { shouldLock = false, name, ...settings } = options;
 

--- a/app/services/platform-apps/platform-app-assets-service.ts
+++ b/app/services/platform-apps/platform-app-assets-service.ts
@@ -102,11 +102,7 @@ export class PlatformAppAssetsService extends PersistentStatefulService<AssetsSe
    * @see {ADD_ASSET}
    */
   async addPlatformAppAsset(appId: string, assetUrl: string) {
-    const originalUrl = this.platformAppsService.getAssetUrl(appId, assetUrl);
-
-    const assetsDir = await this.getAssetsTargetDirectory(appId);
-    const filePath = path.join(assetsDir, path.basename(originalUrl));
-
+    const { originalUrl, filePath } = await this.getAssetDiskInfo(appId, assetUrl);
     await downloadFileAlt(originalUrl, filePath);
 
     const checksum = await getChecksum(filePath);
@@ -114,6 +110,15 @@ export class PlatformAppAssetsService extends PersistentStatefulService<AssetsSe
     this.ADD_ASSET(appId, assetUrl, checksum);
 
     return filePath;
+  }
+
+  async getAssetDiskInfo(appId: string, assetUrl: string) {
+    const originalUrl = this.platformAppsService.getAssetUrl(appId, assetUrl);
+
+    const assetsDir = await this.getAssetsTargetDirectory(appId);
+    const filePath = path.join(assetsDir, path.basename(originalUrl));
+
+    return { originalUrl, filePath };
   }
 
   /**


### PR DESCRIPTION
After deleting a scene transition through the UI, if the developer creates a transition pointing to the same file, the transition would fail to run as we failed to update the path to the file on disk, since we didn't need to download the file again (as it was on our asset link/checksum) we submitted the URL as-is to OBS which is not what we want. We update the URL to the file on disk if that were to be the case.

Reproduction case given:

1. Create a transition via API.
2. Set as default.
3. Change scenes (it'd work)
4. Delete transition through SLOBS UI.
5. Create the same transition through API.
6. Set as default
7. Switch scenes (would no longer work).