### PR TITLE
wait on autosave disable

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -31,7 +31,6 @@ import { AnnouncementsService } from 'services/announcements';
 import { ObsUserPluginsService } from 'services/obs-user-plugins';
 import { IncrementalRolloutService } from 'services/incremental-rollout';
 import { $t } from '../i18n';
-import Vue from 'vue';
 
 const crashHandler = window['require']('crash-handler');
 

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -31,6 +31,7 @@ import { AnnouncementsService } from 'services/announcements';
 import { ObsUserPluginsService } from 'services/obs-user-plugins';
 import { IncrementalRolloutService } from 'services/incremental-rollout';
 import { $t } from '../i18n';
+import Vue from 'vue';
 
 const crashHandler = window['require']('crash-handler');
 
@@ -189,7 +190,12 @@ export class AppService extends StatefulService<IAppState> {
       this.START_LOADING();
       this.windowsService.closeChildWindow();
       this.windowsService.closeAllOneOffs();
-      this.sceneCollectionsService.disableAutoSave();
+
+      // This is kind of ugly, but it gives the browser time to paint before
+      // we do long blocking operations with OBS.
+      await new Promise(resolve => setTimeout(resolve, 200));
+
+      await this.sceneCollectionsService.disableAutoSave();
     }
 
     let error: Error = null;

--- a/app/services/onboarding.ts
+++ b/app/services/onboarding.ts
@@ -108,16 +108,6 @@ export class OnboardingService extends StatefulService<IOnboardingServiceState> 
   @Inject() userService: UserService;
   @Inject() brandDeviceService: BrandDeviceService;
 
-  init() {
-    // This is used for faking authentication in tests.  We have
-    // to do this because Twitch adds a captcha when we try to
-    // actually log in from integration tests.
-    electron.ipcRenderer.on('testing-fakeAuth', () => {
-      this.COMPLETE_STEP('Connect');
-      this.SET_CURRENT_STEP('ObsImport');
-    });
-  }
-
   @mutation()
   SET_CURRENT_STEP(step: TOnboardingStep) {
     this.state.currentStep = step;

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -628,7 +628,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
     this.autoSaveInterval = window.setInterval(async () => {
       this.autoSavePromise = this.save();
       await this.autoSavePromise;
-      await this.stateService.flushManifestFile();
+      this.stateService.flushManifestFile();
     }, 60 * 1000);
   }
 

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -55,7 +55,7 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
       console.warn('Error loading manifest file from disk');
     }
 
-    await this.flushManifestFile();
+    this.flushManifestFile();
   }
 
   /**
@@ -88,9 +88,9 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
    * The manifest file is simply a copy of the Vuex state of this
    * service, persisted to disk.
    */
-  async flushManifestFile() {
+  flushManifestFile() {
     const data = JSON.stringify(this.state, null, 2);
-    await this.writeDataToCollectionFile('manifest', data);
+    this.writeDataToCollectionFile('manifest', data);
   }
 
   /**

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -13,7 +13,6 @@ import { PlatformAppsService } from 'services/platform-apps';
 import { getPlatformService, IPlatformAuth, TPlatform, IPlatformService } from './platforms';
 import { CustomizationService } from 'services/customization';
 import * as Sentry from '@sentry/browser';
-import { AppService } from 'services/app';
 import { RunInLoadingMode } from 'services/app/app-decorators';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { Subject } from 'rxjs';
@@ -32,7 +31,6 @@ interface IUserServiceState {
 export class UserService extends PersistentStatefulService<IUserServiceState> {
   @Inject() private hostsService: HostsService;
   @Inject() private customizationService: CustomizationService;
-  @Inject() private appService: AppService;
   @Inject() private sceneCollectionsService: SceneCollectionsService;
   @Inject() private windowsService: WindowsService;
   @Inject() private onboardingService: OnboardingService;
@@ -86,7 +84,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     // actually log in from integration tests.
     electron.ipcRenderer.on('testing-fakeAuth', async (e: Electron.Event, auth: IPlatformAuth) => {
       const service = getPlatformService(auth.platform.type);
-      this.login(service, auth);
+      await this.login(service, auth);
+      this.onboardingService.next();
     });
   }
 

--- a/test/onboarding.js
+++ b/test/onboarding.js
@@ -3,7 +3,6 @@ import { useSpectron, focusMain, focusChild } from './helpers/spectron/index';
 import { selectSource, clickSourceProperties, sourceIsExisting } from './helpers/spectron/sources';
 import { logOut } from './helpers/spectron/user';
 
-
 useSpectron({ skipOnboarding: false, appArgs: '--nosync' });
 
 test('Adding some starter widgets', async t => {
@@ -25,6 +24,11 @@ test('Adding some starter widgets', async t => {
     widgetToken,
     platform
   });
+
+  // This will show up if there are scene collections to import
+  if (await t.context.app.client.isExisting('button=Continue')) {
+    await t.context.app.client.click('button=Continue');
+  }
 
   // This will only show up if OBS is installed
   if (await t.context.app.client.isExisting('button=Start Fresh')) {


### PR DESCRIPTION
- Resolves a race condition where we could start deloading the application state while an autosave is still in progress.
- When entering the application loading state, wait for 200ms to give the browser time to paint kevin before we start doing slow synchronous operations.