### PR TITLE
Remove debounce from NumberInput

### DIFF
--- a/app/components/shared/inputs/NumberInput.vue
+++ b/app/components/shared/inputs/NumberInput.vue
@@ -10,7 +10,7 @@
         type="text"
         ref="input"
         :placeholder="options.placeholder"
-        :value="value"
+        :value="displayValue"
         @input="handleInput($event.target.value)"
         @mousewheel="onMouseWheelHandler"
         :name="uuid"

--- a/app/components/shared/inputs/NumberInput.vue.ts
+++ b/app/components/shared/inputs/NumberInput.vue.ts
@@ -15,11 +15,6 @@ export default class NumberInput extends BaseInput<number | string, INumberMetad
     input: HTMLInputElement;
   };
 
-  @Debounce(1000)
-  updateValueDebounced(value: string) {
-    this.updateValue(value, true);
-  }
-
   emitInput(value: string) {
     let formattedValue = value;
     if (isNaN(Number(formattedValue))) formattedValue = '0';
@@ -27,12 +22,7 @@ export default class NumberInput extends BaseInput<number | string, INumberMetad
     super.emitInput(Number(formattedValue));
   }
 
-  updateValue(value: string, force = false) {
-    if (!force && this.options.min) {
-      // fields with min value don't work well without Debounce
-      this.updateValueDebounced(value);
-      return;
-    }
+  updateValue(value: string) {
     let formattedValue = String(isNaN(parseInt(value, 10)) ? 0 : parseInt(value, 10));
 
     if (this.options.min !== void 0 && Number(value) < this.options.min) {

--- a/app/components/shared/inputs/NumberInput.vue.ts
+++ b/app/components/shared/inputs/NumberInput.vue.ts
@@ -1,7 +1,6 @@
 import { Component, Prop } from 'vue-property-decorator';
 import { BaseInput } from './BaseInput';
 import { INumberMetadata } from './index';
-import { Debounce } from 'lodash-decorators';
 
 @Component({})
 export default class NumberInput extends BaseInput<number | string, INumberMetadata> {
@@ -15,31 +14,37 @@ export default class NumberInput extends BaseInput<number | string, INumberMetad
     input: HTMLInputElement;
   };
 
+  displayValue: number | string = this.value;
+
+  timeout: number;
+
   emitInput(value: string) {
     let formattedValue = value;
     if (isNaN(Number(formattedValue))) formattedValue = '0';
-    if (formattedValue !== value) this.$refs.input.value = formattedValue;
+    if (formattedValue !== value) this.displayValue = formattedValue;
     super.emitInput(Number(formattedValue));
   }
 
   updateValue(value: string) {
+    console.log(value);
     let formattedValue = String(isNaN(parseInt(value, 10)) ? 0 : parseInt(value, 10));
+    if (this.timeout) clearTimeout(this.timeout);
 
     if (this.options.min !== void 0 && Number(value) < this.options.min) {
-      formattedValue = String(this.options.min);
+      this.timeout = window.setTimeout(() => (this.displayValue = this.options.min), 1000);
+      return;
     }
 
     if (this.options.max !== void 0 && Number(value) > this.options.max) {
       formattedValue = String(this.options.max);
     }
 
-    if (formattedValue !== value) {
-      this.$refs.input.value = formattedValue;
-    }
+    this.displayValue = formattedValue;
     this.emitInput(formattedValue);
   }
 
   handleInput(value: string) {
+    this.displayValue = value;
     if (this.options.isInteger) {
       this.updateValue(value);
     } else {
@@ -48,11 +53,11 @@ export default class NumberInput extends BaseInput<number | string, INumberMetad
   }
 
   increment() {
-    this.updateValue(String(Number(this.$refs.input.value) + 1));
+    this.updateValue(String(Number(this.displayValue) + 1));
   }
 
   decrement() {
-    this.updateValue(String(Number(this.$refs.input.value) - 1));
+    this.updateValue(String(Number(this.displayValue) - 1));
   }
 
   onMouseWheelHandler(event: WheelEvent) {


### PR DESCRIPTION
I'm not sure why this was here in the first place as I'm having no issues without it, but was causing a really unresponsive UX in int inputs

edit: fixed with a variation on the debounce concept to handle minimum values correctly whilst maintaining performance
![intinput](https://user-images.githubusercontent.com/20602520/52754045-f0f5d080-2fad-11e9-9dd5-35aed3f0787d.gif)
