### PR TITLE
Removed SliderInput NaN

### DIFF
--- a/app/components/shared/inputs/SliderInput.vue
+++ b/app/components/shared/inputs/SliderInput.vue
@@ -1,25 +1,26 @@
 <template>
-<div
-  class="w-form-group__wrapper slider-container"
-  data-role="input"
-  data-type="slider"
-  :data-name="options.name"
->
-  <vue-slider class="slider w-form-group__input"
-    :value="localValue"
-    @input="value => updateLocalValue(value)"
-    :max="options.max"
-    :min="options.min"
-    :interval="options.interval"
-    :tooltip="options.displayValue || 'always'"
-    :speed="0"
-    :height="4"
-    :formatter="formatter"
-    :piecewise="options.piecewise || (options.interval && options.interval >= 1)"
-    :piecewiseLabel="options.piecewiseLabel"
-    :data="options.data"
-    ref="slider"
-    :piecewiseStyle="{
+  <div
+    class="w-form-group__wrapper slider-container"
+    data-role="input"
+    data-type="slider"
+    :data-name="options.name"
+  >
+    <vue-slider
+      class="slider w-form-group__input"
+      :value="localValue"
+      @input="value => updateLocalValue(value)"
+      :max="options.max"
+      :min="options.min"
+      :interval="options.interval"
+      :tooltip="options.displayValue || 'always'"
+      :speed="0"
+      :height="4"
+      :formatter="formatter"
+      :piecewise="options.piecewise || (options.interval && options.interval >= 1)"
+      :piecewiseLabel="options.piecewiseLabel"
+      :data="options.data"
+      ref="slider"
+      :piecewiseStyle="{
         position: 'absolute',
         backgroundColor: nightMode ? '#253239' : '#eaecee',
         height: '2px',
@@ -27,26 +28,26 @@
         'borderRadius': '1px',
         top: '12px'
     }"
-    :labelStyle="{ color: nightMode ? '#253239' : '#eaecee' }"
-    :piecewiseActiveStyle="{ backgroundColor: '#3c4c53' }"
-    :sliderStyle="options.sliderStyle"
-    :dotSize="options.dotSize"
-  />
-  <input
-    v-if="options.hasValueBox && !options.usePercentages"
-    class="slider-input"
-    type="text"
-    :value="localValue"
-    @input="updateLocalValue(parseFloat($event.target.value))"
-    @keydown="handleKeydown"
-  />
-</div>
+      :labelStyle="{ color: nightMode ? '#253239' : '#eaecee' }"
+      :piecewiseActiveStyle="{ backgroundColor: '#3c4c53' }"
+      :sliderStyle="options.sliderStyle"
+      :dotSize="options.dotSize"
+    />
+    <input
+      v-if="options.hasValueBox && !options.usePercentages"
+      class="slider-input"
+      type="text"
+      :value="localValue"
+      @input="updateLocalValue($event.target.value)"
+      @keydown="handleKeydown"
+    >
+  </div>
 </template>
 
 <script lang="ts" src="./SliderInput.vue.ts"></script>
 
 <style lang="less">
-@import "../../../styles/index";
+@import '../../../styles/index';
 
 .slider-container {
   width: 100%;
@@ -62,7 +63,7 @@
 .slider {
   background: transparent;
   .padding-v-sides();
-  .padding-h-sides(@0)!important;
+  .padding-h-sides(@0) !important;
   margin: 0;
   flex-grow: 1;
   height: auto;
@@ -111,7 +112,7 @@
 
 .vue-slider-piecewise {
   .vue-slider-piecewise-dot {
-    display: none!important;
+    display: none !important;
   }
 }
 

--- a/app/components/shared/inputs/SliderInput.vue.ts
+++ b/app/components/shared/inputs/SliderInput.vue.ts
@@ -6,6 +6,7 @@ import { CustomizationService } from 'services/customization';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { Inject } from 'util/injector';
 import { ISliderMetadata } from './index';
+import { isString } from 'util';
 
 @Component({
   components: { VueSlider },
@@ -20,7 +21,8 @@ export default class SliderInput extends BaseInput<number, ISliderMetadata> {
   interval: number;
   isFullyMounted = false;
 
-  localValue = this.value || 0;
+  // The displaying value on and within the ui components.
+  localValue: number | string = this.value || 0;
 
   $refs: { slider: any };
 
@@ -34,9 +36,22 @@ export default class SliderInput extends BaseInput<number, ISliderMetadata> {
     new ResizeSensor(this.$el, () => this.onResizeHandler());
   }
 
+  /**
+   * Updates the local value that is used during the display processs.
+   * @param value The value that will be displayed on the interface.
+   */
   updateLocalValue(value: number) {
-    this.localValue = value;
-    this.updateValue(value);
+    const parsedValue = Number(value);
+
+    // Dislay a empty string if and only if the user deletes all of the input field.
+    if ((isNaN(parsedValue) && isString(value)) || (isString(value) && value === '')) {
+      // preview only, when there is no input or just a negative symbol.
+      this.localValue = value.trim() !== '-' ? '' : value;
+    } else if (value != null && !isNaN(value)) {
+      // Otherwise use the provided number value.
+      this.localValue = parsedValue;
+      this.updateValue(parsedValue);
+    }
   }
 
   @debounce(100)


### PR DESCRIPTION
* When a user deletes the input on a slider the input would reflect NaN, now the input will reflect an empty string and negative symbol. Only updating when valid changes occur (e.g '-', '' and NaN are not accepted but displayed).

### Before
![no66335usk](https://user-images.githubusercontent.com/12329422/52799990-cae63400-3072-11e9-936b-c600f128c5dc.gif)

### After
![qffhrsyty1](https://user-images.githubusercontent.com/12329422/52799682-3bd91c00-3072-11e9-84d1-21b0fe28c6ba.gif)