### PR TITLE
Various scene collection fixes

### DIFF
--- a/app/components/windows/ChildWindow.vue
+++ b/app/components/windows/ChildWindow.vue
@@ -7,9 +7,8 @@
     <div class="spinner-spacer" />
   </div>
   <component
-    v-for="(component, index) in components"
+    v-for="(component, index) in componentsToRender"
     :key="`${component.name}-${index}`"
-    v-if="component.name"
     v-show="component.isShown"
     :is="component.name"/>
 </div>

--- a/app/components/windows/ChildWindow.vue.ts
+++ b/app/components/windows/ChildWindow.vue.ts
@@ -5,6 +5,7 @@ import { Inject } from 'util/injector';
 import { getComponents, IWindowOptions, WindowsService } from 'services/windows';
 import { CustomizationService } from 'services/customization';
 import TitleBar from '../TitleBar.vue';
+import { AppService } from 'services/app';
 
 @Component({
   components: {
@@ -15,6 +16,7 @@ import TitleBar from '../TitleBar.vue';
 export default class ChildWindow extends Vue {
   @Inject() private windowsService: WindowsService;
   @Inject() private customizationService: CustomizationService;
+  @Inject() private appService: AppService;
 
   components: { name: string; isShown: boolean; title: string }[] = [];
   private refreshingTimeout = 0;
@@ -37,6 +39,14 @@ export default class ChildWindow extends Vue {
 
   get currentComponent() {
     return this.components[this.components.length - 1];
+  }
+
+  get componentsToRender() {
+    return this.components.filter(c => c.name && !this.appLoading);
+  }
+
+  get appLoading() {
+    return this.appService.state.loading;
   }
 
   clearComponentStack() {

--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -15,13 +15,13 @@
 
       <top-nav v-if="(page !== 'Onboarding')" :locked="applicationLoading"></top-nav>
       <apps-nav v-if="platformApps.length > 0 && (page !== 'Onboarding')"></apps-nav>
-      <div v-if="shouldLockContent" class="main-loading">
+      <div v-if="applicationLoading" class="main-loading">
         <custom-loader></custom-loader>
       </div>
 
       <component
         class="main-page-container"
-        v-if="!shouldLockContent"
+        v-if="!applicationLoading"
         :is="page"
         :params="params"/>
       <studio-footer v-if="!applicationLoading && (page !== 'Onboarding')" />

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -107,18 +107,6 @@ export default class Main extends Vue {
     return this.platformAppsService.enabledApps;
   }
 
-  /**
-   * Only certain pages get locked out while the application
-   * is loading.  Other pages are OK to keep using.
-   */
-  get shouldLockContent() {
-    return (
-      this.applicationLoading &&
-      (this.navigationService.state.currentPage === 'Studio' ||
-        this.navigationService.state.currentPage === 'Live')
-    );
-  }
-
   onDropHandler(event: DragEvent) {
     const files = event.dataTransfer.files;
 

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -187,7 +187,12 @@ export class AppService extends StatefulService<IAppState> {
   async runInLoadingMode(fn: () => Promise<any> | void) {
     if (!this.state.loading) {
       this.START_LOADING();
-      this.windowsService.closeChildWindow();
+
+      // The scene collections window is the only one we don't close when
+      // switching scene collections, because it results in poor UX.
+      if (this.windowsService.state.child.componentName !== 'ManageSceneCollections') {
+        this.windowsService.closeChildWindow();
+      }
       this.windowsService.closeAllOneOffs();
 
       // This is kind of ugly, but it gives the browser time to paint before

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -222,17 +222,20 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   async delete(id?: string): Promise<void> {
     // tslint:disable-next-line:no-parameter-reassignment TODO
     id = id || this.activeCollection.id;
-
     const removingActiveCollection = id === this.activeCollection.id;
 
-    await this.removeCollection(id);
-
     if (removingActiveCollection) {
-      if (this.collections.length > 0) {
-        await this.load(this.collections[0].id);
-      } else {
-        await this.create();
-      }
+      this.appService.runInLoadingMode(async () => {
+        await this.removeCollection(id);
+
+        if (this.collections.length > 0) {
+          await this.load(this.collections[0].id);
+        } else {
+          await this.create();
+        }
+      });
+    } else {
+      await this.removeCollection(id);
     }
   }
 


### PR DESCRIPTION
1) The kevin loading screen now appears no matter what tab you are on.  This prevents the app from looking frozen when you are shutting down on the app store tab for example.
2) When removing the active scene collection, put the application into loading mode first.  This resolves a high volume sentry error: https://sentry.io/streamlabs-obs/streamlabs-obs/issues/463808082/events/984141a93dbd45479fdeb63c97bb7f57/
3) When deleting the active scene collection, do not close the scene collections window, but show a spinner instead.  This fixes UX debt that was introduced by https://github.com/stream-labs/streamlabs-obs/pull/899/files