### PR TITLE
Fix invalid fb id

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -188,7 +188,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
   }
 
   fetchPrefillData() {
-    if (!this.state.activePage) return;
+    if (!this.state.activePage || !this.state.activePage.id) return;
     const url =
       `${this.apiBase}/${this.state.activePage.id}/live_videos?` +
       'fields=status,stream_url,title,description';


### PR DESCRIPTION
It would appear as though sometimes the activePage is sent back from SL without an id, but does exist. This is a bandaid fix but will triage to try and discover the root cause