### PR TITLE
Apps nav chat slot

### DIFF
--- a/app/components/Chat.vue
+++ b/app/components/Chat.vue
@@ -13,9 +13,7 @@
 <style lang="less" scoped>
 @import '../styles/index';
 .chat {
-  position: absolute;
-  width: 100%;
-  height: 100%;
+  .flex--grow();
   overflow: hidden; // webview content can affect external UI without this rule
 }
 

--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -84,13 +84,13 @@
 
       <div class="live-dock-chat" v-if="isTwitch || isMixer || (isYoutube && isStreaming) || isFacebook">
           <div v-if="hasChatApps" class="live-dock-chat-apps__list-input flex">
+            <tabs :tabs="chatTabs" v-model="selectedChat" :hideContent="true" />
             <i
               class="live-dock-chat-apps__popout icon-pop-out-1"
               v-tooltip.left="$t('Pop out to new window')"
               v-if="isPopOutAllowed"
               @click="popOut"
             />
-            <tabs :tabs="chatTabs" v-model="selectedChat" :hideContent="true" />
           </div>
         <!-- v-if is required because left-side chat will not properly load on application startup -->
         <chat v-if="!applicationLoading" :style="defaultChatStyles" ref="chat" />
@@ -99,6 +99,7 @@
           class="live-dock-platform-app-webview"
           :appId="selectedChat"
           :pageSlot="slot"
+          :key="selectedChat"
         />
       </div>
       <div class="flex flex--center flex--column live-dock-chat--offline" v-else >

--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -76,18 +76,6 @@
           </a>
         </div>
         <div class="flex">
-          <div v-if="hasChatApps" class="live-dock-chat-apps__list-input flex">
-            <i
-              class="live-dock-chat-apps__popout icon-pop-out-1"
-              v-tooltip.left="$t('Pop out to new window')"
-              v-if="isPopOutAllowed"
-              @click="popOut"
-            />
-            <list-input
-              v-model="selectedChat"
-              :metadata="chatAppsListMetadata"
-            />
-          </div>
           <a @click="refreshChat" v-if="isTwitch || isMixer || (isYoutube && isStreaming) || isFacebook">
             {{ $t('Refresh Chat') }}
           </a>
@@ -95,6 +83,15 @@
       </div>
 
       <div class="live-dock-chat" v-if="isTwitch || isMixer || (isYoutube && isStreaming) || isFacebook">
+          <div v-if="hasChatApps" class="live-dock-chat-apps__list-input flex">
+            <i
+              class="live-dock-chat-apps__popout icon-pop-out-1"
+              v-tooltip.left="$t('Pop out to new window')"
+              v-if="isPopOutAllowed"
+              @click="popOut"
+            />
+            <tabs :tabs="chatTabs" v-model="selectedChat" :hideContent="true" />
+          </div>
         <!-- v-if is required because left-side chat will not properly load on application startup -->
         <chat v-if="!applicationLoading" :style="defaultChatStyles" ref="chat" />
         <PlatformAppPageView
@@ -227,9 +224,9 @@
 }
 
 .live-dock-chat {
-  flex-grow: 1;
-  position: relative;
   .flex();
+  .flex--column();
+  .flex--grow();
 }
 
 .live-dock-chat--offline {

--- a/app/components/LiveDock.vue.ts
+++ b/app/components/LiveDock.vue.ts
@@ -228,12 +228,14 @@ export default class LiveDock extends Vue {
         value: 'default',
       },
     ].concat(
-      this.chatApps.map(app => {
-        return {
-          name: app.manifest.name,
-          value: app.id,
-        };
-      }),
+      this.chatApps
+        .filter(app => !app.poppedOutSlots.includes(this.slot))
+        .map(app => {
+          return {
+            name: app.manifest.name,
+            value: app.id,
+          };
+        }),
     );
   }
 

--- a/app/services/platform-apps/container-manager.ts
+++ b/app/services/platform-apps/container-manager.ts
@@ -260,7 +260,7 @@ export class PlatformContainerManager {
    */
   private getAppPartition(app: ILoadedApp) {
     const userId = this.userService.platformId;
-    const partition = `platformApp-${app.id}-${userId}`;
+    const partition = `platformApp-${app.id}-${userId}-${app.unpacked}`;
 
     if (!this.sessionsInitialized[partition]) {
       const session = electron.remote.session.fromPartition(partition);


### PR DESCRIPTION
We can't render over browser views, so our old solution of a drop down no longer works.  This switches to using tabs instead.  This is not really scalable, but we only have 1 or 2 apps in the store that utilize this slot currently, so it will work for now.