### PR TITLE
Fix MediaGallery uploading toast and file usage

### DIFF
--- a/app/components/windows/MediaGallery.vue.ts
+++ b/app/components/windows/MediaGallery.vue.ts
@@ -199,6 +199,7 @@ export default class MediaGallery extends Vue {
   }
 
   async upload(filepaths: string[]) {
+    if (!filepaths || !filepaths.length) return;
     this.setBusy($t('Uploading...'));
     this.galleryInfo = await this.mediaGalleryService.upload(filepaths);
     this.setNotBusy();

--- a/app/services/media-gallery/media-gallery.ts
+++ b/app/services/media-gallery/media-gallery.ts
@@ -76,7 +76,10 @@ export class MediaGalleryService extends Service {
 
   async fetchGalleryInfo(): Promise<IMediaGalleryInfo> {
     const [files, limits] = await Promise.all([this.fetchFiles(), this.fetchFileLimits()]);
-    const totalUsage = files.reduce((size: number, file: IMediaGalleryFile) => size + file.size, 0);
+    const totalUsage = files.reduce(
+      (size: number, file: IMediaGalleryFile) => size + Number(file.size),
+      0,
+    );
     return { files, totalUsage, ...limits };
   }
 


### PR DESCRIPTION
I'm not sure what happened in the file api to cause the size to return a string instead of a number, seems like an electron change? Regardless it was causing weird math to happen. Uploading message was just a missing guard clause