### PR TITLE
fix(inputs): exception when opening streamlabel source

### DIFF
--- a/app/components/obs/inputs/ObsGoogleFontSelector.vue.ts
+++ b/app/components/obs/inputs/ObsGoogleFontSelector.vue.ts
@@ -50,12 +50,13 @@ export default class GoogleFontSelector extends ObsInput<IGoogleFont> {
 
   actualStyle: number = 0;
 
-  loading = true;
+  // Disambiguate from `loading` which it would conflict with prop being passed/inherited to this
+  isLoading = true;
 
   created() {
-    this.loading = true;
+    this.isLoading = true;
     this.fontLibraryService.getManifest().then(manifest => {
-      this.loading = false;
+      this.isLoading = false;
       this.fontFamilies = manifest.families.map(family => family.name);
 
       if (this.value.path) this.updateSelectionFromPath();
@@ -80,7 +81,7 @@ export default class GoogleFontSelector extends ObsInput<IGoogleFont> {
   }
 
   setFamily(familyName: string) {
-    this.loading = true;
+    this.isLoading = true;
     this.selectedFamily = familyName;
 
     this.fontLibraryService.findFamily(familyName).then(family => {
@@ -92,7 +93,7 @@ export default class GoogleFontSelector extends ObsInput<IGoogleFont> {
   }
 
   setStyle(styleName: string) {
-    this.loading = true;
+    this.isLoading = true;
     this.selectedStyle = styleName;
 
     this.fontLibraryService.findStyle(this.selectedFamily, styleName).then(style => {
@@ -113,7 +114,7 @@ export default class GoogleFontSelector extends ObsInput<IGoogleFont> {
         this.value.flags = this.actualStyle;
 
         this.emitInput({ ...this.value, path: fontPath });
-        this.loading = false;
+        this.isLoading = false;
       });
     });
   }


### PR DESCRIPTION
Opening a streamlabel source and selecting "Use Google Font" triggers an exception as this
component uses a `loading` property that appears to conflict with our new inputs/form handling, as a result, Vue thinks is the parent prop we're mutating and the general handling of that could be unreliable. Fix just renames prop to `isLoading`.