### PR TITLE
chore(package): fix missing peer dependency for jsx plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "@types/webdriverio": "4.13.0",
     "@xkeshi/vue-qrcode": "0.3.0",
     "ava": "v1.0.0-rc.2",
+    "babel-helper-vue-jsx-merge-props": "2.0.0",
     "babel-loader": "8.0.4",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-plugin-transform-class-properties": "6.24.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,11 @@ babel-helper-get-function-arity@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-helper-vue-jsx-merge-props@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-2.0.0.tgz#a5eea94b03d7be4e61865a775263b17c61bb2a65"
+  integrity sha1-pe6pSwPXvk5hhlp3UmOxfGG7KmU=
+
 babel-loader@8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.4.tgz#7bbf20cbe4560629e2e41534147692d3fecbdce6"


### PR DESCRIPTION
Fixes this warning:
```
warning " > babel-plugin-transform-vue-jsx@3.7.0" has unmet peer dependency "babel-helper-vue-jsx-merge-props@^2.0.0".
```
