### PR TITLE
ci: test timeouts on first run

### DIFF
--- a/test/helpers/runner.js
+++ b/test/helpers/runner.js
@@ -15,7 +15,7 @@ const args = process.argv.slice(2);
 (function main() {
   try {
     rimraf.sync(failedTestsFile);
-    execSync('yarn test ' + args.join(' '), { stdio: [0, 1, 2] });
+    execSync('yarn test --timeout=2m' + args.join(' '), { stdio: [0, 1, 2] });
   } catch (e) {
     retryTests();
   }


### PR DESCRIPTION
Add a 1 minute timeout for tests when running on CI (via `test-flaky`), test retries are not
affected by this at this moment. We should consider changing this as well.