### PR TITLE
ci: remove upsource triggers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,6 @@
 build: off
 
 install:
-  # unfortunately, `commitId` in hooks is abbreviated and we can't work with that for Upsource
-  # set a custom message as the full commit ID. This *has* to be the first job given the way
-  # our service is designed, please don't move.
-  - ps: Add-AppveyorMessage $env:APPVEYOR_REPO_COMMIT
   - ps: Install-Product node 10 x64
   - yarn install --frozen-lockfile --check-files
   - yarn lint
@@ -27,10 +23,6 @@ test_script:
 notifications:
   - provider: GitHubPullRequest
     template: "{{#failed}}:x: build failed{{/failed}} {{#jobs}} {{#messages}} {{message}} {{/messages}} {{/jobs}}"
-  # Build status to Upsource
-  - provider: Webhook
-    url: https://n2svzw3n4f.execute-api.us-east-1.amazonaws.com/dev/hooks/appveyor
-    on_build_status_changed: true
 
 cache:
   - plugins


### PR DESCRIPTION
As Upsource is not being used at the moment, remove the steps necessary to make the CI integration work, namely a custom step that established the commit ID (which is now only adding noise to PR comments), and the webhook (which is definitely failing, and consuming a few seconds).

We can look back at this commit to re-enable, if we ever choose so.