### PR TITLE
Add dynamic keys to AlertBox forms

### DIFF
--- a/app/components/widgets/AlertBox.vue
+++ b/app/components/widgets/AlertBox.vue
@@ -66,23 +66,23 @@
     </div>
   </div>
 
-  <validated-form slot="layout" @input="save()">
-    <alert-layout-input v-model="selectedVariation.settings.layout" v-if="selectedVariation" />
+  <validated-form slot="layout" @input="save()" :key="`layout-${selectedAlert}-${selectedId}`" v-if="selectedVariation">
+    <alert-layout-input v-model="selectedVariation.settings.layout" />
   </validated-form>
 
   <!-- Global Settings -->
-  <validated-form slot="general-properties" @input="save()" v-if="selectedVariation">
+  <validated-form slot="general-properties" :key="`general-properties-${selectedAlert}-${selectedId}`" @input="save()" v-if="selectedVariation">
     <v-form-group v-model="wData.settings.background_color" :metadata="metadata.bgColor" />
     <v-form-group v-model="wData.settings.alert_delay" :metadata="metadata.alertDelay" />
   </validated-form>
-  <validated-form slot="moderation-properties" @input="save()" v-if="selectedVariation">
+  <validated-form slot="moderation-properties" :key="`moderation-properties-${selectedAlert}-${selectedId}`" @input="save()" v-if="selectedVariation">
     <v-form-group v-model="wData.settings.unlimited_alert_moderation_enabled" :metadata="metadata.unlimitedAlertMod" />
     <v-form-group v-model="wData.settings.moderation_delay" :metadata="metadata.moderationDelay" />
     <v-form-group v-model="wData.settings.unlimited_media_moderation_delay" :metadata="metadata.unlimitedMediaMod" />
   </validated-form>
 
   <!-- Alert-Specific Settings -->
-  <validated-form slot="title-properties" key="title-properties" @input="save()" v-if="selectedVariation">
+  <validated-form slot="title-properties" :key="`title-properties-${selectedAlert}-${selectedId}`" @input="save()" v-if="selectedVariation">
     <div v-if="selectedVariation.settings.text">
       <v-form-group v-model="selectedVariation.settings.text.format" :metadata="metadata.template" />
       <v-form-group v-model="selectedVariation.settings.text.font" :metadata="metadata.fontFamily" />
@@ -92,12 +92,12 @@
       <v-form-group v-model="selectedVariation.settings.text.color2" :metadata="metadata.secondaryColor" />
     </div>
   </validated-form>
-  <validated-form slot="media-properties" key="media-properties" @input="handleFacemaskInput()" v-if="selectedVariation">
+  <validated-form slot="media-properties" :key="`media-properties--${selectedAlert}-${selectedId}`" @input="handleFacemaskInput()" v-if="selectedVariation">
     <v-form-group v-model="selectedVariation.settings.image.href" :metadata="metadata.imageFile" v-if="selectedVariation.settings.image" />
     <v-form-group :metadata="metadata.soundFile" v-model="selectedVariation.settings.sound.href" v-if="selectedVariation.settings.sound" />
     <v-form-group v-model="selectedVariation.settings.sound.volume" :metadata="metadata.soundVolume" v-if="selectedVariation.settings.sound" />
   </validated-form>
-  <validated-form slot="message-properties" key="message-properties" @input="save()" v-if="selectedVariation">
+  <validated-form slot="message-properties" :key="`message-properties-${selectedAlert}-${selectedId}`" @input="save()" v-if="selectedVariation">
     <v-form-group v-model="selectedVariation.showMessage" :metadata="metadata.showMessage" />
     <div v-if="selectedVariation.settings.message">
       <v-form-group v-model="selectedVariation.settings.message.minAmount" :metadata="metadata.minAmount" />
@@ -116,14 +116,14 @@
       <v-form-group v-model="selectedVariation.settings.tts.security" :metadata="metadata.ttsSecurity" />
     </div>
   </validated-form>
-  <validated-form slot="animation-properties" key="animation-properties" @input="handleFacemaskInput()" v-if="selectedVariation">
+  <validated-form slot="animation-properties" :key="`animation-properties-${selectedAlert}-${selectedId}`" @input="handleFacemaskInput()" v-if="selectedVariation">
     <v-form-group v-model="selectedVariation.settings.showAnimation" :metadata="metadata.showAnimation" />
     <v-form-group v-model="selectedVariation.settings.hideAnimation" :metadata="metadata.hideAnimation" />
     <v-form-group v-model="selectedVariation.settings.duration" :metadata="metadata.duration" />
     <v-form-group v-model="selectedVariation.settings.text.animation"  :metadata="metadata.textAnimation" v-if="selectedVariation.settings.text" />
     <v-form-group v-model="selectedVariation.settings.textDelay" :metadata="metadata.textDelay" />
   </validated-form>
-  <validated-form slot="alert-properties" key="alert-properties" @input="save()" v-if="selectedVariation">
+  <validated-form slot="alert-properties" :key="`alert-properties-${selectedAlert}-${selectedId}`" @input="save()" v-if="selectedVariation">
     <v-form-group v-model="minTriggerAmount" :metadata="metadata.minTriggerAmount" v-if="['donations', 'bits', 'hosts', 'raids'].includes(selectedAlert)" />
     <v-form-group v-model="minRecentEvents" :metadata="metadata.minRecentEvents" v-if="['donations', 'hosts'].includes(selectedAlert)" />
     <div v-if="selectedId !== 'default'">

--- a/app/components/widgets/AlertBox.vue.ts
+++ b/app/components/widgets/AlertBox.vue.ts
@@ -127,7 +127,10 @@ export default class AlertBox extends WidgetSettings<IAlertBoxData, AlertBoxServ
       { value: 'animation', label: $t('Animation') },
     ];
     if (HAS_DONOR_MESSAGE.includes(this.selectedAlert)) {
-      baseItems.push({ value: 'message', label: $t('Donor Message') });
+      baseItems.push({
+        value: 'message',
+        label: this.selectedAlert === 'subs' ? $t('Resub Message') : $t('Donor Message'),
+      });
     }
     if (HAS_ALERT_SETTINGS.includes(this.selectedAlert) || this.selectedId !== 'default') {
       baseItems.push({ value: 'alert', label: $t('Alert Settings') });

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component, Prop, Watch } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { $t } from 'services/i18n';
 import { TObsFormData } from 'components/obs/inputs/ObsInput';
@@ -170,6 +170,11 @@ export default class WidgetEditor extends Vue {
 
   updateCurrentSetting(value: string) {
     this.currentSetting = value;
+  }
+
+  @Watch('selectedAlert')
+  autoselectCurrentSetting() {
+    this.currentSetting = this.navItems[0].value;
   }
 
   toggleCustomCode(enabled: boolean) {


### PR DESCRIPTION
Should stop settings from overwriting eachother when switching between alert variations

Also tightens up the UI for a better overall flow when switching between elements