### PR TITLE
refactor: unused imports with tslint

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -10,7 +10,6 @@ import Vue from 'vue';
 import { createStore } from './store';
 import { WindowsService } from './services/windows';
 import { AppService } from './services/app';
-import { ServicesManager } from './services-manager';
 import Utils from './services/utils';
 import electron from 'electron';
 import * as Sentry from '@sentry/browser';

--- a/app/components/AppsNav.vue.ts
+++ b/app/components/AppsNav.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { NavigationService } from 'services/navigation';
 import { PlatformAppsService, EAppPageSlot, ILoadedApp } from 'services/platform-apps';

--- a/app/components/Login.vue.ts
+++ b/app/components/Login.vue.ts
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { UserService } from 'services/user';
-import { OnboardingService } from 'services/onboarding';
 import { Inject } from 'util/injector';
 import { $t } from 'services/i18n';
 

--- a/app/components/TopNav.vue.ts
+++ b/app/components/TopNav.vue.ts
@@ -10,7 +10,7 @@ import { SettingsService } from 'services/settings';
 import { WindowsService } from 'services/windows';
 import Utils from 'services/utils';
 import { TransitionsService } from 'services/transitions';
-import { PlatformAppsService, EAppPageSlot } from 'services/platform-apps';
+import { PlatformAppsService } from 'services/platform-apps';
 import { IncrementalRolloutService, EAvailableFeatures } from 'services/incremental-rollout';
 import { AppService } from '../services/app';
 import VueResize from 'vue-resize';

--- a/app/components/obs/inputs/ObsColorInput.vue.ts
+++ b/app/components/obs/inputs/ObsColorInput.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Watch, Prop } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import { debounce } from 'lodash-decorators';
 import { TObsType, IObsInput, ObsInput } from './ObsInput';
 import Utils from '../../../services/utils';

--- a/app/components/obs/inputs/ObsListInput.vue.ts
+++ b/app/components/obs/inputs/ObsListInput.vue.ts
@@ -1,5 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
-import { TObsType, IObsListInput, IObsListOption, ObsInput, TObsValue } from './ObsInput';
+import { TObsType, IObsListInput, ObsInput, TObsValue } from './ObsInput';
 import { ListInput } from 'components/shared/inputs/inputs';
 import HFormGroup from 'components/shared/inputs/HFormGroup.vue';
 

--- a/app/components/page-components/Chatbot/Bet/ChatbotBetOptionModal.vue.ts
+++ b/app/components/page-components/Chatbot/Bet/ChatbotBetOptionModal.vue.ts
@@ -4,7 +4,7 @@ import ListInput from 'components/shared/inputs/ListInput.vue';
 import NumberInput from 'components/shared/inputs/NumberInput.vue';
 import { $t } from 'services/i18n';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
-import { EInputType, formMetadata } from 'components/shared/inputs/index';
+import { formMetadata } from 'components/shared/inputs';
 
 import { IBettingOption } from 'services/chatbot';
 import VFormGroup from 'components/shared/inputs/VFormGroup.vue';

--- a/app/components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue.ts
+++ b/app/components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue.ts
@@ -1,5 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep';
-import { Component, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import { $t } from 'services/i18n';
 import {
@@ -22,7 +22,6 @@ import {
   IInputMetadata,
   ITextMetadata,
 } from 'components/shared/inputs/index';
-import { debounce } from 'lodash-decorators';
 
 interface IChatbotPunishmentMetadata {
   type: IListMetadata<string>;

--- a/app/components/page-components/Chatbot/windows/ChatbotBettingPreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotBettingPreferencesWindow.vue.ts
@@ -3,10 +3,8 @@ import cloneDeep from 'lodash/cloneDeep';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import { $t } from 'services/i18n';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
-
 import { IBettingPreferencesResponse } from 'services/chatbot';
-
-import { metadata, formMetadata } from 'components/shared/inputs/index';
+import { metadata, formMetadata } from 'components/shared/inputs';
 import { ITab } from 'components/Tabs.vue';
 import { debounce } from 'lodash-decorators';
 

--- a/app/components/page-components/Chatbot/windows/ChatbotCapsProtectionWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotCapsProtectionWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotModToolsBase from 'components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue';
 import { $t } from 'services/i18n';
 import { ITab } from 'components/Tabs.vue';

--- a/app/components/page-components/Chatbot/windows/ChatbotCommandPreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotCommandPreferencesWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { $t } from 'services/i18n';

--- a/app/components/page-components/Chatbot/windows/ChatbotCustomCommandWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotCustomCommandWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Watch, Vue } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import ChatbotAliases from 'components/page-components/Chatbot/shared/ChatbotAliases.vue';
 import cloneDeep from 'lodash/cloneDeep';

--- a/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotDefaultCommandWindow.vue.ts
@@ -7,8 +7,7 @@ import ChatbotAliases from 'components/page-components/Chatbot/shared/ChatbotAli
 import { metadata as metadataHelper } from 'components/widgets/inputs';
 import { $t } from 'services/i18n';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
-
-import { IListMetadata, ITextMetadata, EInputType } from 'components/shared/inputs/index';
+import { IListMetadata, EInputType } from 'components/shared/inputs';
 import { debounce } from 'lodash-decorators';
 
 @Component({

--- a/app/components/page-components/Chatbot/windows/ChatbotGamblePreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotGamblePreferencesWindow.vue.ts
@@ -5,7 +5,7 @@ import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
 
 import { IGamblePreferencesResponse } from 'services/chatbot';
 
-import { EInputType, metadata, formMetadata } from 'components/shared/inputs/index';
+import { metadata, formMetadata } from 'components/shared/inputs/index';
 import { debounce } from 'lodash-decorators';
 
 @Component({

--- a/app/components/page-components/Chatbot/windows/ChatbotHeistPreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotHeistPreferencesWindow.vue.ts
@@ -1,12 +1,11 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import { $t } from 'services/i18n';
 import cloneDeep from 'lodash/cloneDeep';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
-import Vue from 'vue';
 import { IHeistPreferencesResponse } from 'services/chatbot';
 
-import { EInputType, metadata, formMetadata } from 'components/shared/inputs/index';
+import { metadata, formMetadata } from 'components/shared/inputs/index';
 import { ITab } from 'components/Tabs.vue';
 import { debounce } from 'lodash-decorators';
 

--- a/app/components/page-components/Chatbot/windows/ChatbotQueuePreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotQueuePreferencesWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { $t } from 'services/i18n';

--- a/app/components/page-components/Chatbot/windows/ChatbotQuotePreferencesWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotQuotePreferencesWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { $t } from 'services/i18n';

--- a/app/components/page-components/Chatbot/windows/ChatbotQuoteWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotQuoteWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { $t } from 'services/i18n';

--- a/app/components/page-components/Chatbot/windows/ChatbotSongRequestOnboardingWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotSongRequestOnboardingWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ChatbotWindowsBase from 'components/page-components/Chatbot/windows/ChatbotWindowsBase.vue';
 import { $t } from 'services/i18n';
 import cloneDeep from 'lodash/cloneDeep';

--- a/app/components/page-components/Chatbot/windows/ChatbotSymbolProtectionWindow.vue.ts
+++ b/app/components/page-components/Chatbot/windows/ChatbotSymbolProtectionWindow.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import ChatbotModToolsBase from 'components/page-components/Chatbot/module-bases/ChatbotModToolsBase.vue';
 import { $t } from 'services/i18n';
 import { ITab } from 'components/Tabs.vue';

--- a/app/components/pages/Help.vue.ts
+++ b/app/components/pages/Help.vue.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:max-line-length */
 import Vue from 'vue';
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import electron from 'electron';
 
 @Component({})

--- a/app/components/pages/PlatformAppStore.vue.ts
+++ b/app/components/pages/PlatformAppStore.vue.ts
@@ -5,7 +5,7 @@ import { Inject } from 'util/injector';
 import { GuestApiService } from 'services/guest-api';
 import { I18nService } from 'services/i18n';
 import electron from 'electron';
-import { PlatformAppsService, EAppPageSlot } from 'services/platform-apps';
+import { PlatformAppsService } from 'services/platform-apps';
 import { PlatformAppStoreService } from 'services/platform-app-store';
 import Utils from 'services/utils';
 

--- a/app/components/pages/onboarding_steps/SceneCollectionsImport.vue.ts
+++ b/app/components/pages/onboarding_steps/SceneCollectionsImport.vue.ts
@@ -2,9 +2,6 @@ import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 import { Inject } from '../../../util/injector';
 import { OnboardingService } from '../../../services/onboarding';
-import { Multiselect } from 'vue-multiselect';
-import { ObsImporterService } from '../../../services/obs-importer';
-import { defer } from 'lodash';
 import { SceneCollectionsService } from 'services/scene-collections';
 
 @Component({})

--- a/app/components/shared/Display.vue.ts
+++ b/app/components/shared/Display.vue.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import { Component, Prop, Watch } from 'vue-property-decorator';
-import electron from 'electron';
 import { Inject } from 'util/injector';
 import { VideoService, Display as OBSDisplay } from 'services/video';
 import { WindowsService } from 'services/windows';

--- a/app/components/shared/HScroll.vue.ts
+++ b/app/components/shared/HScroll.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, Prop } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import ResizeSensor from 'css-element-queries/src/ResizeSensor';
 import { isEqual } from 'lodash';
 

--- a/app/components/shared/inputs/BaseFormGroup.ts
+++ b/app/components/shared/inputs/BaseFormGroup.ts
@@ -1,9 +1,7 @@
-import { Prop, Watch, Component } from 'vue-property-decorator';
-import Vue from 'vue';
+import { Prop } from 'vue-property-decorator';
 import { ErrorField } from 'vee-validate';
 import { EInputType, IInputMetadata } from './index';
 import { BaseInput } from './BaseInput';
-import ValidatedForm from 'components/shared/inputs/ValidatedForm.vue';
 
 /**
  * Base class for input-component layouts

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
-import { Component, Prop } from 'vue-property-decorator';
+import { Prop } from 'vue-property-decorator';
 import uuid from 'uuid/v4';
 import { IInputMetadata } from './index';
 import ValidatedForm from './ValidatedForm.vue';

--- a/app/components/shared/inputs/FontFamilyInput.vue.ts
+++ b/app/components/shared/inputs/FontFamilyInput.vue.ts
@@ -1,5 +1,4 @@
 import { Component, Prop } from 'vue-property-decorator';
-import { Multiselect } from 'vue-multiselect';
 import { BaseInput } from './BaseInput';
 import ListInput from './ListInput.vue';
 import { IInputMetadata } from './index';

--- a/app/components/shared/inputs/NumberInput.vue.ts
+++ b/app/components/shared/inputs/NumberInput.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component, Prop } from 'vue-property-decorator';
 import { BaseInput } from './BaseInput';
 import { INumberMetadata } from './index';
 

--- a/app/components/shared/inputs/SoundInput.vue.ts
+++ b/app/components/shared/inputs/SoundInput.vue.ts
@@ -1,4 +1,3 @@
-import { shell } from 'electron';
 import Component from 'vue-class-component';
 import { Inject } from 'util/injector';
 import { Prop } from 'vue-property-decorator';

--- a/app/components/widgets/MediaShare.vue.ts
+++ b/app/components/widgets/MediaShare.vue.ts
@@ -1,9 +1,5 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
-import {
-  MediaShareService,
-  IMediaShareData,
-  IMediaShareBan,
-} from 'services/widgets/settings/media-share';
+import { Component } from 'vue-property-decorator';
+import { MediaShareService, IMediaShareData } from 'services/widgets/settings/media-share';
 import { Inject } from '../../util/injector';
 
 import WidgetEditor from 'components/windows/WidgetEditor.vue';

--- a/app/components/widgets/SpinWheel.vue.ts
+++ b/app/components/widgets/SpinWheel.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { SpinWheelService, ISpinWheelData } from 'services/widgets/settings/spin-wheel';
 
 import WidgetEditor from 'components/windows/WidgetEditor.vue';

--- a/app/components/widgets/SponsorBanner.vue.ts
+++ b/app/components/widgets/SponsorBanner.vue.ts
@@ -1,4 +1,4 @@
-import { Component, Prop, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { SponsorBannerService, ISponsorBannerData } from 'services/widgets/settings/sponsor-banner';
 
 import WidgetEditor from 'components/windows/WidgetEditor.vue';

--- a/app/components/widgets/inputs/FrequencyInput.vue.ts
+++ b/app/components/widgets/inputs/FrequencyInput.vue.ts
@@ -1,5 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
-import { IInputMetadata, IListOption } from '../../shared/inputs';
+import { IInputMetadata } from '../../shared/inputs';
 import ListInput from 'components/shared/inputs/ListInput.vue';
 import { BaseInput } from 'components/shared/inputs/BaseInput';
 import { $t } from 'services/i18n';

--- a/app/components/widgets/inputs/SectionedMultiselectInput.vue.ts
+++ b/app/components/widgets/inputs/SectionedMultiselectInput.vue.ts
@@ -1,5 +1,5 @@
 import { Component, Prop } from 'vue-property-decorator';
-import { IListMetadata, IListOption } from '../../shared/inputs';
+import { IListMetadata } from '../../shared/inputs';
 import { BaseInput } from 'components/shared/inputs/BaseInput';
 import { Multiselect } from 'vue-multiselect';
 

--- a/app/components/windows/AddSource.vue.ts
+++ b/app/components/windows/AddSource.vue.ts
@@ -3,17 +3,11 @@ import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { WindowsService } from 'services/windows';
 import { IScenesServiceApi } from 'services/scenes';
-import {
-  ISourcesServiceApi,
-  TSourceType,
-  TPropertiesManager,
-  ISourceApi,
-  ISourceAddOptions,
-} from 'services/sources';
+import { ISourcesServiceApi, TSourceType, ISourceApi, ISourceAddOptions } from 'services/sources';
 import ModalLayout from 'components/ModalLayout.vue';
 import Selector from 'components/Selector.vue';
 import Display from 'components/shared/Display.vue';
-import { WidgetsService, WidgetType, WidgetDefinitions } from 'services/widgets';
+import { WidgetsService, WidgetDefinitions } from 'services/widgets';
 import { $t } from 'services/i18n';
 import { PlatformAppsService } from 'services/platform-apps';
 

--- a/app/components/windows/ChildWindow.vue.ts
+++ b/app/components/windows/ChildWindow.vue.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import electron from 'electron';
-import { Component, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { getComponents, IWindowOptions, WindowsService } from 'services/windows';
 import { CustomizationService } from 'services/customization';

--- a/app/components/windows/OneOffWindow.vue.ts
+++ b/app/components/windows/OneOffWindow.vue.ts
@@ -1,6 +1,5 @@
 import Vue from 'vue';
-import electron from 'electron';
-import { Component, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { Inject } from 'util/injector';
 import { getComponents, WindowsService } from 'services/windows';
 import { CustomizationService } from 'services/customization';

--- a/app/components/windows/Projector.vue.ts
+++ b/app/components/windows/Projector.vue.ts
@@ -7,7 +7,6 @@ import { WindowsService } from 'services/windows';
 import { ISourcesServiceApi } from 'services/sources';
 import electron from 'electron';
 import Util from 'services/utils';
-import { $t } from 'services/i18n';
 import { Subscription } from 'rxjs';
 
 @Component({

--- a/app/components/windows/RenameSource.vue.ts
+++ b/app/components/windows/RenameSource.vue.ts
@@ -4,8 +4,8 @@ import { Inject } from '../../util/injector';
 import ModalLayout from '../ModalLayout.vue';
 import { WindowsService } from '../../services/windows';
 import { IScenesServiceApi } from '../../services/scenes';
-import { ISourcesServiceApi, TSourceType, TPropertiesManager } from '../../services/sources';
-import { WidgetsService, WidgetDefinitions, WidgetType } from '../../services/widgets';
+import { ISourcesServiceApi } from '../../services/sources';
+import { WidgetsService } from '../../services/widgets';
 import { $t } from 'services/i18n';
 
 @Component({

--- a/app/services/announcements.ts
+++ b/app/services/announcements.ts
@@ -3,7 +3,6 @@ import { UserService } from './user';
 import { HostsService } from './hosts';
 import { Inject } from '../util/injector';
 import { authorizedHeaders } from '../util/requests';
-import { TAppPage } from './navigation';
 
 interface IAnnouncementsInfo {
   id: number;

--- a/app/services/chatbot/chatbot-heist.ts
+++ b/app/services/chatbot/chatbot-heist.ts
@@ -5,16 +5,7 @@ import { mutation } from '../stateful-service';
 import { ChatbotCommonService } from './chatbot-common';
 import { ChatbotBaseApiService } from './chatbot-base';
 
-import {
-  IChatbotAPIPutResponse,
-  IChatbotAPIDeleteResponse,
-  ILoyaltyResponse,
-  IChatbotLoyalty,
-  ILoyaltyPreferencesData,
-  ILoyaltyPreferencesResponse,
-  IChatbotAPIPostResponse,
-  IHeistPreferencesResponse,
-} from './chatbot-interfaces';
+import { IChatbotAPIPostResponse, IHeistPreferencesResponse } from './chatbot-interfaces';
 
 // state
 interface IChatbotHeistApiServiceState {

--- a/app/services/font-library.ts
+++ b/app/services/font-library.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import fs from 'fs';
 import https from 'https';
 import electron from 'electron';
-import { EFontStyle } from 'obs-studio-node';
 
 export interface IFamilyWithStyle {
   family: IFontFamily;

--- a/app/services/media-gallery/stock-library.ts
+++ b/app/services/media-gallery/stock-library.ts
@@ -1,5 +1,3 @@
-import { IMediaGalleryFile } from './media-gallery';
-
 export const stockSounds = [
   {
     href: 'http://uploads.twitchalerts.com/sound-defaults/bonus-2.ogg',

--- a/app/services/onboarding.ts
+++ b/app/services/onboarding.ts
@@ -2,7 +2,6 @@ import { StatefulService, mutation } from './stateful-service';
 import { NavigationService } from './navigation';
 import { UserService } from './user';
 import { Inject } from '../util/injector';
-import electron from 'electron';
 import { BrandDeviceService } from 'services/auto-config/brand-device';
 
 type TOnboardingStep =

--- a/app/services/platform-apps/api/modules/authorization.ts
+++ b/app/services/platform-apps/api/modules/authorization.ts
@@ -1,5 +1,5 @@
 import { Module, EApiPermissions, apiMethod, IApiContext } from './module';
-import electron, { BrowserWindow, app } from 'electron';
+import electron, { BrowserWindow } from 'electron';
 import url from 'url';
 import uuid from 'uuid/v4';
 

--- a/app/services/platform-apps/api/modules/sources.ts
+++ b/app/services/platform-apps/api/modules/sources.ts
@@ -1,11 +1,4 @@
-import {
-  Module,
-  EApiPermissions,
-  apiMethod,
-  apiEvent,
-  NotImplementedError,
-  IApiContext,
-} from './module';
+import { Module, EApiPermissions, apiMethod, apiEvent, IApiContext } from './module';
 import { SourcesService, TSourceType, Source } from 'services/sources';
 import { Inject } from 'util/injector';
 import { Subject } from 'rxjs';

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -1,7 +1,6 @@
 import { StatefulService, mutation } from '../stateful-service';
 import {
   IPlatformService,
-  IPlatformAuth,
   IChannelInfo,
   IGame,
   TPlatformCapability,

--- a/app/services/platforms/mixer.ts
+++ b/app/services/platforms/mixer.ts
@@ -1,4 +1,3 @@
-import { Service } from '../service';
 import { StatefulService, mutation } from '../stateful-service';
 import {
   IPlatformService,

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -1,4 +1,3 @@
-import { Service } from '../service';
 import { StatefulService, mutation } from '../stateful-service';
 import {
   IPlatformService,

--- a/app/services/scene-collections/nodes/overlays/slots.ts
+++ b/app/services/scene-collections/nodes/overlays/slots.ts
@@ -1,5 +1,5 @@
 import { ArrayNode } from '../array-node';
-import { SceneItem, Scene, TSceneNode, TSceneNodeType, ScenesService } from 'services/scenes';
+import { SceneItem, Scene, TSceneNode, ScenesService } from 'services/scenes';
 import { VideoService } from 'services/video';
 import { SourcesService } from 'services/sources';
 import { SourceFiltersService, TSourceFilterType } from 'services/source-filters';

--- a/app/services/scene-collections/nodes/overlays/streamlabel.ts
+++ b/app/services/scene-collections/nodes/overlays/streamlabel.ts
@@ -1,8 +1,6 @@
 import { Node } from '../node';
 import { SceneItem } from '../../../scenes';
 import { TextNode } from './text';
-import { Inject } from '../../../../util/injector';
-import path from 'path';
 
 interface ISchema {
   labelType: string;

--- a/app/services/scene-collections/nodes/overlays/widget.ts
+++ b/app/services/scene-collections/nodes/overlays/widget.ts
@@ -1,6 +1,5 @@
 import { Node } from '../node';
 import { SceneItem } from '../../../scenes';
-import { uniqueId } from 'lodash';
 import { WidgetType } from 'services/widgets';
 
 interface ISchema {

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -31,7 +31,7 @@ import {
 } from '.';
 import { SceneCollectionsStateService } from './state';
 import { Subject } from 'rxjs';
-import { TransitionsService, ETransitionType } from 'services/transitions';
+import { TransitionsService } from 'services/transitions';
 import { $t } from '../i18n';
 import { StreamingService, EStreamingState } from 'services/streaming';
 

--- a/app/services/scene-collections/server-api.ts
+++ b/app/services/scene-collections/server-api.ts
@@ -3,7 +3,6 @@ import { Inject } from 'util/injector';
 import { HostsService } from 'services/hosts';
 import { handleResponse, authorizedHeaders } from 'util/requests';
 import { UserService } from 'services/user';
-import Util from 'services/utils';
 
 export interface IServerSceneCollection {
   id?: number;

--- a/app/services/scenes/scene-folder.ts
+++ b/app/services/scenes/scene-folder.ts
@@ -1,5 +1,5 @@
 import { ScenesService, Scene } from './index';
-import { merge, uniq } from 'lodash';
+import { merge } from 'lodash';
 import { mutation, ServiceHelper } from '../stateful-service';
 import Utils from '../utils';
 import { Inject } from 'util/injector';

--- a/app/services/scenes/scene-item.ts
+++ b/app/services/scenes/scene-item.ts
@@ -23,7 +23,6 @@ import {
   ISceneItem,
   ISceneItemApi,
   ISceneItemInfo,
-  TSceneNodeType,
 } from './index';
 import { SceneItemNode } from './scene-node';
 import { v2, Vec2 } from '../../util/vec2';

--- a/app/services/selection/selection-api.ts
+++ b/app/services/selection/selection-api.ts
@@ -1,7 +1,6 @@
 import {
   ISceneItemActions,
   ISceneItemApi,
-  ISceneItem,
   TSceneNodeApi,
   ISceneItemNode,
   ISceneItemFolderApi,

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -1,4 +1,4 @@
-import { invert, cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { StatefulService, mutation } from 'services/stateful-service';
 import {
   inputValuesToObsValues,

--- a/app/services/settings/stream-encoder/stream-encoder-settings.ts
+++ b/app/services/settings/stream-encoder/stream-encoder-settings.ts
@@ -1,4 +1,4 @@
-import { invert, cloneDeep } from 'lodash';
+import { invert } from 'lodash';
 import { Service } from 'services/service';
 import { SettingsService } from 'services/settings';
 import { Inject } from 'util/injector';

--- a/app/services/sources/properties-managers/streamlabels-manager.ts
+++ b/app/services/sources/properties-managers/streamlabels-manager.ts
@@ -1,7 +1,6 @@
 import { DefaultManager, IDefaultManagerSettings } from './default-manager';
 import { Inject } from 'util/injector';
 import { StreamlabelsService, IStreamlabelSubscription } from 'services/streamlabels';
-import { getDefinitions } from 'services/streamlabels/definitions';
 import { UserService } from 'services/user';
 
 export interface IStreamlabelsManagerSettings extends IDefaultManagerSettings {

--- a/app/services/stream-info.ts
+++ b/app/services/stream-info.ts
@@ -5,7 +5,7 @@ import { Inject } from 'util/injector';
 import { StreamingService } from './streaming';
 import { HostsService } from 'services/hosts';
 import { authorizedHeaders } from 'util/requests';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 interface IStreamInfoServiceState {
   fetching: boolean;

--- a/app/services/widgets/settings/alert-box/alert-box-data.ts
+++ b/app/services/widgets/settings/alert-box/alert-box-data.ts
@@ -1,10 +1,5 @@
 import uuid from 'uuid/v4';
-import {
-  IAlertBoxSettings,
-  IAlertBoxApiSettings,
-  IAlertBoxSetting,
-  IAlertBoxVariation,
-} from './alert-box-api';
+import { IAlertBoxVariation } from './alert-box-api';
 import { $t } from 'services/i18n';
 
 export const API_NAME_MAP = {

--- a/app/services/widgets/settings/media-share.ts
+++ b/app/services/widgets/settings/media-share.ts
@@ -1,7 +1,5 @@
 import { IWidgetData, IWidgetSettings, WidgetSettingsService } from '../index';
 import { WidgetType } from 'services/widgets';
-import { clone } from 'lodash';
-import { $t } from 'services/i18n';
 import { InheritMutations } from '../../stateful-service';
 
 export interface IMediaShareSettings extends IWidgetSettings {

--- a/app/util/menus/GroupMenu.ts
+++ b/app/util/menus/GroupMenu.ts
@@ -1,4 +1,3 @@
-import { uniq } from 'lodash';
 import { Menu } from './Menu';
 import { ScenesService } from 'services/scenes';
 import { SelectionService } from 'services/selection';


### PR DESCRIPTION
Sorry for the big diff, this removes all remaining unused imports, using `tslint` and `tslint-etc` one-off run. 

There are still warnings that require more thorough fixes, will need to figure out when to address these.