### PR TITLE
test: advanced settings

### DIFF
--- a/test/helpers/spectron/forms.ts
+++ b/test/helpers/spectron/forms.ts
@@ -4,7 +4,11 @@ import { TExecutionContext } from './index';
 
 async function getNthLabelId(t: TExecutionContext, label: string, index: number) {
   const el = await t.context.app.client.$$(`label=${label}`);
-  return (el[index] as any).ELEMENT;
+  try {
+    return (el[index] as any).ELEMENT;
+  } catch (e) {
+    throw new Error(`Could not find element with label ${label}`);
+  }
 }
 
 export async function setFormInput(t: TExecutionContext, label: string, value: string, index = 0) {
@@ -17,6 +21,16 @@ export async function getFormInput(t: TExecutionContext, label: string, index = 
   const id = await getNthLabelId(t, label, index);
 
   return t.context.app.client.elementIdElement(id, '../..').getValue('input');
+}
+
+export async function getFormCheckbox(
+  t: TExecutionContext,
+  label: string,
+  index = 0,
+): Promise<boolean> {
+  const id = await getNthLabelId(t, label, index);
+
+  return t.context.app.client.elementIdElement(id, '../input').isSelected();
 }
 
 export async function clickFormInput(t: TExecutionContext, label: string, index = 0) {

--- a/test/settings/advanced.ts
+++ b/test/settings/advanced.ts
@@ -1,0 +1,80 @@
+import { focusChild, focusMain, test, useSpectron } from '../helpers/spectron';
+import { FormMonkey } from '../helpers/form-monkey';
+import { addTrailingSpace, createOptionsAssertion } from '../helpers/spectron/assertions';
+import { getFormCheckbox, getFormInput } from '../helpers/spectron/forms';
+
+useSpectron();
+
+test('Populates advanced settings', async t => {
+  const { app } = t.context;
+  const form = new FormMonkey(t);
+  const assertOptions = createOptionsAssertion(t, form);
+
+  await focusMain(t);
+  await app.client.click('.top-nav .icon-settings');
+
+  await focusChild(t);
+  await app.client.click('li=Advanced');
+
+  // Process Priority
+  await assertOptions(
+    '[data-name=ProcessPriority]',
+    'Normal',
+    ['High', 'Above Normal', 'Normal', 'Below Normal', 'Idle'].map(addTrailingSpace),
+  );
+
+  // Color Profile
+  await assertOptions(
+    '[data-name=ColorFormat]',
+    'NV12',
+    ['NV12', 'I420', 'I444', 'RGB'].map(addTrailingSpace),
+  );
+
+  // YUV Color Space
+  await assertOptions('[data-name=ColorSpace]', '601', ['601', '709'].map(addTrailingSpace));
+
+  // YUV Color Range
+  await assertOptions(
+    '[data-name=ColorRange]',
+    'Partial',
+    ['Partial', 'Full'].map(addTrailingSpace),
+  );
+
+  // Force GPU as render device should be checked by default
+  t.true(await getFormCheckbox(t, 'Force GPU as render device'));
+
+  if (process.env.CI) {
+    // Audio Monitoring Device
+    await assertOptions(
+      '[data-name=MonitoringDeviceName]',
+      'Default',
+      ['Default'].map(addTrailingSpace),
+    );
+  }
+
+  // Disable Windows audio ducking should be unchecked
+  t.false(await getFormCheckbox(t, 'Disable Windows audio ducking'));
+
+  // Recording
+  t.is('%CCYY-%MM-%DD %hh-%mm-%ss', await getFormInput(t, 'Filename Formatting'));
+  t.false(await getFormCheckbox(t, 'Overwrite if file exists'));
+
+  // Replay Buffer
+  t.is('Replay', await getFormInput(t, 'Replay Buffer Filename Prefix'));
+  t.is('', await getFormInput(t, 'Replay Buffer Filename Suffix'));
+
+  // Stream Delay
+  t.false(await getFormCheckbox(t, 'Enable'));
+  t.is('20', await getFormInput(t, 'Duration (seconds)'));
+  t.true(await getFormCheckbox(t, 'Preserved cutoff point (increase delay) when reconnecting'));
+
+  // Automatically reconnect
+  t.true(await getFormCheckbox(t, 'Enable', 1));
+  t.is('10', await getFormInput(t, 'Retry Delay (seconds)'));
+  t.is('20', await getFormInput(t, 'Maximum Retries'));
+
+  // Browser Source hardware acceleration should be enabled by default
+  t.true(
+    await getFormCheckbox(t, 'Enable Browser Source Hardware Acceleration (requires a restart)'),
+  );
+});


### PR DESCRIPTION
Test Advanced settings (do not confuse with Advanced settings for Output), e.g. audio ducking, auto-reconnect, stream delay, etc.

Depends on #1440 as other PRs, refactors/helpers were introduced there, will update base branch once that is in.

In addition, adds a custom error message when `getFormInput` from the spectron helpers fails to find an element since the default error doesn't help with debugging at all (`Cannot find property ELEMENT of undefined`).