### PR TITLE
Add scoped variables for colors

### DIFF
--- a/app/components/shared/inputs/ToggleInput.m.less
+++ b/app/components/shared/inputs/ToggleInput.m.less
@@ -8,8 +8,8 @@
   .cursor--pointer();
 }
 .toggleinput__track {
-  .transition;
-  background-color: @light-3;
+  .transition();
+  background-color: var(--input-border);
   border-radius: 20px;
   width: 100%;
   height: 100%;
@@ -24,16 +24,6 @@
   top: 2px;
   left: 2px;
   background-color: @white;
-
-}
-:global(.night-theme) {
-  .toggleinput__track {
-    .transition;
-    background-color: @dark-5;
-    border-radius: 20px;
-    width: 100%;
-    height: 100%;
-  }
 }
 
 .toggleinput__container.active {

--- a/app/components/windows/ChildWindow.vue
+++ b/app/components/windows/ChildWindow.vue
@@ -27,10 +27,14 @@
   height: 100%;
   width: 100%;
   z-index: -1;
-
-  background-color: @day-primary;
   font-size: 24px;
   text-align: center;
+}
+
+.blank-slate,
+.child-window-titlebar {
+  background-color: var(--background);
+  color: var(--paragraph);
 }
 
 .child-window-titlebar {
@@ -39,13 +43,5 @@
 
 .spinner-spacer {
   flex-grow: 1;
-}
-
-.night-theme {
-  .blank-slate,
-  .child-window-titlebar {
-    background-color: @night-primary;
-    color: @night-paragraph;
-  }
 }
 </style>

--- a/app/components/windows/SourcesShowcase.vue
+++ b/app/components/windows/SourcesShowcase.vue
@@ -194,19 +194,13 @@
 
 .source-info {
   .padding(2);
-  border-bottom: 1px solid @day-border;
+  background-color: var(--background);
+  border-bottom: 1px solid var(--border);
   display: flex;
   flex-direction: row;
   flex: 0 0 225px;
   height: 225px;
   align-items: flex-start;
-}
-
-.night-theme {
-  .source-info {
-    border-color: @night-border;
-    background-color: @night-primary;
-  }
 }
 </style>
 
@@ -266,7 +260,7 @@ h2 {
   .transition();
   padding: 4px 8px;
   margin-top: 8px;
-  background-color: @day-section;
+  background-color: var(--section);
   width: 49%;
   .radius();
   white-space: nowrap;
@@ -277,9 +271,9 @@ h2 {
 
   &:hover,
   &.source--active {
-    color: @day-title;
+    color: var(--title);
     .weight(@medium);
-    background-color: @light-3;
+    background-color: var(--button);
   }
 
   > div {
@@ -301,7 +295,7 @@ h2 {
 }
 
 .source-info__media {
-  .radius;
+  .radius();
   overflow: hidden;
   text-align: center;
   .padding-left(2);
@@ -335,17 +329,6 @@ h2 {
 }
 
 .night-theme {
-  .source {
-    background: @night-hover;
-    border-color: @night-hover;
-
-    &:hover,
-    &.source--active {
-      color: @night-title;
-      background: @night-secondary;
-    }
-  }
-
   .source__demo--day {
     display: none;
   }

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -79,11 +79,11 @@
 @info-light: #FFF9E5;
 @icon: #91979A;
 
+// TODO: Replace with scoped variables
 @day-bg: @light-1;
 @day-section: @light-2;
 @day-title: @dark-2;
 @day-paragraph: @dark-5;
-@day-input-border: @light-3;
 @day-button: @light-3;
 @day-link: @dark-5;
 @day-link-active: @dark-2;
@@ -109,3 +109,41 @@
 @night-dropdown-border: @dark-4;
 @night-hover: @dark-4;
 @night-shadow: rgba(1, 2, 2, 0.16);
+
+// Scoped Variables
+:root {
+  --background: @light-1;
+  --section: @light-2;
+  --section-alt: @light-2;
+  --title: @dark-2;
+  --paragraph: @dark-5;
+  --button: @light-3;
+  --link: @dark-5;
+  --link-active: @dark-2;
+  --input-bg: @light-1;
+  --input-border: @light-3;
+  --solid-input: @light-2;
+  --dropdown-bg: @light-2;
+  --dropdown-border: @light-2;
+  --hover: @light-2;
+  --shadow: rgba(55, 71, 79, 0.12);
+}
+
+.night-theme {
+  --background: @dark-3;
+  --section: @dark-2;
+  --section-alt: @dark-4;
+  --title: @light-1;
+  --paragraph: @light-4;
+  --button: @dark-5;
+  --link: @light-4;
+  --link-active: @light-1;
+  --input-bg: transparent;
+  --input-border: @dark-5;
+  --solid-input: @dark-4;
+  --dropdown-bg: @dark-4;
+  --dropdown-border: @dark-4;
+  --hover: @dark-4;
+  --shadow: rgba(1, 2, 2, 0.16);
+}
+


### PR DESCRIPTION
This gives us a few big wins for styling:
1. Using scoped variables means we'll never forget about styling day/night mode again
2. Allows us to simply and effectively implement new themes as we wish
3. Reduces a ton of our styling boilerplate

I didn't replace all examples of former variable usage (that will be done in a separate PR) but I wanted to get out a proof-of-concept PR with a few example uses

edit: reason for using CSS native variables here are that LESS variable scoping is a little wonky, and also since we have native support now I think we should prefer it in most non-LESS specific cases