### PR TITLE
test: re-enable themes test

### DIFF
--- a/test/themes.ts
+++ b/test/themes.ts
@@ -9,7 +9,7 @@ const OVERLAY_NAME = 'Talon Stream Package by VBI';
 const OVERLAY_SCENES = ['Starting Soon', 'Be Right Back', 'Stream Ending', 'Intermission', 'Main'];
 
 // TODO: Test is flaky
-test.skip('Installing a theme', async (t: any) => {
+test('Installing a theme', async (t: any) => {
   const { app } = t.context;
   const formMonkey = new FormMonkey(t);
 
@@ -31,7 +31,7 @@ test.skip('Installing a theme', async (t: any) => {
 
   // wait for installation complete
   await focusMain(t);
-  await app.client.waitForExist('.studio-page', 10000);
+  await app.client.waitForExist('.studio-page', 60000);
 
   // Should've loaded the overlay as a new scene collection
   t.true(await app.client.isExisting(`span=${OVERLAY_NAME}`));


### PR DESCRIPTION
Re-enables "Installing a theme" test, after fixing by increasing timeout for theme install which seems to take noticeably-longer on CI.