### PR TITLE
chore(package): update NodeJS version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "0.12.0-preview.7",
   "main": "main.js",
   "engines": {
-    "node": ">= 8 < 12",
+    "node": ">= 10 < 12",
     "yarn": ">= 1.5.2"
   },
   "scripts": {


### PR DESCRIPTION
Update `package.json` to reflect NodeJS version requirements.
Version 10 is the minimum that we should support, and this ensures every developer/contributor isn't running an unsupported version. 

Node 10 was chosen, because:

1. It is the current LTS version: https://nodejs.org/en/about/releases/
2. CI has been running Node 10 exclusively for a while now.
3. Upcoming code that might require N-API not to be marked as experimental.