### PR TITLE
get rid of confusing previewEnabled customization setting

### DIFF
--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -75,7 +75,7 @@
         </div>
       </div>
 
-      <div class="live-dock-chat" v-if="!hideChat && (isTwitch || isMixer || (isYoutube && isStreaming) || isFacebook)">
+      <div class="live-dock-chat" v-if="!resizingInProgress && (isTwitch || isMixer || (isYoutube && isStreaming) || isFacebook)">
           <div v-if="hasChatApps" class="flex">
             <tabs :tabs="chatTabs" v-model="selectedChat" :hideContent="true" />
             <i

--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -98,7 +98,7 @@
       <div class="flex flex--center flex--column live-dock-chat--offline" v-else >
         <img class="live-dock-chat__img--offline live-dock-chat__img--offline-day" src="../../media/images/sleeping-kevin-day.png">
         <img class="live-dock-chat__img--offline live-dock-chat__img--offline-night" src="../../media/images/sleeping-kevin-night.png">
-        <span>{{ $t('Your chat is currently offline') }}</span>
+        <span v-if="!resizingInProgress">{{ $t('Your chat is currently offline') }}</span>
       </div>
     </div>
   </transition>

--- a/app/components/LiveDock.vue.ts
+++ b/app/components/LiveDock.vue.ts
@@ -188,11 +188,8 @@ export default class LiveDock extends Vue {
     this.chatService.refreshChat();
   }
 
-  get hideChat() {
-    // previewEnabled is poorly named.  It really just means stuff
-    // we disable while resizing.  It should not be in the customization
-    // service.  This is lazy.
-    return !this.customizationService.previewEnabled;
+  get resizingInProgress() {
+    return this.customizationService.state.resizingInProgress;
   }
 
   get hasChatApps() {

--- a/app/components/MixerItem.vue
+++ b/app/components/MixerItem.vue
@@ -9,7 +9,7 @@
     </div>
   </div>
 
-  <MixerVolmeter :audioSource="audioSource" v-if="previewEnabled"></MixerVolmeter>
+  <MixerVolmeter :audioSource="audioSource" v-if="!performanceMode"></MixerVolmeter>
 
   <div class="flex">
     <slider-input

--- a/app/components/MixerItem.vue.ts
+++ b/app/components/MixerItem.vue.ts
@@ -15,8 +15,8 @@ export default class MixerItem extends Vue {
 
   @Inject() private customizationService: CustomizationService;
 
-  get previewEnabled() {
-    return !this.customizationService.state.performanceMode;
+  get performanceMode() {
+    return this.customizationService.state.performanceMode;
   }
 
   get sliderMetadata() {

--- a/app/components/pages/Live.vue.ts
+++ b/app/components/pages/Live.vue.ts
@@ -59,7 +59,7 @@ export default class Live extends Vue {
     return (
       this.customizationService.state.livePreviewEnabled &&
       !this.performanceModeEnabled &&
-      this.customizationService.state.previewEnabled
+      !this.customizationService.state.resizingInProgress
     );
   }
 
@@ -99,10 +99,10 @@ export default class Live extends Vue {
   }
 
   onResizeStartHandler() {
-    this.customizationService.setSettings({ previewEnabled: false });
+    this.customizationService.setSettings({ resizingInProgress: true });
   }
 
   onResizeStopHandler() {
-    this.customizationService.setSettings({ previewEnabled: true });
+    this.customizationService.setSettings({ resizingInProgress: false });
   }
 }

--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="studio-page">
-  <div v-if="previewEnabled" class="studio-mode-container" ref="studioModeContainer" :class="{ stacked }">
+  <div v-if="displayEnabled" class="studio-mode-container" ref="studioModeContainer" :class="{ stacked }">
     <studio-mode-controls v-if="studioMode" :stacked="stacked" />
     <div
       class="studio-display-container"
@@ -11,7 +11,7 @@
       </div>
     </div>
   </div>
-  <div v-if="!previewEnabled" class="no-preview">
+  <div v-else class="no-preview">
     <div class="message" v-if="performanceMode">
       {{ $t('Preview is disabled in performance mode') }}
       <div class="button button--action button--sm" @click="enablePreview">{{ $t('Disable Performance Mode') }}</div>

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -44,8 +44,8 @@ export default class Studio extends Vue {
     clearInterval(this.sizeCheckInterval);
   }
 
-  get previewEnabled() {
-    return this.customizationService.previewEnabled;
+  get displayEnabled() {
+    return !this.customizationService.state.resizingInProgress && !this.performanceMode;
   }
 
   get performanceMode() {
@@ -81,10 +81,10 @@ export default class Studio extends Vue {
   }
 
   onResizeStartHandler() {
-    this.customizationService.setSettings({ previewEnabled: false });
+    this.customizationService.setSettings({ resizingInProgress: true });
   }
 
   onResizeStopHandler() {
-    this.customizationService.setSettings({ previewEnabled: true });
+    this.customizationService.setSettings({ resizingInProgress: false });
   }
 }

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -175,7 +175,7 @@ export default class Main extends Vue {
   }
 
   onResizeStartHandler() {
-    this.customizationService.setSettings({ previewEnabled: false });
+    this.customizationService.setSettings({ resizingInProgress: true });
   }
 
   onResizeStopHandler(offset: number) {
@@ -183,7 +183,7 @@ export default class Main extends Vue {
     offset = this.leftDock ? offset : -offset;
     this.setWidth(this.customizationService.state.livedockSize + offset);
     this.customizationService.setSettings({
-      previewEnabled: true,
+      resizingInProgress: false,
     });
   }
 

--- a/app/services/customization/customization-api.ts
+++ b/app/services/customization/customization-api.ts
@@ -12,13 +12,19 @@ export interface ICustomizationServiceState {
   livedockSize: number;
   bottomdockSize: number;
   performanceMode: boolean;
-  previewEnabled: boolean;
   chatZoomFactor: number;
   enableBTTVEmotes: boolean;
   enableFFZEmotes: boolean;
   mediaBackupOptOut: boolean;
   navigateToLiveOnStreamStart: boolean;
   experimental: any;
+
+  /**
+   * Will be true when a UI resizing operation is in
+   * progress. All displays and BrowserViews will be
+   * hidden during this operation.
+   */
+  resizingInProgress: boolean;
 }
 
 export interface ICustomizationSettings extends ICustomizationServiceState {}

--- a/app/services/customization/customization.ts
+++ b/app/services/customization/customization.ts
@@ -31,7 +31,6 @@ export class CustomizationService extends PersistentStatefulService<ICustomizati
     livedockSize: 0,
     bottomdockSize: 240,
     performanceMode: false,
-    previewEnabled: true,
     chatZoomFactor: 1,
     enableBTTVEmotes: false,
     enableFFZEmotes: false,
@@ -41,6 +40,7 @@ export class CustomizationService extends PersistentStatefulService<ICustomizati
     experimental: {
       // put experimental features here
     },
+    resizingInProgress: true,
   };
 
   settingsChanged = new Subject<Partial<ICustomizationSettings>>();
@@ -48,7 +48,9 @@ export class CustomizationService extends PersistentStatefulService<ICustomizati
   init() {
     super.init();
     this.setLiveDockCollapsed(true); // livedock is always collapsed on app start
-    this.setSettings({ previewEnabled: true }); // preview is always enabled on app start
+
+    // Make sure we somehow didn't persist this as true
+    this.setSettings({ resizingInProgress: false });
   }
 
   setSettings(settingsPatch: Partial<ICustomizationSettings>) {
@@ -68,10 +70,6 @@ export class CustomizationService extends PersistentStatefulService<ICustomizati
 
   get nightMode() {
     return this.state.nightMode;
-  }
-
-  get previewEnabled(): boolean {
-    return !this.state.performanceMode && this.state.previewEnabled;
   }
 
   setNightMode(val: boolean) {


### PR DESCRIPTION
This setting name didn't make any sense the way we now use this setting.  Hopefully this new setup should be a lot clearer, and fixes an issue where chat was disabled in performance mode.