### PR TITLE
Get rid of Props decorator in ObsInput

### DIFF
--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -448,8 +448,7 @@ export function setPropertiesFormData(obsSource: obs.ISource, form: TObsFormData
 }
 
 export abstract class ObsInput<TValueType> extends Vue {
-  @Prop()
-  value: TValueType;
+  abstract value: TValueType;
 
   emitInput(eventData: TValueType) {
     this.$emit('input', eventData);

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -6,16 +6,18 @@ import { IInputMetadata } from './index';
 import ValidatedForm from './ValidatedForm.vue';
 import TsxComponent from 'components/tsx-component';
 
-export abstract class BaseInput<
-  TValueType,
-  TMetadataType extends IInputMetadata
-> extends TsxComponent<{
+export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends TsxComponent<{
   metadata: TMetadataType;
   value: TValueType;
   title: string;
 }> {
+  @Prop()
   readonly value: TValueType;
+
+  @Prop()
   readonly title: string;
+
+  @Prop({ default: () => ({}) })
   readonly metadata: TMetadataType;
 
   /**

--- a/app/components/shared/inputs/BaseInput.ts
+++ b/app/components/shared/inputs/BaseInput.ts
@@ -6,18 +6,16 @@ import { IInputMetadata } from './index';
 import ValidatedForm from './ValidatedForm.vue';
 import TsxComponent from 'components/tsx-component';
 
-export class BaseInput<TValueType, TMetadataType extends IInputMetadata> extends TsxComponent<{
+export abstract class BaseInput<
+  TValueType,
+  TMetadataType extends IInputMetadata
+> extends TsxComponent<{
   metadata: TMetadataType;
   value: TValueType;
   title: string;
 }> {
-  @Prop()
   readonly value: TValueType;
-
-  @Prop()
   readonly title: string;
-
-  @Prop({ default: () => ({}) })
   readonly metadata: TMetadataType;
 
   /**


### PR DESCRIPTION
The @Props decorator adds a watcher that doesn't work correctly if you extend the component with this decorator

This PR fixes the high-volume Sentry error
``` 
[Sentry] TypeError
Cannot read property 'call' of undefined
```