### PR TITLE
use separate sessions for platform auth windows

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -166,6 +166,8 @@ export class AppService extends StatefulService<IAppState> {
     this.ipcServerService.stopListening();
     this.tcpServerService.stopListening();
 
+    this.userService.flushUserSession();
+
     window.setTimeout(async () => {
       await this.sceneCollectionsService.deinitialize();
       this.performanceMonitorService.stop();

--- a/app/services/chat.ts
+++ b/app/services/chat.ts
@@ -59,8 +59,11 @@ export class ChatService extends Service {
   private initChat() {
     if (this.chatView) return;
 
+    const partition = this.userService.state.auth.parition;
+
     this.chatView = new electron.remote.BrowserView({
       webPreferences: {
+        partition,
         nodeIntegration: false,
       },
     });

--- a/app/services/chat.ts
+++ b/app/services/chat.ts
@@ -59,7 +59,7 @@ export class ChatService extends Service {
   private initChat() {
     if (this.chatView) return;
 
-    const partition = this.userService.state.auth.parition;
+    const partition = this.userService.state.auth.partition;
 
     this.chatView = new electron.remote.BrowserView({
       webPreferences: {

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -121,7 +121,7 @@ export interface IPlatformAuth {
    * Session partition used to separate cookies associated
    * with this user login.
    */
-  parition?: string;
+  partition?: string;
 }
 
 export interface IUserInfo {

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -116,6 +116,12 @@ export interface IPlatformAuth {
     id: string;
     channelId?: string;
   };
+
+  /**
+   * Session partition used to separate cookies associated
+   * with this user login.
+   */
+  parition?: string;
 }
 
 export interface IUserInfo {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -131,8 +131,8 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
    * Attempts to flush the user's session to disk if it exists
    */
   flushUserSession() {
-    if (this.isLoggedIn() && this.state.auth.parition) {
-      electron.remote.session.fromPartition(this.state.auth.parition).flushStorageData();
+    if (this.isLoggedIn() && this.state.auth.partition) {
+      electron.remote.session.fromPartition(this.state.auth.partition).flushStorageData();
     }
   }
 
@@ -271,11 +271,9 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     // Navigate away from disabled tabs on logout
     this.navigationService.navigate('Studio');
 
-    let session = electron.remote.session.defaultSession;
-
-    if (this.state.auth.parition) {
-      session = electron.remote.session.fromPartition(this.state.auth.parition);
-    }
+    const session = this.state.auth.partition
+      ? electron.remote.session.fromPartition(this.state.auth.partition)
+      : electron.remote.session.defaultSession;
 
     session.clearStorageData({ storages: ['cookies'] });
 
@@ -341,7 +339,7 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
       const parsed = this.parseAuthFromUrl(url);
 
       if (parsed) {
-        parsed.parition = partition;
+        parsed.partition = partition;
         authWindow.close();
         onAuthStart();
         await this.login(service, parsed);


### PR DESCRIPTION
Have the user log in to the streaming platform in a separate partition, and then use that same partition for chat.  This has a couple benefits:
- It makes it very easy to ensure we aren't accidentally leaking cookies when the user logs out, as the id of the partition is deleted and can't be re-generated.
- It will hopefully work around an issue we've been seeing where the default session will get corrupted and stop updating cookies eventually.  This appears to be a chromium bug.