### PR TITLE
Throttle widget testers

### DIFF
--- a/app/app-services.ts
+++ b/app/app-services.ts
@@ -93,7 +93,7 @@ export { PlatformAppAssetsService } from 'services/platform-apps/platform-app-as
 export { ChatService } from 'services/chat';
 
 // WIDGETS
-export { WidgetSource, WidgetsService, WidgetTester } from './services/widgets';
+export { WidgetSource, WidgetsService } from './services/widgets';
 export { BitGoalService } from 'services/widgets/settings/bit-goal';
 export { ChatBoxService } from 'services/widgets/settings/chat-box';
 export { DonationGoalService } from 'services/widgets/settings/donation-goal';

--- a/app/components/TestWidgets.vue
+++ b/app/components/TestWidgets.vue
@@ -13,7 +13,7 @@
           class="button button--trans"
           v-for="tester in widgetTesters"
           :key="tester.name"
-          @click="tester.test()">
+          @click="test(tester.name)">
           {{ $t(tester.name) }}
         </button>
       </div>

--- a/app/components/TestWidgets.vue.ts
+++ b/app/components/TestWidgets.vue.ts
@@ -25,4 +25,8 @@ export default class TestWidgets extends Vue {
   get facemasksActive() {
     return this.facemasksService.active;
   }
+
+  test(testerName: string) {
+    this.widgetsService.test(testerName);
+  }
 }

--- a/app/components/widgets/TestButtons.vue
+++ b/app/components/widgets/TestButtons.vue
@@ -4,7 +4,7 @@
       class="button button--action"
       v-for="tester in widgetTesters"
       :key="tester.name"
-      @click="tester.test()">
+      @click="test(tester.name)">
       {{ $t(tester.name) }}
     </button>
   </div>

--- a/app/components/widgets/TestButtons.vue.ts
+++ b/app/components/widgets/TestButtons.vue.ts
@@ -17,4 +17,8 @@ export default class TestButtons extends Vue {
       ? availableTesters.filter(tester => this.testers.includes(tester.name))
       : availableTesters;
   }
+
+  test(testerName: string) {
+    this.widgetsService.test(testerName);
+  }
 }

--- a/app/services/widgets/widgets.ts
+++ b/app/services/widgets/widgets.ts
@@ -13,26 +13,13 @@ import { ServicesManager } from 'services-manager';
 import { authorizedHeaders } from 'util/requests';
 import { ISerializableWidget, IWidgetSource, IWidgetsServiceApi } from './widgets-api';
 import { WidgetType, WidgetDefinitions, WidgetTesters } from './widgets-data';
-import { mutation, ServiceHelper, StatefulService } from '../stateful-service';
+import { mutation, StatefulService } from '../stateful-service';
 import { WidgetSource } from './widget-source';
 import { InitAfter } from '../../util/service-observer';
 import Vue from 'vue';
 import cloneDeep from 'lodash/cloneDeep';
 import { Subscription } from 'rxjs';
-
-@ServiceHelper()
-export class WidgetTester {
-  constructor(public name: string, private url: string) {
-    this.test = throttle(this.test, 1000);
-  }
-
-  @Inject() userService: UserService;
-
-  test() {
-    const headers = authorizedHeaders(this.userService.apiToken);
-    fetch(new Request(this.url, { headers }));
-  }
-}
+import { Throttle } from 'lodash-decorators';
 
 export interface IWidgetSourcesState {
   widgetSources: Dictionary<IWidgetSource>;
@@ -159,16 +146,23 @@ export class WidgetsService extends StatefulService<IWidgetSourcesState>
     return servicesManager.getResource(serviceName);
   }
 
-  getTesters() {
+  getTesters(): { name: string; url: string }[] {
     if (!this.userService.isLoggedIn()) return;
     return WidgetTesters.filter(tester => {
       return tester.platforms.includes(this.userService.platform.type);
     }).map(tester => {
-      return new WidgetTester(
-        tester.name,
-        tester.url(this.hostsService.streamlabs, this.userService.platform.type),
-      );
+      return {
+        name: tester.name,
+        url: tester.url(this.hostsService.streamlabs, this.userService.platform.type),
+      };
     });
+  }
+
+  @Throttle(1000)
+  test(testerName: string) {
+    const tester = this.getTesters().find(tester => tester.name === testerName);
+    const headers = authorizedHeaders(this.userService.apiToken);
+    fetch(new Request(tester.url, { headers }));
   }
 
   private previewSourceWatchers: Dictionary<Subscription> = {};


### PR DESCRIPTION
Throttle doesn't work for the WidgetTester in Alertbox window, because we create a new instance of `WidgetTester` before calling `test` method under the hood