### PR TITLE
fix: prevent default dragenter behavior of electron

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -117,6 +117,7 @@ Vue.use(VModal);
 
 // Disable chrome default drag/drop behavior
 document.addEventListener('dragover', event => event.preventDefault());
+document.addEventListener('dragenter', event => event.preventDefault());
 document.addEventListener('drop', event => event.preventDefault());
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
![2019-03-22 20-20-38](https://user-images.githubusercontent.com/24884114/54820898-fac4cf00-4ce3-11e9-994d-1ef4fb80e58b.gif)

## procedure for reproducing
This issue can reproduce on aba0ff93957ef48fecf11a773ec46a947cf76576 .
1. Lunch SLOBS
2. some file drag and drop to SLOBS from explorer **very quickly**.
3. Electrons often display the file directly.

I reproduced this at around of 2019-03-22 18:55(UTC+9) and 2019-03-22 20:20(UTC+9).
Use these timestamps for searcing exceptions by sentry :)

-------------

This issue seems caused by dragenter event.

I referred [MDN page for drag and drop events](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Drag_operations#droptargets).

In SLOBS(also N Air), both drop and dragover events were prevented.
However, the dragenter event was not prevented.

After this fix, it did not repreduce as far as I tried.
