### PR TITLE
Fix FB stream info overwrite

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -200,8 +200,9 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
         if (info && ['SCHEDULED_UNPUBLISHED', 'LIVE_STOPPED'].includes(info.status)) {
           this.SET_LIVE_VIDEO_ID(info.id);
           this.SET_STREAM_URL(info.stream_url);
+        } else {
+          this.SET_LIVE_VIDEO_ID(null);
         }
-        this.SET_LIVE_VIDEO_ID(null);
         return info;
       });
   }

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -201,6 +201,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
           this.SET_LIVE_VIDEO_ID(info.id);
           this.SET_STREAM_URL(info.stream_url);
         }
+        this.SET_LIVE_VIDEO_ID(null);
         return info;
       });
   }


### PR DESCRIPTION
We were caching the live video id (used to set stream info) and never actually clearing it