### PR TITLE
Stop the crash handler and close the IPC connection before shutdown

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -101,8 +101,11 @@ export class AppService extends StatefulService<IAppState> {
       showDialog(message);
 
       crashHandler.unregisterProcess(this.pid);
-      electron.ipcRenderer.send('shutdownComplete');
 
+      obs.NodeObs.StopCrashHandler();
+      obs.IPC.disconnect();
+
+      electron.ipcRenderer.send('shutdownComplete');
       return;
     }
 


### PR DESCRIPTION
I detected that the frontend was performing some calls to the backend after its initialization failed, the correct behaviour would be closing all connections and exit after showing the warning message to the user.
Those calls are causing false crash reports because SLOBS isn't initialized to support any request (the calls are mainly the `getSettings()` method)

My additions will terminate the connection between front and backend, also disabling the crash handler.
