### PR TITLE
Fix stream service not changing in some cases

### DIFF
--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -55,5 +55,6 @@
   "Select stream tags": "Select stream tags",
   "You can now edit your channel tags from this screen.": "You can now edit your channel tags from this screen.",
   "Log out and back in to reauthorize additional permissions.": "Log out and back in to reauthorize additional permissions.",
-  "Are you sure you want to start streaming?": "Are you sure you want to start streaming?"
+  "Are you sure you want to start streaming?": "Are you sure you want to start streaming?",
+  "Please enable account for streaming to recieve a stream key": "Please enable account for streaming to recieve a stream key"
 }

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -11,6 +11,7 @@ import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
 import { handleResponse, requiresToken, authorizedHeaders } from '../../util/requests';
 import { UserService } from '../user';
+import { $t } from 'services/i18n';
 
 interface IYoutubeServiceState {
   liveStreamingEnabled: boolean;
@@ -150,7 +151,9 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
   }
 
   fetchStreamKey(): Promise<string> {
-    return this.fetchBoundStreamId().then(boundStreamId => this.fetchStreamKeyForId(boundStreamId));
+    return this.fetchBoundStreamId()
+      .then(boundStreamId => this.fetchStreamKeyForId(boundStreamId))
+      .catch(() => $t('Please enable account for streaming to recieve a stream key'));
   }
 
   fetchChannelInfo(): Promise<IChannelInfo> {


### PR DESCRIPTION
When a user logs into a YT account not enabled to stream there is an uncaught error that keeps the service and stream key set to whatever it was previously