### PR TITLE
Fix mutation buffering

### DIFF
--- a/app/services-manager.ts
+++ b/app/services-manager.ts
@@ -34,7 +34,7 @@ export class ServicesManager extends Service {
    * The child windows or one-off windows don't execute services methods directly
    * They use InternalApiClient to send IPC requests to the main window
    */
-  private internalApiClient: InternalApiClient;
+  internalApiClient: InternalApiClient;
 
   init() {
     // this helps to debug services from the console

--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -40,7 +40,7 @@ export class ExternalApiService extends RpcApi {
   /**
    * InternalApiService is for fallback calls
    */
-  @Inject() private internalApiService: InternalApiService;
+  @Inject() internalApiService: InternalApiService;
   /**
    * List of all API resources
    * @see RpcApi.getResource()

--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -1,6 +1,6 @@
 import electron from 'electron';
 import { Observable, Subject } from 'rxjs';
-import { IJsonRpcEvent, IJsonRpcResponse, JsonrpcService } from 'services/api/jsonrpc';
+import { IJsonRpcEvent, IJsonRpcResponse, IMutation, JsonrpcService } from 'services/api/jsonrpc';
 import * as traverse from 'traverse';
 import { Service } from '../service';
 import { ServicesManager } from '../../services-manager';
@@ -24,6 +24,8 @@ export class InternalApiClient {
    * almost the same as `promises` but for keeping subscriptions
    */
   private subscriptions: Dictionary<Subject<any>> = {};
+
+  private skippedMutationsCount = 0;
 
   constructor() {
     this.listenMainWindowMessages();
@@ -73,7 +75,13 @@ export class InternalApiClient {
           }
 
           const result = response.result;
-          response.mutations.forEach(mutation => commitMutation(mutation));
+          const mutations = response.mutations;
+
+          // commit all mutations caused by the api-request now
+          mutations.forEach(mutation => commitMutation(mutation));
+          // we'll still receive already committed mutations from async IPC event
+          // mark them as ignored
+          this.skippedMutationsCount = mutations.length;
 
           if (result && result._type === 'SUBSCRIPTION') {
             if (result.emitter === 'PROMISE') {
@@ -114,6 +122,15 @@ export class InternalApiClient {
   getResource(resourceId: string) {
     // ServiceManager already applied the proxy-function to all services in the ChildWindow
     return this.servicesManager.getResource(resourceId);
+  }
+
+  handleMutation(mutation: IMutation) {
+    if (this.skippedMutationsCount) {
+      // this mutation is already committed
+      this.skippedMutationsCount--;
+      return;
+    }
+    commitMutation(mutation);
   }
 
   /**

--- a/app/services/api/rpc-api.ts
+++ b/app/services/api/rpc-api.ts
@@ -116,7 +116,7 @@ export abstract class RpcApi extends Service {
     }
 
     if (response) {
-      if (this.isMutationBufferingEnabled()) this.stopBufferingMutations();
+      if (this.mutationsBufferingEnabled) this.stopBufferingMutations();
       return response;
     }
 
@@ -256,12 +256,8 @@ export abstract class RpcApi extends Service {
     return mutations;
   }
 
-  isMutationBufferingEnabled() {
-    return this.mutationsBufferingEnabled;
-  }
-
-  addMutationToBuffer(mutation: IMutation) {
-    this.bufferedMutations.push(mutation);
+  handleMutation(mutation: IMutation) {
+    if (this.mutationsBufferingEnabled) this.bufferedMutations.push(mutation);
   }
 
   /**


### PR DESCRIPTION
After investigating Sentry errors from Projector window I found that we don't commit mutations coming from the child window because `mutationsBuffering` prevent this. Here is a PR with a fix  