### PR TITLE
Use realpath for image sources

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -219,7 +219,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   addFile(path: string): Source {
-    let realpath = fs.realpathSync(path);
+    const realpath = fs.realpathSync(path);
     const SUPPORTED_EXT = {
       image_source: ['png', 'jpg', 'jpeg', 'tga', 'bmp'],
       ffmpeg_source: [

--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -219,6 +219,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
   }
 
   addFile(path: string): Source {
+    let realpath = fs.realpathSync(path);
     const SUPPORTED_EXT = {
       image_source: ['png', 'jpg', 'jpeg', 'tga', 'bmp'],
       ffmpeg_source: [
@@ -238,7 +239,7 @@ export class SourcesService extends StatefulService<ISourcesState> implements IS
       browser_source: ['html'],
       text_gdiplus: ['txt'],
     };
-    let ext = path.split('.').splice(-1)[0];
+    let ext = realpath.split('.').splice(-1)[0];
     if (!ext) return null;
     ext = ext.toLowerCase();
     const filename = path.split('\\').splice(-1)[0];


### PR DESCRIPTION
I'm building an app that lets users swap out image sources from a simple point-and-click UI.

It's breaking on GIF images because of the special handling for them, [in a weird way](https://github.com/soatok/fursona-sticker-switcher#caveats-with-animated-gifs-and-streamlabs-obs). Using the realpath of the file to get the extension should enable the correct behavior.

> If you append `.gif` to the Image Source file path, you can use GIFs (but
only GIFs) and they will animate. If you leave the image source without an
extension, it works with all image types, but GIFs will not be animated.
> 
> In the future, I'll devise a workaround (even if it means sending a pull
request to Streamlabs OBS) to make this usability wart go away.

The cause for this behavior was that GIFs are handled by ffmpeg and other images are not.