### PR TITLE
Fix mutation buffering

### DIFF
--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -81,7 +81,7 @@ export class InternalApiClient {
           mutations.forEach(mutation => commitMutation(mutation));
           // we'll still receive already committed mutations from async IPC event
           // mark them as ignored
-          this.skippedMutationsCount = mutations.length;
+          this.skippedMutationsCount += mutations.length;
 
           if (result && result._type === 'SUBSCRIPTION') {
             if (result.emitter === 'PROMISE') {


### PR DESCRIPTION
The mutation buffering works incorrectly when the child window calls 2 methods in the row that trigger mutations 