### PR TITLE
Fix encoder test

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -12,13 +12,34 @@ export enum EEncoder {
 
 enum EObsEncoder {
   x264 = 'x264',
-  obs_x264 = 'obs_x264',
+  x264_lowcpu = 'x264_lowcpu',
   nvenc = 'nvenc',
-  ffmpeg_nvenc = 'ffmpeg_nvenc',
   amd = 'amd',
-  amd_amf_h264 = 'amd_amf_h264',
   qsv = 'qsv',
+  jim_nvenc = 'jim_nvenc',
+
+  ffmpeg_nvenc = 'ffmpeg_nvenc',
+  obs_x264 = 'obs_x264',
+  amd_amf_h264 = 'amd_amf_h264',
   obs_qsv11 = 'obs_qsv11',
+}
+
+enum EObsSimpleEncoder {
+  x264 = 'x264',
+  x264_lowcpu = 'x264_lowcpu',
+  nvenc = 'nvenc',
+  amd = 'amd',
+  qsv = 'qsv',
+  jim_nvenc = 'jim_nvenc',
+}
+
+enum EObsAdvancedEncoder {
+  x264 = 'x264',
+  x264_lowcpu = 'x264_lowcpu',
+  nvenc = 'nvenc',
+  amd = 'amd',
+  qsv = 'qsv',
+  jim_nvenc = 'jim_nvenc',
 }
 
 enum EFileFormat {

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -121,13 +121,13 @@ const simpleEncoderToAnvancedEncoderMap: Dictionary<EObsAdvancedEncoder> = {
 };
 
 /**
- * each encoder have different set of fields
+ * each encoder have different names for setting fields
  */
 export const encoderFieldsMap = {
-  x264: { preset: 'preset', encoderOptions: 'x264opts' },
-  nvenc: { preset: 'preset' },
-  qsv: { preset: 'target_usage' },
-  amd: { preset: 'QualityPreset' },
+  [EEncoderFamily.x264]: { preset: 'preset', encoderOptions: 'x264opts' },
+  [EEncoderFamily.nvenc]: { preset: 'preset' },
+  [EEncoderFamily.qsv]: { preset: 'target_usage' },
+  [EEncoderFamily.amd]: { preset: 'QualityPreset' },
 };
 
 function simpleEncoderToAdvancedEncoder(encoder: EEncoderFamily) {
@@ -137,9 +137,22 @@ function simpleEncoderToAdvancedEncoder(encoder: EEncoderFamily) {
 export function obsEncoderToEncoderFamily(
   obsEncoder: EObsAdvancedEncoder | EObsSimpleEncoder,
 ): EEncoderFamily {
-  if (obsEncoder === 'obs_x264') return EEncoderFamily.x264;
-  const encoder = invert(simpleEncoderToAnvancedEncoderMap)[obsEncoder] || obsEncoder;
-  return encoder as EEncoderFamily;
+  switch (obsEncoder) {
+    case EObsAdvancedEncoder.obs_x264:
+    case EObsSimpleEncoder.x264:
+    case EObsSimpleEncoder.x264_lowcpu:
+      return EEncoderFamily.x264;
+    case EObsSimpleEncoder.qsv:
+    case EObsAdvancedEncoder.obs_qsv11:
+      return EEncoderFamily.qsv;
+    case EObsSimpleEncoder.nvenc:
+    case EObsAdvancedEncoder.ffmpeg_nvenc:
+    case EObsAdvancedEncoder.jim_nvenc:
+      return EEncoderFamily.nvenc;
+    case EObsSimpleEncoder.amd:
+    case EObsAdvancedEncoder.amd_amf_h264:
+      return EEncoderFamily.amd;
+  }
 }
 
 export class OutputSettingsService extends Service {

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -121,6 +121,7 @@ function simpleEncoderToAdvancedEncoder(encoder: EEncoder) {
  * returns a short encoder's name if exists
  */
 export function obsEncoderToEncoder(obsEncoder: EObsEncoder): EEncoder {
+  if (obsEncoder === 'obs_x264') return EEncoder.x264;
   const encoder = invert(simpleEncoderToAnvancedEncoderMap)[obsEncoder] || obsEncoder;
   return encoder as EEncoder;
 }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -16,7 +16,7 @@ import { WindowsService } from 'services/windows';
 import Utils from '../utils';
 import { AppService } from 'services/app';
 import { $t } from 'services/i18n';
-import { encoderFieldsMap, OutputSettingsService, obsEncoderToEncoder } from './output';
+import { encoderFieldsMap, OutputSettingsService, obsEncoderToEncoderFamily } from './output';
 import { VideoEncodingOptimizationService } from 'services/video-encoding-optimizations';
 import { ISettingsServiceApi, ISettingsSubCategory } from './settings-api';
 import { PlatformAppsService } from 'services/platform-apps';
@@ -166,7 +166,7 @@ export class SettingsService extends StatefulService<ISettingsState>
       !this.streamingService.isIdle &&
       this.videoEncodingOptimizationService.state.useOptimizedProfile
     ) {
-      const encoder = obsEncoderToEncoder(
+      const encoder = obsEncoderToEncoderFamily(
         this.findSettingValue(settings, 'Streaming', 'Encoder') ||
           this.findSettingValue(settings, 'Streaming', 'StreamEncoder'),
       );

--- a/app/services/video-encoding-optimizations/definitions.ts
+++ b/app/services/video-encoding-optimizations/definitions.ts
@@ -1,8 +1,8 @@
-import { EEncoder } from 'services/settings';
+import { EEncoderFamily } from 'services/settings';
 
 export interface IEncoderProfile {
   game: string;
-  encoder: EEncoder;
+  encoder: EEncoderFamily;
   bitrateMin: number;
   bitrateMax: number;
   presetIn: string;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - yarn compile:ci
 
 test_script:
-  - yarn test --match="Shows optimized encoder for specific games"
+  - yarn test-flaky
   # - yarn screentest
   # - 7z a screentest.zip test-dist\screentest\*
   # - ps: $env:warning_ico = ":warning:"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,8 @@
 build: off
 
+init:
+- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+
 install:
   - ps: Install-Product node 10 x64
   - yarn install --frozen-lockfile --check-files

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - yarn compile:ci
 
 test_script:
-  - yarn test-flaky
+  - yarn test --match="Shows optimized encoder for specific games"
   # - yarn screentest
   # - 7z a screentest.zip test-dist\screentest\*
   # - ps: $env:warning_ico = ":warning:"

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -55,24 +55,24 @@ test('Shows optimized encoder for specific games', async t => {
    * Unfortunately, only a handful of these are actually testable. We also only test on CI as this
    * is going to be different for each developer machine.
    */
-  if (process.env.CI) {
-    await app.client.click('.profile input[type=checkbox]');
-    await sleep(1000);
-    await app.client.click('button=Confirm & Go Live');
-    await focusMain(t);
-    await app.client.waitForExist('button=End Stream');
-    await app.client.click('.top-nav .icon-settings');
-
-    await focusChild(t);
-    await app.client.click('li=Output');
-
-    t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
-    t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
-    t.is('2500', await getFormInput(t, 'Bitrate'));
-
-    await app.client.click('button=Done');
-    await focusMain(t);
-    await app.client.click('button=End Stream');
-    await app.client.isExisting('button=Go Live');
-  }
+  // if (process.env.CI) {
+  //   await app.client.click('.profile input[type=checkbox]');
+  //   await sleep(1000);
+  //   await app.client.click('button=Confirm & Go Live');
+  //   await focusMain(t);
+  //   await app.client.waitForExist('button=End Stream');
+  //   await app.client.click('.top-nav .icon-settings');
+  //
+  //   await focusChild(t);
+  //   await app.client.click('li=Output');
+  //
+  //   t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
+  //   t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
+  //   t.is('2500', await getFormInput(t, 'Bitrate'));
+  //
+  //   await app.client.click('button=Done');
+  //   await focusMain(t);
+  //   await app.client.click('button=End Stream');
+  //   await app.client.isExisting('button=Go Live');
+  // }
 });

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -3,7 +3,7 @@ import { getFormInput } from '../helpers/spectron/forms';
 import { sleep } from '../helpers/sleep';
 import { logIn } from '../helpers/spectron/user';
 
-useSpectron({ appArgs: '--nosync', pauseIfFailed: true });
+useSpectron({ appArgs: '--nosync' });
 
 test('Shows optimized encoder for specific games', async t => {
   const { app } = t.context;

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -55,45 +55,24 @@ test('Shows optimized encoder for specific games', async t => {
    * Unfortunately, only a handful of these are actually testable. We also only test on CI as this
    * is going to be different for each developer machine.
    */
-  // if (process.env.CI) {
-  //   await app.client.click('.profile input[type=checkbox]');
-  //   await sleep(1000);
-  //   await app.client.click('button=Confirm & Go Live');
-  //   await focusMain(t);
-  //   await app.client.waitForExist('button=End Stream');
-  //   await app.client.click('.top-nav .icon-settings');
-  //
-  //   await focusChild(t);
-  //   await app.client.click('li=Output');
-  //
-  //   t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
-  //   t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
-  //   t.is('2500', await getFormInput(t, 'Bitrate'));
-  //
-  //   await app.client.click('button=Done');
-  //   await focusMain(t);
-  //   await app.client.click('button=End Stream');
-  //   await app.client.isExisting('button=Go Live');
-  // }
+  if (process.env.CI) {
+    await app.client.click('.profile input[type=checkbox]');
+    await sleep(1000);
+    await app.client.click('button=Confirm & Go Live');
+    await focusMain(t);
+    await app.client.waitForExist('button=End Stream');
+    await app.client.click('.top-nav .icon-settings');
 
-  await sleep(9999999);
+    await focusChild(t);
+    await app.client.click('li=Output');
 
-  await app.client.click('.profile input[type=checkbox]');
-  await sleep(1000);
-  await app.client.click('button=Confirm & Go Live');
-  await focusMain(t);
-  await app.client.waitForExist('button=End Stream');
-  await app.client.click('.top-nav .icon-settings');
+    t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
+    t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
+    t.is('2500', await getFormInput(t, 'Bitrate'));
 
-  await focusChild(t);
-  await app.client.click('li=Output');
-
-  t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
-  t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
-  t.is('2500', await getFormInput(t, 'Bitrate'));
-
-  await app.client.click('button=Done');
-  await focusMain(t);
-  await app.client.click('button=End Stream');
-  await app.client.isExisting('button=Go Live');
+    await app.client.click('button=Done');
+    await focusMain(t);
+    await app.client.click('button=End Stream');
+    await app.client.isExisting('button=Go Live');
+  }
 });

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -75,4 +75,25 @@ test('Shows optimized encoder for specific games', async t => {
   //   await app.client.click('button=End Stream');
   //   await app.client.isExisting('button=Go Live');
   // }
+
+  await sleep(9999999);
+
+  await app.client.click('.profile input[type=checkbox]');
+  await sleep(1000);
+  await app.client.click('button=Confirm & Go Live');
+  await focusMain(t);
+  await app.client.waitForExist('button=End Stream');
+  await app.client.click('.top-nav .icon-settings');
+
+  await focusChild(t);
+  await app.client.click('li=Output');
+
+  t.is('Advanced', await app.client.getValue('[data-name=Mode] input'));
+  t.is('Software (x264)', await app.client.getValue('[data-name=Encoder] input'));
+  t.is('2500', await getFormInput(t, 'Bitrate'));
+
+  await app.client.click('button=Done');
+  await focusMain(t);
+  await app.client.click('button=End Stream');
+  await app.client.isExisting('button=Go Live');
 });

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -3,7 +3,7 @@ import { getFormInput } from '../helpers/spectron/forms';
 import { sleep } from '../helpers/sleep';
 import { logIn } from '../helpers/spectron/user';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron({ appArgs: '--nosync', pauseIfFailed: true });
 
 test('Shows optimized encoder for specific games', async t => {
   const { app } = t.context;


### PR DESCRIPTION
* fixed optimized-encoder test
* `console.error` now save multiple arguments to the log file (`console.error('This is my Error', e)` )
* it's possible to set a flag for pausing test execution if something wrong to debug test via RDP
