### PR TITLE
De-jank folders UI

### DIFF
--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -46,7 +46,7 @@
       </template>
 
       <template slot="toggle" slot-scope="{ node }">
-        <span v-if="!node.isLeaf && node.children.length">
+        <span v-if="!node.isLeaf">
           <i v-if="node.isExpanded" class="icon-down"></i>
           <i v-if="!node.isExpanded" class="icon-down icon-right"></i>
         </span>
@@ -91,7 +91,7 @@ i.disabled {
   overflow: auto;
 }
 
-.sl-vue-tree-node {
+.sl-vue-tree-node-item {
   &:hover,
   &.sl-vue-tree-selected {
     .transition();

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -457,15 +457,15 @@ export class Selection implements ISelection {
    * A selection is considered visible if at least 1 item
    * in the selection is visible.
    */
-  isVisible() {
-    return this.getItems().find(item => item.visible);
+  isVisible(): boolean {
+    return !!this.getItems().find(item => item.visible);
   }
 
   /**
    * A selection is considered locked if all items in the
    * selection are locked.
    */
-  isLocked() {
+  isLocked(): boolean {
     return !this.getItems().find(item => !item.locked);
   }
 

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -453,10 +453,18 @@ export class Selection implements ISelection {
     }
   }
 
+  /**
+   * A selection is considered visible if at least 1 item
+   * in the selection is visible.
+   */
   isVisible() {
-    return !this.getItems().find(item => !item.visible);
+    return this.getItems().find(item => item.visible);
   }
 
+  /**
+   * A selection is considered locked if all items in the
+   * selection are locked.
+   */
   isLocked() {
     return !this.getItems().find(item => !item.locked);
   }


### PR DESCRIPTION
Changes:
- Show a open/close "caret" even for empty folders.  We were displaying a `+` here before (default in sl-vue-tree maybe?) but this just makes things consistent.
- Fix the hover class so hovering over a single element in a folder doesn't highlight actions for the entire folder and all parent folders too
- Fix so that hiding a single item in a folder doesn't show the entire folder as hidden.  For a folder to show as hidden, every item in the folder needs to be hidden.  A future refactor would be to make folders have a third icon which indicates when they are in a "mixed" state - i.e. not all items are visible or hidden, but it's a mix of visibility.  Same for locked.  But for now this brings visibility in line with the way we handle locked state so at least we are consistent.