### PR TITLE
fix(windows): only update scale if window is found

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -219,9 +219,11 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
   private updateScaleFactor(windowId: string) {
     const window = this.windows[windowId];
-    const bounds = window.getBounds();
-    const currentDisplay = electron.screen.getDisplayMatching(bounds);
-    this.UPDATE_SCALE_FACTOR(windowId, currentDisplay.scaleFactor);
+    if (window) {
+      const bounds = window.getBounds();
+      const currentDisplay = electron.screen.getDisplayMatching(bounds);
+      this.UPDATE_SCALE_FACTOR(windowId, currentDisplay.scaleFactor);
+    }
   }
 
   showWindow(options: Partial<IWindowOptions>) {


### PR DESCRIPTION
Only process scale factor updates if `window` is found. There could be a race condition where window is destroying and we attempt to run this code.