### PR TITLE
scene collection optimizations

### DIFF
--- a/app/components/ExtraSettings.vue.ts
+++ b/app/components/ExtraSettings.vue.ts
@@ -11,6 +11,7 @@ import { WindowsService } from 'services/windows';
 import { UserService } from 'services/user';
 import { StreamingService } from 'services/streaming';
 import { $t } from 'services/i18n';
+import { AppService } from 'services/app';
 
 @Component({
   components: { BoolInput },
@@ -23,6 +24,7 @@ export default class ExtraSettings extends Vue {
   @Inject() windowsService: WindowsService;
   @Inject() userService: UserService;
   @Inject() streamingService: StreamingService;
+  @Inject() appService: AppService;
 
   cacheUploading = false;
 
@@ -43,7 +45,7 @@ export default class ExtraSettings extends Vue {
   }
 
   showCacheDir() {
-    electron.remote.shell.openItem(electron.remote.app.getPath('userData'));
+    electron.remote.shell.openItem(this.appService.appDataDirectory);
   }
 
   deleteCacheDir() {

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -63,7 +63,7 @@ export class AppService extends StatefulService<IAppState> {
     argv: electron.remote.process.argv,
   };
 
-  private autosaveInterval: number;
+  readonly appDataDirectory = electron.remote.app.getPath('userData');
 
   @Inject() transitionsService: TransitionsService;
   @Inject() sourcesService: SourcesService;

--- a/app/services/auto-config/brand-device.ts
+++ b/app/services/auto-config/brand-device.ts
@@ -9,9 +9,7 @@ import { InitAfter } from '../../util/service-observer';
 import { downloadFile } from '../../util/requests';
 import { AppService } from 'services/app';
 import { SceneCollectionsService } from 'services/scene-collections';
-import { ScenesService } from 'services/scenes';
 import { IpcServerService } from 'services/api/ipc-server';
-import { AudioService } from 'services/audio';
 import { PrefabsService } from 'services/prefabs';
 import { UserService } from 'services/user';
 
@@ -52,8 +50,6 @@ export class BrandDeviceService extends StatefulService<IBrandDeviceState> {
   @Inject() private hostsService: HostsService;
   @Inject() private appService: AppService;
   @Inject() private sceneCollectionsService: SceneCollectionsService;
-  @Inject() private scenesService: ScenesService;
-  @Inject() private audioService: AudioService;
   @Inject() private ipcServerService: IpcServerService;
   @Inject() private prefabsService: PrefabsService;
   @Inject() private userService: UserService;
@@ -102,7 +98,7 @@ export class BrandDeviceService extends StatefulService<IBrandDeviceState> {
     try {
       const deviceUrls = await this.fetchDeviceUrls();
       const deviceName = deviceUrls.name;
-      const cacheDir = electron.remote.app.getPath('userData');
+      const cacheDir = this.appService.appDataDirectory;
       const tempDir = electron.remote.app.getPath('temp');
       let newSceneCollectionCreated = false;
 

--- a/app/services/cache-uploader.ts
+++ b/app/services/cache-uploader.ts
@@ -8,13 +8,14 @@ import os from 'os';
 import { compact } from 'lodash';
 import archiver from 'archiver';
 import AWS from 'aws-sdk';
+import { AppService } from 'services/app';
 
 export class CacheUploaderService extends Service {
-  @Inject()
-  userService: UserService;
+  @Inject() userService: UserService;
+  @Inject() appService: AppService;
 
   get cacheDir() {
-    return electron.remote.app.getPath('userData');
+    return this.appService.appDataDirectory;
   }
 
   uploadCache(): Promise<string> {

--- a/app/services/crash-reporter.ts
+++ b/app/services/crash-reporter.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 import path from 'path';
 import fs from 'fs';
 import { UsageStatisticsService } from 'services/usage-statistics';
+import { AppService } from 'services/app';
 
 /**
  * If we start up and the app is in anything other than the
@@ -33,6 +34,7 @@ export class CrashReporterService extends Service {
 
   @Inject() streamingService: StreamingService;
   @Inject() usageStatisticsService: UsageStatisticsService;
+  @Inject() appService: AppService;
 
   streamingSubscription: Subscription;
 
@@ -101,7 +103,7 @@ export class CrashReporterService extends Service {
   }
 
   private get appStateFile() {
-    return path.join(electron.remote.app.getPath('userData'), 'appState');
+    return path.join(this.appService.appDataDirectory, 'appState');
   }
 
   private readStateFile(): ICrashReporterState {

--- a/app/services/facemasks/index.ts
+++ b/app/services/facemasks/index.ts
@@ -21,6 +21,7 @@ import { TObsValue } from 'components/obs/inputs/ObsInput';
 import { $t } from 'services/i18n';
 import { throttle } from 'lodash-decorators';
 import * as Interfaces from './definitions';
+import { AppService } from 'services/app';
 
 export class FacemasksService extends PersistentStatefulService<Interfaces.IFacemasksServiceState> {
   @Inject() userService: UserService;
@@ -30,6 +31,7 @@ export class FacemasksService extends PersistentStatefulService<Interfaces.IFace
   @Inject() sourceFiltersService: SourceFiltersService;
   @Inject() streamingService: StreamingService;
   @Inject() private windowsService: WindowsService;
+  @Inject() appService: AppService;
 
   cdn = `https://${this.hostsService.facemaskCDN}`;
   facemaskFilter: obs.IFilter = null;
@@ -737,7 +739,7 @@ export class FacemasksService extends PersistentStatefulService<Interfaces.IFace
   }
 
   private get facemasksDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'plugin_config/facemask-plugin');
+    return path.join(this.appService.appDataDirectory, 'plugin_config/facemask-plugin');
   }
 
   private libraryUrl(uuid: string) {

--- a/app/services/font-library.ts
+++ b/app/services/font-library.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import fs from 'fs';
 import https from 'https';
 import electron from 'electron';
+import { AppService } from 'services/app';
+import { Inject } from 'util/injector';
 
 export interface IFamilyWithStyle {
   family: IFontFamily;
@@ -25,6 +27,8 @@ export interface IFontManifest {
 
 export class FontLibraryService extends Service {
   private manifest: IFontManifest;
+
+  @Inject() appService: AppService;
 
   // Used to prevent downloading the same font multiple times
   fontDownloadPromises: Dictionary<Promise<string>> = {};
@@ -117,7 +121,7 @@ export class FontLibraryService extends Service {
   }
 
   private get fontsDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'Fonts');
+    return path.join(this.appService.appDataDirectory, 'Fonts');
   }
 
   // Create a local font library path from a filename

--- a/app/services/obs-importer.ts
+++ b/app/services/obs-importer.ts
@@ -12,6 +12,7 @@ import { Inject } from 'util/injector';
 import { SceneCollectionsService } from 'services/scene-collections';
 import * as obs from '../../obs-api';
 import { SettingsService } from 'services/settings';
+import { AppService } from 'services/app';
 
 interface Source {
   name?: string;
@@ -78,6 +79,7 @@ export class ObsImporterService extends Service {
   @Inject() sceneCollectionsService: SceneCollectionsService;
   @Inject() audioService: AudioService;
   @Inject() settingsService: SettingsService;
+  @Inject() appService: AppService;
 
   async load(selectedprofile: string) {
     if (!this.isOBSinstalled()) return;
@@ -339,7 +341,7 @@ export class ObsImporterService extends Service {
       if (file === 'basic.ini' || file === 'streamEncoder.json' || file === 'recordEncoder.json') {
         const obsFilePath = path.join(profileDirectory, file);
 
-        const appData = electron.remote.app.getPath('userData');
+        const appData = this.appService.appDataDirectory;
         const currentFilePath = path.join(appData, file);
 
         const readData = fs.readFileSync(obsFilePath);

--- a/app/services/scene-collections/overlays.ts
+++ b/app/services/scene-collections/overlays.ts
@@ -22,6 +22,7 @@ import { ScenesService } from 'services/scenes';
 import { SelectionService } from 'services/selection';
 import uuid from 'uuid/v4';
 import { SceneSourceNode } from './nodes/overlays/scene';
+import { AppService } from 'services/app';
 
 const NODE_TYPES = {
   RootNode,
@@ -46,6 +47,7 @@ export interface IDownloadProgress {
 export class OverlaysPersistenceService extends Service {
   @Inject() private scenesService: ScenesService;
   @Inject() private selectionService: SelectionService;
+  @Inject() private appService: AppService;
 
   /**
    * Downloads the requested overlay into a temporary directory
@@ -134,6 +136,6 @@ export class OverlaysPersistenceService extends Service {
   }
 
   get overlaysDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'Overlays');
+    return path.join(this.appService.appDataDirectory, 'Overlays');
   }
 }

--- a/app/services/scene-collections/scene-collections.ts
+++ b/app/services/scene-collections/scene-collections.ts
@@ -664,7 +664,7 @@ export class SceneCollectionsService extends Service implements ISceneCollection
   }
 
   private get legacyDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'SceneConfigs');
+    return path.join(this.appService.appDataDirectory, 'SceneConfigs');
   }
 
   /**

--- a/app/services/scene-collections/state.ts
+++ b/app/services/scene-collections/state.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import electron from 'electron';
 import { FileManagerService } from 'services/file-manager';
 import { Inject } from 'util/injector';
+import { AppService } from 'services/app';
 
 interface ISceneCollectionsManifest {
   activeId: string;
@@ -22,6 +23,7 @@ interface ISceneCollectionsManifest {
  */
 export class SceneCollectionsStateService extends StatefulService<ISceneCollectionsManifest> {
   @Inject() fileManagerService: FileManagerService;
+  @Inject() appService: AppService;
 
   static initialState: ISceneCollectionsManifest = {
     activeId: null,
@@ -165,7 +167,7 @@ export class SceneCollectionsStateService extends StatefulService<ISceneCollecti
   }
 
   get collectionsDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'SceneCollections');
+    return path.join(this.appService.appDataDirectory, 'SceneCollections');
   }
 
   getCollectionFilePath(id: string) {

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import electron from 'electron';
 import rimraf from 'rimraf';
 import { without } from 'lodash';
+import { AppService } from 'services/app';
 
 interface IStreamlabelActiveSubscriptions {
   filename: string;
@@ -68,6 +69,7 @@ export class StreamlabelsService extends Service {
   @Inject() userService: UserService;
   @Inject() hostsService: HostsService;
   @Inject() websocketService: WebsocketService;
+  @Inject() appService: AppService;
 
   /**
    * Represents the raw strings that should be
@@ -390,7 +392,7 @@ export class StreamlabelsService extends Service {
   }
 
   private get streamlabelsDirectory() {
-    return path.join(electron.remote.app.getPath('userData'), 'Streamlabels');
+    return path.join(this.appService.appDataDirectory, 'Streamlabels');
   }
 
   private getStreamlabelsPath(filename: string) {


### PR DESCRIPTION
- Stop using the remote module to fetch `userData` which never changes
- Use `fetch` instead of `request` to get file data.  I'm not entirely sure why, but using `request` was causing the JS thread to block for a while here.  Plus using browser API gives better visibility and debugging overall.