### PR TITLE
Fix re-fetching streaming key

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -9,8 +9,9 @@ import {
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
-import { handleResponse, authorizedHeaders, requiresToken } from '../../util/requests';
+import { authorizedHeaders } from '../../util/requests';
 import { UserService } from '../user';
+import { handlePlatformResponse, requiresToken } from './utils';
 
 interface IFacebookPage {
   access_token: string;
@@ -122,7 +123,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
   fetchPages() {
     const request = this.formRequest(`${this.apiBase}/me/accounts`);
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(async json => {
         let pageId = this.userService.platform.channelId;
         if (!pageId) {
@@ -174,7 +175,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
       this.activeToken,
     );
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         const streamKey = json.stream_url.substr(json.stream_url.lastIndexOf('/') + 1);
         this.SET_LIVE_VIDEO_ID(json.id);
@@ -193,7 +194,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
       'fields=status,stream_url,title,description';
     const request = this.formRequest(url, {}, this.activeToken);
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         const info =
           json.data.find((vid: any) => vid.status === 'SCHEDULED_UNPUBLISHED') || json.data[0];
@@ -222,14 +223,14 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
       status: 'SCHEDULED_UNPUBLISHED',
     });
     const req = new Request(url, { headers, body, method: 'POST' });
-    return fetch(req).then(handleResponse);
+    return fetch(req).then(handlePlatformResponse);
   }
 
   fetchViewerCount(): Promise<number> {
     const url = `${this.apiBase}/${this.state.liveVideoId}?fields=live_views`;
     const request = this.formRequest(url, {}, this.activeToken);
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.live_views);
   }
 
@@ -257,7 +258,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
         body: JSON.stringify(data),
       });
       return fetch(request)
-        .then(handleResponse)
+        .then(handlePlatformResponse)
         .then(() => true);
     }
     return Promise.resolve(true);
@@ -270,7 +271,7 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
     const headers = this.getHeaders();
     const request = new Request(url, { headers, method: 'GET' });
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then((json: any) => json.data);
   }
 

--- a/app/services/platforms/mixer.ts
+++ b/app/services/platforms/mixer.ts
@@ -10,9 +10,10 @@ import {
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
-import { handleResponse, requiresToken, authorizedHeaders } from '../../util/requests';
+import { authorizedHeaders } from '../../util/requests';
 import { UserService } from '../user';
 import { integer } from 'aws-sdk/clients/cloudfront';
+import { handlePlatformResponse, requiresToken } from './utils';
 
 interface IMixerServiceState {
   typeIdMap: object;
@@ -104,7 +105,7 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     const request = new Request(url, { headers });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(response => this.userService.updatePlatformToken(response.access_token));
   }
 
@@ -116,7 +117,7 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         this.userService.updatePlatformChannelId(json.id);
         return json;
@@ -148,7 +149,7 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     const request = new Request(`${this.apiBase}channels/${this.mixerUsername}`, { headers });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.viewersCurrent);
   }
 
@@ -168,7 +169,7 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(() => true);
   }
 
@@ -181,7 +182,7 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     );
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(response => {
         response.forEach((game: any) => {
           this.ADD_GAME_MAPPING(game.name, game.id);

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -10,11 +10,12 @@ import {
 import { HostsService } from 'services/hosts';
 import { SettingsService } from 'services/settings';
 import { Inject } from 'util/injector';
-import { handleResponse, requiresToken, authorizedHeaders } from 'util/requests';
+import { authorizedHeaders } from 'util/requests';
 import { UserService } from 'services/user';
 import { StreamInfoService } from 'services/stream-info';
 import { getAllTags, getStreamTags, TTwitchTag, updateTags } from './twitch/tags';
 import { TTwitchOAuthScope } from './twitch/scopes';
+import { handlePlatformResponse, requiresToken } from './utils';
 
 /**
  * Request headers that need to be sent to Twitch
@@ -107,7 +108,7 @@ export class TwitchService extends Service implements IPlatformService {
     const request = new Request(url, { headers });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(response => this.userService.updatePlatformToken(response.access_token));
   }
 
@@ -116,7 +117,7 @@ export class TwitchService extends Service implements IPlatformService {
     const headers = this.getHeaders(true);
     const request = new Request('https://api.twitch.tv/kraken/channel', { headers });
 
-    return fetch(request).then(handleResponse);
+    return fetch(request).then(handlePlatformResponse);
   }
 
   fetchStreamKey(): Promise<string> {
@@ -150,7 +151,7 @@ export class TwitchService extends Service implements IPlatformService {
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => (json[0] && json[0].login ? { username: json[0].login as string } : {}));
   }
 
@@ -161,7 +162,7 @@ export class TwitchService extends Service implements IPlatformService {
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => (json.stream ? json.stream.viewers : 0));
   }
 
@@ -175,9 +176,10 @@ export class TwitchService extends Service implements IPlatformService {
       body: JSON.stringify(data),
     });
 
-    return Promise.all([fetch(request).then(handleResponse), this.setStreamTags(tags)]).then(
-      _ => true,
-    );
+    return Promise.all([
+      fetch(request).then(handlePlatformResponse),
+      this.setStreamTags(tags),
+    ]).then(_ => true);
   }
 
   searchGames(searchString: string): Promise<IGame[]> {
@@ -187,7 +189,7 @@ export class TwitchService extends Service implements IPlatformService {
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.games);
   }
 
@@ -242,7 +244,7 @@ export class TwitchService extends Service implements IPlatformService {
     });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.results[0].hits);
   }
 
@@ -250,7 +252,7 @@ export class TwitchService extends Service implements IPlatformService {
     return fetch('https://id.twitch.tv/oauth2/validate', {
       headers: this.getHeaders(true),
     })
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then((response: ITwitchOAuthValidateResponse) => response.scopes.includes(scope));
   }
 

--- a/app/services/platforms/utils.ts
+++ b/app/services/platforms/utils.ts
@@ -1,0 +1,33 @@
+/**
+ * same as handleResponse but passes a Response object instead a response body
+ * in the case of Promise rejection
+ * @see handleResponse
+ */
+export function handlePlatformResponse(response: Response): Promise<any> {
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType && contentType.includes('application/json');
+  const result = isJson ? response.json() : response.text();
+  return response.ok ? result : Promise.reject(response);
+}
+
+export function requiresToken() {
+  return (target: any, methodName: string, descriptor: PropertyDescriptor) => {
+    const original = descriptor.value;
+    return {
+      ...descriptor,
+      value(...args: any[]) {
+        return original.apply(target.constructor.instance, args).catch((error: Response) => {
+          if (!(error instanceof Response)) {
+            console.error('Expected Response but got', error);
+          }
+          if (error.status === 401) {
+            return target.fetchNewToken().then(() => {
+              return original.apply(target.constructor.instance, args);
+            });
+          }
+          return Promise.reject(error);
+        });
+      },
+    };
+  };
+}

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -9,9 +9,10 @@ import {
 import { HostsService } from '../hosts';
 import { SettingsService } from '../settings';
 import { Inject } from '../../util/injector';
-import { handleResponse, requiresToken, authorizedHeaders } from '../../util/requests';
+import { authorizedHeaders } from '../../util/requests';
 import { UserService } from '../user';
 import { $t } from 'services/i18n';
+import { handlePlatformResponse, requiresToken } from './utils';
 
 interface IYoutubeServiceState {
   liveStreamingEnabled: boolean;
@@ -110,7 +111,9 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(`${this.apiBase}/${endpoint}&access_token=${this.oauthToken}`);
 
     return fetch(request)
-      .then(resp => (resp.status === 403 ? this.handleForbidden(resp) : handleResponse(resp)))
+      .then(resp => {
+        return resp.status === 403 ? this.handleForbidden(resp) : handlePlatformResponse(resp);
+      })
       .then(() => this.SET_ENABLED_STATUS(true));
   }
 
@@ -124,7 +127,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(`${this.apiBase}/${endpoint}&access_token=${this.oauthToken}`);
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.items[0].contentDetails.boundStreamId);
   }
 
@@ -146,7 +149,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(`${this.apiBase}/${endpoint}&access_token=${this.oauthToken}`);
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => json.items[0].cdn.ingestionInfo.streamName);
   }
 
@@ -168,7 +171,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(`${this.apiBase}/${endpoint}&access_token=${this.oauthToken}`);
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         if (json.items.length) {
           this.SET_STREAM_ID(json.items[0].id);
@@ -186,7 +189,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
       const request = new Request(url);
 
       return fetch(request)
-        .then(handleResponse)
+        .then(handlePlatformResponse)
         .then(json => json.items[0].liveStreamingDetails.concurrentViewers || 0);
     });
   }
@@ -201,7 +204,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
       this.oauthToken
     }`;
     return fetch(`${this.apiBase}/liveBroadcasts?${query}`)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         if (!json.items.length) return;
         this.SET_STREAM_ID(json.items[0].id);
@@ -220,7 +223,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
       status: { privacyStatus: 'public' },
     });
     const req = new Request(url, { headers, body, method: 'POST' });
-    return fetch(req).then(handleResponse);
+    return fetch(req).then(handlePlatformResponse);
   }
 
   fetchNewToken(): Promise<void> {
@@ -230,7 +233,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(url, { headers });
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(response => this.userService.updatePlatformToken(response.access_token));
   }
 
@@ -264,7 +267,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
         });
 
         return fetch(request)
-          .then(handleResponse)
+          .then(handlePlatformResponse)
           .then(() => true);
       });
   }
@@ -283,7 +286,7 @@ export class YoutubeService extends StatefulService<IYoutubeServiceState>
     const request = new Request(`${this.apiBase}/${endpoint}&access_token=${this.oauthToken}`);
 
     return fetch(request)
-      .then(handleResponse)
+      .then(handlePlatformResponse)
       .then(json => {
         const youtubeDomain = mode === 'day' ? 'https://youtube.com' : 'https://gaming.youtube.com';
         this.SET_STREAM_ID(json.items[0].id);

--- a/app/util/requests.ts
+++ b/app/util/requests.ts
@@ -15,7 +15,7 @@ export const handleResponse = (response: Response): Promise<any> => {
   const contentType = response.headers.get('content-type');
   const isJson = contentType && contentType.includes('application/json');
   const result = isJson ? response.json() : response.text();
-  return response.ok ? result : Promise.reject(response);
+  return response.ok ? result : result.then(r => Promise.reject(r));
 };
 
 export const handleErrors = (response: Response): Promise<any> => {
@@ -33,25 +33,6 @@ export function camelize(response: Response): Promise<any> {
       resolve(humps.camelizeKeys(json));
     });
   });
-}
-
-export function requiresToken() {
-  return (target: any, methodName: string, descriptor: PropertyDescriptor) => {
-    const original = descriptor.value;
-    return {
-      ...descriptor,
-      value(...args: any[]) {
-        return original.apply(target.constructor.instance, args).catch((error: Response) => {
-          if (error.status === 401) {
-            return target.fetchNewToken().then(() => {
-              return original.apply(target.constructor.instance, args);
-            });
-          }
-          return Promise.reject(error);
-        });
-      },
-    };
-  };
 }
 
 /**

--- a/app/util/requests.ts
+++ b/app/util/requests.ts
@@ -15,8 +15,7 @@ export const handleResponse = (response: Response): Promise<any> => {
   const contentType = response.headers.get('content-type');
   const isJson = contentType && contentType.includes('application/json');
   const result = isJson ? response.json() : response.text();
-
-  return response.ok ? result : result.then(r => Promise.reject(r));
+  return response.ok ? result : Promise.reject(response);
 };
 
 export const handleErrors = (response: Response): Promise<any> => {


### PR DESCRIPTION
`@requiresToken()` doesn't work correctly
`@requiresToken` decorator expects a `http response` , not a `http response body`
when it checks `error.status === 401` the field status can exist in `http response` but there are no guarantees that `status` field will be in the `http response body`