### PR TITLE
added align-items: center to fix preview disabled message in editor

### DIFF
--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -80,6 +80,7 @@
   flex-grow: 1;
   display: flex;
   justify-content: center;
+  align-items: center;
 
   .message {
     max-width: 50%;


### PR DESCRIPTION
The "preview is disabled in performance mode" message and button took a little trip up north

I put it back where it belongs. 