### PR TITLE
fix loader and FM race condition issues

### DIFF
--- a/app/components/windows/Main.vue
+++ b/app/components/windows/Main.vue
@@ -19,7 +19,7 @@
       />
     </div>
 
-    <div class="main-middle" :class="mainResponsiveClasses" ref="mainMiddle">
+    <div class="main-middle" :class="mainResponsiveClasses" v-if="!showLoadingSpinner" ref="mainMiddle">
       <resize-observer @notify="handleResize"></resize-observer>
 
       <top-nav v-if="(page !== 'Onboarding')" :locked="applicationLoading"></top-nav>
@@ -27,7 +27,6 @@
 
       <component
         class="main-page-container"
-        v-if="!showLoadingSpinner"
         :is="page"
         :params="params"/>
       <studio-footer v-if="!applicationLoading && (page !== 'Onboarding')" />
@@ -45,7 +44,7 @@
     </div>
   </div>
   <transition name="loader">
-    <div class="main-loading" v-if="applicationLoading"><custom-loader></custom-loader></div>
+    <div class="main-loading" v-if="showLoadingSpinner"><custom-loader></custom-loader></div>
   </transition>
 </div>
 </template>

--- a/app/components/windows/Main.vue.ts
+++ b/app/components/windows/Main.vue.ts
@@ -73,7 +73,6 @@ export default class Main extends Vue {
     }
 
     electron.remote.getCurrentWindow().show();
-    this.handleResize();
   }
 
   get title() {


### PR DESCRIPTION
Fixes:
- No longer show the loader during onboarding
- No longer show the loader over the top of the themes library when installing a theme
- Unmount more components while loading (including the top nav), which prevents us loading services too early.