### PR TITLE
Fix Face Mask Bugs

### DIFF
--- a/app/components/widgets/AlertBox.vue.ts
+++ b/app/components/widgets/AlertBox.vue.ts
@@ -223,6 +223,10 @@ export default class AlertBox extends WidgetSettings<IAlertBoxData, AlertBoxServ
           duration,
           enabled: this.facemaskEnabled,
           device: this.facemasksService.getEnabledDevice(),
+          donations_enabled: this.facemasksService.state.settings.donations_enabled,
+          subs_enabled: this.facemasksService.state.settings.donations_enabled,
+          bits_enabled: this.facemasksService.state.settings.donations_enabled,
+          bits_price: this.facemasksService.state.settings.bits_price,
         })
         .catch(() => this.onFailHandler($t('Something went wrong updating Facemask settings')));
     }

--- a/app/services/facemasks/definitions.ts
+++ b/app/services/facemasks/definitions.ts
@@ -53,6 +53,12 @@ export interface IUserFacemaskSettings {
   facemasks?: IFacemask[];
   duration: number;
   device: IInputDeviceSelection;
+  donations_enabled: boolean;
+  subs_enabled: boolean;
+  sub_duration?: number;
+  bits_enabled: boolean;
+  bits_duration?: number;
+  bits_price: number;
 }
 
 export interface IFacemaskDonation {

--- a/app/services/facemasks/index.ts
+++ b/app/services/facemasks/index.ts
@@ -272,7 +272,7 @@ export class FacemasksService extends PersistentStatefulService<Interfaces.IFace
       this.registerSubscriptionEvent({
         subscriberId: event.message[0].subscriber_twitch_id,
         subPlan: event.message[0].sub_plan,
-        name: event.message[0].name,
+        name: event.message[0].name.toLowerCase(),
       });
     }
 
@@ -301,7 +301,7 @@ export class FacemasksService extends PersistentStatefulService<Interfaces.IFace
       this.playSubscriptionEvent({
         subscriberId: event.message.subscriber_twitch_id,
         subPlan: event.message.sub_plan,
-        name: event.message.name,
+        name: event.message.name.toLowerCase(),
       });
     }
 


### PR DESCRIPTION
1. Recent changes to sub events have caused name property to be inconsistently capitalized between `alertPlaying` and `subscription` events. The name property will be converted to lower case as an extra measure of safety against further changes to this data.
2. Widget settings window wasn't updated with new required parameters. This PR adds these.