### PR TITLE
make updaters UAC request appear not minimized

### DIFF
--- a/updater/bootstrap.js
+++ b/updater/bootstrap.js
@@ -300,7 +300,7 @@ async function entry(info) {
 
     const update_spawned = cp.spawn(`${updaterStartCommand}`, updaterArgs, {
         cwd: info.tempDir,
-        detached: false,
+        detached: true,
         shell: true
     });
 


### PR DESCRIPTION
For issue when sometimes users have UAC request for updater start minimized. 
Looks like with "detached: false" spawn command have higher chance to have request UAC in minimized state. As it depends on what window is in focus at the time when Windows process UAC request.