### PR TITLE
Fix visual bug in jar selection

### DIFF
--- a/app/components/shared/inputs/ImagePickerInput.vue
+++ b/app/components/shared/inputs/ImagePickerInput.vue
@@ -21,13 +21,14 @@
   width: 100%;
   max-width: 370px;
   display: grid;
-  grid-template-columns: repeat( auto-fit, 64px);
-  grid-column-gap: 8px;
+  grid-template-columns: repeat(auto-fit, 56px);
+  grid-column-gap: 4px;
+  grid-row-gap: 4px;
 }
 
 .widget-layout-picker__option {
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   border: 1px solid var(--solid-input);
   background-color: var(--solid-input);
   .transition();

--- a/app/components/windows/WidgetEditor.vue
+++ b/app/components/windows/WidgetEditor.vue
@@ -328,6 +328,7 @@
 
   .subsection__content.custom {
     overflow: visible;
+    padding: 8px;
   }
 
   .source-property {


### PR DESCRIPTION
Returns jar selector to a 4x4 grid instead of an awkward 3x5 + 1 grid