### PR TITLE
Validate ListInputs

### DIFF
--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -452,11 +452,12 @@ export function setPropertiesFormData(obsSource: obs.ISource, form: TObsFormData
   updatedFormData.forEach(prop => {
     if (prop.type !== 'OBS_PROPERTY_LIST') return;
     const listProp = prop as IObsListInput<TObsValue>;
+    if (!listProp.options.length) return;
     const optionExists = !!listProp.options.find(option => option.value === listProp.value);
     if (optionExists) return;
 
     needUpdatePropsAgain = true;
-    listProp.value = listProp.options[0] && listProp.options[0].value;
+    listProp.value = listProp.options[0].value;
   });
   if (needUpdatePropsAgain) setPropertiesFormData(obsSource, updatedFormData);
 }

--- a/app/components/obs/inputs/ObsInput.ts
+++ b/app/components/obs/inputs/ObsInput.ts
@@ -445,6 +445,20 @@ export function setPropertiesFormData(obsSource: obs.ISource, form: TObsFormData
   if (formInputs.length === 0) return;
 
   obsSource.update(settings);
+
+  // validate list-inputs and update properties again if some of list inputs are invalid
+  const updatedFormData = getPropertiesFormData(obsSource);
+  let needUpdatePropsAgain = false;
+  updatedFormData.forEach(prop => {
+    if (prop.type !== 'OBS_PROPERTY_LIST') return;
+    const listProp = prop as IObsListInput<TObsValue>;
+    const optionExists = !!listProp.options.find(option => option.value === listProp.value);
+    if (optionExists) return;
+
+    needUpdatePropsAgain = true;
+    listProp.value = listProp.options[0] && listProp.options[0].value;
+  });
+  if (needUpdatePropsAgain) setPropertiesFormData(obsSource, updatedFormData);
 }
 
 export abstract class ObsInput<TValueType> extends Vue {


### PR DESCRIPTION
When we're switching a video device in the video capture source it's possible to get an unsupported resolution because we don't clear the resolution ListInput from the previous device