### PR TITLE
Add channel info prepopulation to Twitch and Mixer

### DIFF
--- a/app/components/windows/EditStreamInfo.vue.ts
+++ b/app/components/windows/EditStreamInfo.vue.ts
@@ -111,7 +111,7 @@ export default class EditStreamInfo extends Vue {
     if (!this.streamInfoService.state.channelInfo) {
       await this.refreshStreamInfo();
     }
-    if (this.isFacebook || this.isYoutube) {
+    if (this.isServicedPlatform) {
       const service = getPlatformService(this.userService.platform.type);
       await service
         .prepopulateInfo()
@@ -332,6 +332,10 @@ export default class EditStreamInfo extends Vue {
 
   get isFacebook() {
     return this.userService.platform.type === 'facebook';
+  }
+
+  get isServicedPlatform() {
+    return this.isFacebook || this.isYoutube || this.isTwitch || this.isMixer;
   }
 
   get submitText() {

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -101,7 +101,7 @@ export interface IPlatformService {
 
   afterGoLive?: (context?: StreamingContext) => Promise<void>;
 
-  prepopulateInfo?: () => Promise<any>;
+  prepopulateInfo: () => Promise<any>;
 
   scheduleStream?: (startTime: string, info: IChannelInfo) => Promise<any>;
 }

--- a/app/services/platforms/mixer.ts
+++ b/app/services/platforms/mixer.ts
@@ -146,6 +146,10 @@ export class MixerService extends StatefulService<IMixerServiceState> implements
     });
   }
 
+  prepopulateInfo() {
+    return this.fetchChannelInfo();
+  }
+
   @requiresToken()
   fetchViewerCount(): Promise<number> {
     const headers = this.getHeaders();

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -205,6 +205,13 @@ export class TwitchService extends Service implements IPlatformService {
     return getAllTags(this.getRawHeaders(true));
   }
 
+  prepopulateInfo() {
+    return this.fetchRawChannelInfo().then(json => ({
+      title: json.status,
+      game: json.game,
+    }));
+  }
+
   @requiresToken()
   getStreamTags(): Promise<TTwitchTag[]> {
     return getStreamTags(this.twitchId, this.getRawHeaders(true, true));


### PR DESCRIPTION
We used to update channel only on app launch but i think it would be useful to update every time they open EditStreamInfo like it does on YT and FB