### PR TITLE
Add public IP to the agent name and allow to select a pool

### DIFF
--- a/scripts/install-ci.ps1
+++ b/scripts/install-ci.ps1
@@ -45,7 +45,8 @@ Invoke-WebRequest -Uri https://vstsagentpackage.azureedge.net/agent/2.150.3/vsts
 Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD\agent.zip", "$PWD")
 
 echo "Configure Azure Agent"
-.\config --unattended --url https://dev.azure.com/streamlabs --auth pat --token $token --agent "$env:computername $(Get-Random)"
+$publicIp = (Invoke-RestMethod ipinfo.io/ip).trim()
+.\config --unattended --url https://dev.azure.com/streamlabs --auth pat --token $token --agent "$env:computername $publicIp"
 
 # Azure Agent has --AutoLogon option to add Anget to autostartup
 # But it doesn't allow to pass any arguments to the Agent

--- a/scripts/install-ci.ps1
+++ b/scripts/install-ci.ps1
@@ -1,9 +1,12 @@
 # Run this script as administrator to setup enviroment on new CI machine:
-# powershell install.ps1 your_azure_token host_user host_password
+# powershell install.ps1 your_azure_token host_user host_password agent_pool?
 
 $token=$args[0]
 $username=$args[1]
 $password=$args[2]
+$pool=$args[2]
+if (-Not $pool) { $pool = 'Default' }
+
 $agentPath = "C:\agent\run.cmd"
 
 
@@ -46,7 +49,7 @@ Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression
 
 echo "Configure Azure Agent"
 $publicIp = (Invoke-RestMethod ipinfo.io/ip).trim()
-.\config --unattended --url https://dev.azure.com/streamlabs --auth pat --token $token --agent "$env:computername $publicIp"
+.\config --unattended --url https://dev.azure.com/streamlabs --auth pat --token $token --agent "$env:computername $publicIp" --pool $pool
 
 # Azure Agent has --AutoLogon option to add Anget to autostartup
 # But it doesn't allow to pass any arguments to the Agent

--- a/scripts/install-ci.ps1
+++ b/scripts/install-ci.ps1
@@ -4,7 +4,7 @@
 $token=$args[0]
 $username=$args[1]
 $password=$args[2]
-$pool=$args[2]
+$pool=$args[3]
 if (-Not $pool) { $pool = 'Default' }
 
 $agentPath = "C:\agent\run.cmd"


### PR DESCRIPTION
Azure Pipelines don't show the IP address of the agent in UI. That's very inconvenient when you need to do an RDP connection. I added the IP address to the agent name; 