### PR TITLE
fix object is destroyed error

### DIFF
--- a/main.js
+++ b/main.js
@@ -254,7 +254,9 @@ function startApp() {
   }
 
   ipcMain.on('services-ready', () => {
-    childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+    if (!childWindow.isDestroyed()) {
+      childWindow.loadURL(`${global.indexUrl}?windowId=child`);
+    }
   });
 
   ipcMain.on('services-request', (event, payload) => {


### PR DESCRIPTION
Fixes: https://sentry.io/organizations/streamlabs-obs/issues/980263462

We hit this error when you try to close Streamlabs OBS while it is still initializing.  We have ~3-4k occurrences daily.