### PR TITLE
remove extra logging from file manager

### DIFF
--- a/app/services/file-manager.ts
+++ b/app/services/file-manager.ts
@@ -144,7 +144,6 @@ export class FileManagerService extends Service {
       await this.writeFile(filePath, file.data);
 
       if (version !== file.version) {
-        // TODO: throw here seems to be used as control flow
         throw new Error('Wrote out of date file!  Will retry...');
       }
 
@@ -182,14 +181,12 @@ export class FileManagerService extends Service {
 
       fs.writeFile(tmpPath, data, err => {
         if (err) {
-          console.error(err);
           reject(err);
           return;
         }
 
         fs.rename(tmpPath, filePath, err => {
           if (err) {
-            console.error(err);
             reject(err);
             return;
           }


### PR DESCRIPTION
The error logging here is really unnecessary and clogs up sentry - especially since sentry doesn't thread these together due to differing file paths.  We really shouldn't be logging here because it is an optimistic locking system, and some level of contention is expected.  It's not worth filling up sentry with `EBUSY` reports when that's fairly expected.

I also removed the TODO as I genuinely believe this system would be far more difficult to write and less obvious if that `throw` were removed.  An exception makes sense here because optimistic logging is essentially doing your write and then aborting if it fails.  Were this a database, the version mismatch would be an actual exception from our database library, but since this isn't a database, we throw it ourselves.