### PR TITLE
Increase image comparison threshold

### DIFF
--- a/test/screentest/comparator.ts
+++ b/test/screentest/comparator.ts
@@ -120,7 +120,7 @@ const parsedImages: { [imageName: string]: IParsedImage } = {};
       parsedImage.diff.data,
       baseImage.width,
       baseImage.height,
-      { threshold: 0.1 },
+      { threshold: CONFIG.threshold },
     );
 
     regression.isChanged = numDiffPixels > 0;

--- a/test/screentest/config.json
+++ b/test/screentest/config.json
@@ -2,6 +2,7 @@
   "baseBranch": "staging",
   "dist": "test-dist/screentest",
   "compiledTestsDist": "test-dist/test",
+  "threshold": 0.15,
   "configs": {
     "resolution": {
       "window": "main",


### PR DESCRIPTION
Looking on this screentests result http://slobs-screentest.s3.amazonaws.com/532f68e4-a675-4563-947f-5827563b924c/preview.html it seems that `threshold=0.1` is not always a good value. Going to try `threshold=0.15`