### PR TITLE
Change duration from 2s to 8s to match website default

### DIFF
--- a/app/services/widgets/settings/alert-box/alert-box-data.ts
+++ b/app/services/widgets/settings/alert-box/alert-box-data.ts
@@ -145,7 +145,7 @@ export const newVariation = (type: string): IAlertBoxVariation => ({
     customHtmlEnabled: false,
     customJs: '',
     customJson: '',
-    duration: 2,
+    duration: 8,
     hideAnimation: 'fadeOut',
     image: { href: 'http://uploads.twitchalerts.com/image-defaults/1n9bK4w.gif' },
     layout: 'above',


### PR DESCRIPTION
The website uses a default of 8seconds and this was throwing off a couple of users when their new one was 2seconds