### PR TITLE
add a few tests for undo and fix the bugs they uncovered

### DIFF
--- a/app/services/editor-commands/commands/remove-folder.ts
+++ b/app/services/editor-commands/commands/remove-folder.ts
@@ -8,6 +8,7 @@ export class RemoveFolderCommand extends Command {
 
   private name: string;
   private childrenIds: string[];
+  private parentId: string;
 
   constructor(private sceneId: string, private folderId: string) {
     super();
@@ -21,12 +22,14 @@ export class RemoveFolderCommand extends Command {
     const folder = this.scenesService.getScene(this.sceneId).getFolder(this.folderId);
     this.name = folder.name;
     this.childrenIds = folder.childrenIds;
+    this.parentId = folder.parentId;
     folder.ungroup();
   }
 
   rollback() {
     const scene = this.scenesService.getScene(this.sceneId);
-    scene.createFolder(this.name, { id: this.folderId });
+    const folder = scene.createFolder(this.name, { id: this.folderId });
     scene.getSelection(this.childrenIds).setParent(this.folderId);
+    if (this.parentId) folder.setParent(this.parentId);
   }
 }

--- a/app/services/editor-commands/commands/remove-nodes.ts
+++ b/app/services/editor-commands/commands/remove-nodes.ts
@@ -9,6 +9,7 @@ export class RemoveNodesCommand extends Command {
   private removeItemSubCommands: RemoveItemCommand[];
 
   private selectionName: string;
+  private nodeOrder: string[];
 
   constructor(private selection: Selection) {
     super();
@@ -22,6 +23,8 @@ export class RemoveNodesCommand extends Command {
   async execute() {
     this.removeFolderSubCommands = [];
     this.removeItemSubCommands = [];
+
+    this.nodeOrder = this.selection.getScene().getNodesIds();
 
     this.selection.getFolders().forEach(folder => {
       const subCommand = new RemoveFolderCommand(this.selection.sceneId, folder.id);
@@ -37,10 +40,12 @@ export class RemoveNodesCommand extends Command {
   }
 
   async rollback() {
-    for (const itemCommand of this.removeItemSubCommands.reverse()) {
+    for (const itemCommand of [...this.removeItemSubCommands].reverse()) {
       await itemCommand.rollback();
     }
 
-    this.removeFolderSubCommands.forEach(cmd => cmd.rollback());
+    [...this.removeFolderSubCommands].reverse().forEach(cmd => cmd.rollback());
+
+    this.selection.getScene().setNodesOrder(this.nodeOrder);
   }
 }

--- a/app/services/scenes/scene-folder.ts
+++ b/app/services/scenes/scene-folder.ts
@@ -38,7 +38,7 @@ export class SceneItemFolder extends SceneItemNode {
   }
 
   ungroup() {
-    this.getItems()
+    this.getNodes()
       .reverse()
       .forEach(item => item.setParent(this.parentId));
     this.remove();

--- a/test/helpers/scene-builder.ts
+++ b/test/helpers/scene-builder.ts
@@ -62,6 +62,8 @@ export class SceneBuilder {
   }
 
   parse(sketch: string): ISceneBuilderNode[] {
+    if (sketch === '') return [];
+
     let strings = sketch.split('\n');
     let offset = -1;
 

--- a/test/helpers/spectron/scenes.js
+++ b/test/helpers/spectron/scenes.js
@@ -30,6 +30,12 @@ export async function rightClickScene(t, name) {
   await t.context.app.client.rightClick(`div=${name}`);
 }
 
+export async function duplicateScene(t, sourceName, targetName) {
+  await openDuplicateWindow(t, sourceName);
+  await t.context.app.client.setValue('input', targetName);
+  await t.context.app.client.click('button=Done');
+}
+
 export async function addScene(t, name) {
   const app = t.context.app;
 

--- a/test/undo.ts
+++ b/test/undo.ts
@@ -1,0 +1,146 @@
+import { useSpectron, test, focusMain, TExecutionContext } from './helpers/spectron/index';
+import { addSource, sourceIsExisting } from './helpers/spectron/sources';
+import { SceneBuilder } from './helpers/scene-builder';
+import { getClient } from './helpers/api-client';
+import {
+  addScene,
+  clickRemoveScene,
+  selectScene,
+  duplicateScene,
+  sceneExisting,
+} from './helpers/spectron/scenes';
+import { sleep } from './helpers/sleep';
+
+useSpectron();
+
+async function undo(t: TExecutionContext) {
+  await t.context.app.client.click('.fa-undo');
+}
+
+async function redo(t: TExecutionContext) {
+  await t.context.app.client.click('.fa-redo');
+}
+
+test('Creating some sources with undo/redo', async t => {
+  await focusMain(t);
+
+  await addSource(t, 'Color Source', 'Color Source 1');
+  await addSource(t, 'Color Source', 'Color Source 2');
+  await addSource(t, 'Color Source', 'Color Source 3');
+
+  await focusMain(t);
+
+  t.true(await sourceIsExisting(t, 'Color Source 1'));
+  t.true(await sourceIsExisting(t, 'Color Source 2'));
+  t.true(await sourceIsExisting(t, 'Color Source 3'));
+
+  await undo(t);
+
+  t.true(await sourceIsExisting(t, 'Color Source 1'));
+  t.true(await sourceIsExisting(t, 'Color Source 2'));
+  t.false(await sourceIsExisting(t, 'Color Source 3'));
+
+  await undo(t);
+
+  t.true(await sourceIsExisting(t, 'Color Source 1'));
+  t.false(await sourceIsExisting(t, 'Color Source 2'));
+  t.false(await sourceIsExisting(t, 'Color Source 3'));
+
+  await undo(t);
+
+  t.false(await sourceIsExisting(t, 'Color Source 1'));
+  t.false(await sourceIsExisting(t, 'Color Source 2'));
+  t.false(await sourceIsExisting(t, 'Color Source 3'));
+
+  await redo(t);
+  await redo(t);
+  await redo(t);
+
+  t.true(await sourceIsExisting(t, 'Color Source 1'));
+  t.true(await sourceIsExisting(t, 'Color Source 2'));
+  t.true(await sourceIsExisting(t, 'Color Source 3'));
+});
+
+test('Deleting a scene with undo/redo', async t => {
+  const client = await getClient();
+  const sceneBuilder = new SceneBuilder(client);
+
+  await addScene(t, 'New Scene');
+
+  // Build a complex item and folder hierarchy
+  const sketch = `
+    Item1:
+    Item2:
+    Folder1
+      Item3:
+      Item4:
+    Item5:
+    Folder2
+      Item6:
+      Folder3
+        Item7:
+        Item8:
+      Item9:
+      Folder4
+        Item10:
+    Item11:
+  `;
+
+  sceneBuilder.build(sketch);
+
+  await focusMain(t);
+  await clickRemoveScene(t);
+
+  t.true(sceneBuilder.isEqualTo(''));
+
+  await undo(t);
+  await selectScene(t, 'New Scene');
+
+  t.true(sceneBuilder.isEqualTo(sketch));
+
+  await redo(t);
+  t.true(sceneBuilder.isEqualTo(''));
+});
+
+test('Duplicating a scene with undo/redo', async t => {
+  const client = await getClient();
+  const sceneBuilder = new SceneBuilder(client);
+
+  // Build a complex item and folder hierarchy
+  const sketch = `
+    Item1:
+    Item2:
+    Folder1
+      Item3:
+      Item4:
+    Item5:
+    Folder2
+      Item6:
+      Folder3
+        Item7:
+        Item8:
+      Item9:
+      Folder4
+        Item10:
+    Item11:
+  `;
+
+  sceneBuilder.build(sketch);
+  await duplicateScene(t, 'Scene', 'Duplicate');
+  await focusMain(t);
+
+  await selectScene(t, 'Duplicate');
+  t.true(sceneBuilder.isEqualTo(sketch));
+
+  await selectScene(t, 'Scene');
+  t.true(sceneBuilder.isEqualTo(sketch));
+
+  await undo(t);
+
+  t.false(await sceneExisting(t, 'Duplicate'));
+
+  await redo(t);
+
+  await selectScene(t, 'Duplicate');
+  t.true(sceneBuilder.isEqualTo(sketch));
+});


### PR DESCRIPTION
I'm not going to write exhaustive tests for every single undo command, so I wanted to start with a few tests that that will have as broad a reach as possible.  The commands tested here are extremely complex and utilize lots of other subcommands to get their job done.  So in reality these 3 tests end up testing 10+ commands, so reach is fairly good.

The test to remove a scene ended up surfacing a few bugs, including the sentry error that I was having trouble locating the source of.  Those bugs are fixed as part of this PR.

More tests are coming later.