### PR TITLE
handle unhandled facebook promise

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -227,6 +227,8 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
   }
 
   fetchViewerCount(): Promise<number> {
+    if (this.state.liveVideoId == null) return Promise.resolve(0);
+
     const url = `${this.apiBase}/${this.state.liveVideoId}?fields=live_views`;
     const request = this.formRequest(url, {}, this.activeToken);
     return fetch(request)

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -231,7 +231,8 @@ export class FacebookService extends StatefulService<IFacebookServiceState>
     const request = this.formRequest(url, {}, this.activeToken);
     return fetch(request)
       .then(handlePlatformResponse)
-      .then(json => json.live_views);
+      .then(json => json.live_views)
+      .catch(() => 0);
   }
 
   fbGoLive() {


### PR DESCRIPTION
Sentry is now reporting unhandled promise rejections, and this one is particularly noisy.