### PR TITLE
Setup twitch tags for streaming tests

### DIFF
--- a/app/components/shared/inputs/TwitchTagsInput.vue
+++ b/app/components/shared/inputs/TwitchTagsInput.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="tags-container">
+  <div
+    class="tags-container"
+    data-role="input"
+    data-type="twitchTags"
+    :data-name="name"
+  >
     <label class="input-label">{{ tagsLabel }}</label>
     <v-selectpage
       v-if="hasPermission"

--- a/app/components/shared/inputs/TwitchTagsInput.vue.ts
+++ b/app/components/shared/inputs/TwitchTagsInput.vue.ts
@@ -13,6 +13,8 @@ export default class TwitchTagsInput extends Vue {
   @Inject() i18nService: I18nService;
   @Inject() customizationService: CustomizationService;
 
+  @Prop() name: string;
+
   @Prop() value: TTwitchTagWithLabel[];
 
   @Prop() tags: TTwitchTag[];

--- a/app/components/windows/EditStreamInfo.vue
+++ b/app/components/windows/EditStreamInfo.vue
@@ -60,6 +60,7 @@
         <TwitchTagsInput
           v-if="isTwitch"
           v-model="twitchTags"
+          name="tags"
           :tags="allTwitchTags"
           :has-permission="hasUpdateTagsPermission"
           @input="setTags"

--- a/test/helpers/form-monkey.ts
+++ b/test/helpers/form-monkey.ts
@@ -90,6 +90,9 @@ export class FormMonkey {
         case 'fontWeight':
           await this.setSliderValue(input.selector, value);
           break;
+        case 'twitchTags':
+          await this.setTwitchTagsValue(input.selector, value);
+          break;
         default:
           throw new Error(`No setter found for input type = ${input.type}`);
       }
@@ -282,6 +285,29 @@ export class FormMonkey {
     await ((this.client.keys(['Control', 'a']) as any) as Promise<any>); // clear
     await ((this.client.keys('Control') as any) as Promise<any>); // release ctrl key
     await ((this.client.keys(value) as any) as Promise<any>); // type text
+  }
+
+  async setTwitchTagsValue(selector: string, values: string[]) {
+    // clear tags
+    const closeSelector = `${selector} .sp-icon-close`;
+    while (await this.client.isExisting(closeSelector)) {
+      await this.client.click(closeSelector);
+    }
+
+    // click to open the popup
+    await this.client.click(selector);
+
+    // select values
+    const inputSelector = `.v-dropdown-container .sp-search-input`;
+    for (const value of values) {
+      await this.setInputValue(inputSelector, value);
+      await ((this.client.keys('ArrowDown') as any) as Promise<any>);
+      await ((this.client.keys('Enter') as any) as Promise<any>);
+    }
+
+    // click away and wait for the control to dismiss
+    await this.client.click('.tags-container .input-label');
+    await this.client.waitForExist('.sp-input-container.sp-open', 500, true);
   }
 
   private async getAttribute(selector: string, attrName: string) {

--- a/test/screentest/tests/streaming.ts
+++ b/test/screentest/tests/streaming.ts
@@ -30,6 +30,7 @@ platforms.forEach(platform => {
         await fillForm(t, 'form[name=editStreamForm]', {
           stream_title: 'SLOBS Test Stream',
           game: 'PLAYERUNKNOWN\'S BATTLEGROUNDS',
+          tags: ['100%', 'AMA'],
         });
         break;
 


### PR DESCRIPTION
Because the user-pool every time provide different accounts we may have a different set of twitch tags. So we have inconsistent screenshots for the streaming tests:
![image](https://user-images.githubusercontent.com/3768346/59399323-6731f600-8d48-11e9-9269-baa903b92e49.png)

The solution is to explicitly preset twitch tags in tests