### PR TITLE
send proper auth headers to all helix APIs

### DIFF
--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -155,7 +155,7 @@ export class TwitchService extends Service implements IPlatformService {
 
   @requiresToken()
   fetchUserInfo() {
-    const headers = this.getHeaders();
+    const headers = this.getHeaders(true, true);
     const request = new Request(`https://api.twitch.tv/helix/users?id=${this.twitchId}`, {
       headers,
     });
@@ -212,7 +212,7 @@ export class TwitchService extends Service implements IPlatformService {
 
   @requiresToken()
   getAllTags(): Promise<TTwitchTag[]> {
-    return getAllTags(this.getRawHeaders(true));
+    return getAllTags(this.getRawHeaders(true, true));
   }
 
   prepopulateInfo() {


### PR DESCRIPTION
This will ensure we don't get rate limited.