### PR TITLE
add mouse hotkeys support

### DIFF
--- a/app/components/shared/Hotkey.vue
+++ b/app/components/shared/Hotkey.vue
@@ -12,7 +12,8 @@
             type="text"
             class="Hotkey-input"
             :value="getBindingString(binding.binding)"
-            @keydown="e => handleKeydown(e, index)"
+            @keydown="e => handlePress(e, index)"
+            @mousedown="e => handlePress(e, index)"
           />
           <i class="Hotkey-control fa fa-plus" @click="addBinding(index);" />
           <i class="Hotkey-control fa fa-minus" @click="removeBinding(index);" />

--- a/app/components/shared/Hotkey.vue.ts
+++ b/app/components/shared/Hotkey.vue.ts
@@ -148,6 +148,10 @@ export default class HotkeyComponent extends TsxComponent<{ hotkey: IHotkey }> {
     const matchKey = binding.key.match(/^Key([A-Z])$/);
     if (matchKey) key = matchKey[1];
 
+    if (key === 'MiddleMouseButton') key = 'Mouse 3';
+    if (key === 'X1MouseButton') key = 'Mouse 4';
+    if (key === 'X2MouseButton') key = 'Mouse 5';
+
     keys.push(key);
 
     return keys.join('+');

--- a/app/components/shared/Hotkey.vue.ts
+++ b/app/components/shared/Hotkey.vue.ts
@@ -27,22 +27,35 @@ export default class HotkeyComponent extends TsxComponent<{ hotkey: IHotkey }> {
     }
   }
 
-  handleKeydown(event: KeyboardEvent, index: number) {
-    event.preventDefault();
+  handlePress(event: KeyboardEvent | MouseEvent, index: number) {
+    // We don't allow binding left or right click
+    if (event instanceof MouseEvent && (event.button === 0 || event.button === 2)) return;
 
-    if (this.isModifierPress(event)) return;
+    // We don't allow binding a modifier by instelf
+    if (event instanceof KeyboardEvent && this.isModifierPress(event)) return;
+
+    event.preventDefault();
 
     const binding = this.bindings[index];
 
+    const key =
+      event instanceof MouseEvent
+        ? {
+            1: 'MiddleMouseButton',
+            3: 'X1MouseButton',
+            4: 'X2MouseButton',
+          }[event.button]
+        : event.code;
+
     binding.binding = {
-      key: event.code,
+      key,
       modifiers: this.getModifiers(event),
     };
 
     this.setBindings();
   }
 
-  getModifiers(event: KeyboardEvent) {
+  getModifiers(event: KeyboardEvent | MouseEvent) {
     return {
       alt: event.altKey,
       ctrl: event.ctrlKey,


### PR DESCRIPTION
This was a lot easier since we upgraded to electron 5 and `mousedown` event behaves a bit differently.