### PR TITLE
Remove guest api functions for face mask settings

### DIFF
--- a/app/components/pages/Dashboard.vue.ts
+++ b/app/components/pages/Dashboard.vue.ts
@@ -3,7 +3,6 @@ import { Component, Prop } from 'vue-property-decorator';
 import { UserService } from 'services/user';
 import { Inject } from 'services/core/injector';
 import { GuestApiService } from 'services/guest-api';
-import { FacemasksService } from 'services/facemasks';
 import electron from 'electron';
 import { NavigationService, TAppPage } from 'services/navigation';
 
@@ -11,7 +10,6 @@ import { NavigationService, TAppPage } from 'services/navigation';
 export default class Dashboard extends Vue {
   @Inject() userService: UserService;
   @Inject() guestApiService: GuestApiService;
-  @Inject() facemasksService: FacemasksService;
   @Inject() navigationService: NavigationService;
   @Prop() params: Dictionary<string>;
 
@@ -22,12 +20,6 @@ export default class Dashboard extends Vue {
   mounted() {
     this.$refs.dashboard.addEventListener('did-finish-load', () => {
       this.guestApiService.exposeApi(this.$refs.dashboard.getWebContents().id, {
-        testAudio: this.testAudio,
-        getStatus: this.getStatus,
-        getDevices: this.getDevices,
-        enableMask: this.enableMask,
-        updateSettings: this.updateSettings,
-        getDownloadProgress: this.getDownloadProgress,
         navigate: this.navigate,
       });
     });
@@ -43,34 +35,6 @@ export default class Dashboard extends Vue {
 
   get dashboardUrl() {
     return this.userService.dashboardUrl(this.params.subPage || '');
-  }
-
-  async getStatus() {
-    return this.facemasksService.getDeviceStatus();
-  }
-
-  async getDevices() {
-    return this.facemasksService.getInputDevicesList();
-  }
-
-  async enabledDevice() {
-    return this.facemasksService.getEnabledDevice();
-  }
-
-  async enableMask(uuid: string) {
-    return this.facemasksService.enableMask(uuid);
-  }
-
-  async updateSettings() {
-    return this.facemasksService.startup();
-  }
-
-  async getDownloadProgress() {
-    return this.facemasksService.getDownloadProgress();
-  }
-
-  async testAudio(volume: number) {
-    return;
   }
 
   async navigate(page: TAppPage) {

--- a/app/services/facemasks/index.ts
+++ b/app/services/facemasks/index.ts
@@ -468,23 +468,6 @@ export class FacemasksService extends PersistentStatefulService<Interfaces.IFace
     this.SET_DOWNLOAD_PROGRESS(progress);
   }
 
-  // Redundant function to be deleted once legacy settings page is sunsetted
-  getDownloadProgress() {
-    if (!this.state.settings.enabled) {
-      return 'Not Enabled';
-    }
-
-    let current = 0;
-    Object.keys(this.downloadProgress).forEach(key => {
-      current += this.downloadProgress[key];
-    });
-
-    if (current / Object.keys(this.downloadProgress).length === 1) {
-      return this.state.active ? 'Ready' : 'Loading';
-    }
-    return `${((current / Object.keys(this.downloadProgress).length) * 100).toFixed(2)}%`;
-  }
-
   getEnabledDevice() {
     return this.state.settings.device;
   }


### PR DESCRIPTION
Now that face mask settings are integrated into slobs natively and there is no dashboard settings page, the guest api functions exposed to the legacy settings page are no longer necessary.