### PR TITLE
Fix mask duration for test menu

### DIFF
--- a/app/components/windows/FacemaskSettings.vue.ts
+++ b/app/components/windows/FacemaskSettings.vue.ts
@@ -146,7 +146,7 @@ export default class FacemaskSettings extends Vue {
   }
 
   clickMask(mask: IFacemaskSelection) {
-    this.facemasksService.trigger(mask.uuid, this.facemasksService.state.settings.sub_duration);
+    this.facemasksService.playMask(mask.uuid);
   }
 
   onFailHandler(msg: string) {


### PR DESCRIPTION
Newly expanded menu that allows users to test all face masks was incorrectly using sub duration instead of proper duration value