### PR TITLE
Add performance service to external api

### DIFF
--- a/app/services/api/external-api/performance/index.ts
+++ b/app/services/api/external-api/performance/index.ts
@@ -1,0 +1,1 @@
+export * from './performance';

--- a/app/services/api/external-api/performance/performance.ts
+++ b/app/services/api/external-api/performance/performance.ts
@@ -1,0 +1,31 @@
+import { Singleton, Fallback } from 'services/api/external-api';
+import { Inject } from 'services/core/injector';
+import { PerformanceService as InternalPerformanceService } from 'services/performance';
+
+interface IPerformanceState {
+  CPU: number;
+  numberDroppedFrames: number;
+  percentageDroppedFrames: number;
+  bandwidth: number;
+  frameRate: number;
+}
+
+/**
+ * Api for performance monitoring
+ */
+@Singleton()
+export class PerformanceService {
+  @Fallback()
+  @Inject()
+  private performanceService: InternalPerformanceService;
+
+  getModel(): IPerformanceState {
+    return {
+      CPU: this.performanceService.state.CPU,
+      bandwidth: this.performanceService.state.bandwidth,
+      frameRate: this.performanceService.state.frameRate,
+      numberDroppedFrames: this.performanceService.state.numberDroppedFrames,
+      percentageDroppedFrames: this.performanceService.state.percentageDroppedFrames,
+    };
+  }
+}

--- a/app/services/api/external-api/resources.ts
+++ b/app/services/api/external-api/resources.ts
@@ -9,3 +9,4 @@ export * from './streaming';
 export * from './scene-collections';
 export * from './audio';
 export * from './notifications';
+export * from './performance';


### PR DESCRIPTION
This simply wraps services/performance and gives external apps access to live CPU usage, framerate, dropped frames, etc.

This was inspired from the implementation of `services/api/external-api/scenes/scenes.ts`.

**I am fairly new to typescript and Node, so please do review carefully what I propose here.** I tested the API using https://stream-labs.github.io/streamlabs-obs-api-docs/ and it works. I also ran a private YouTube stream without issue.