### PR TITLE
Prevent announcement banner for new users under 1 week

### DIFF
--- a/app/services/announcements.ts
+++ b/app/services/announcements.ts
@@ -60,7 +60,7 @@ export class AnnouncementsService extends StatefulService<IAnnouncementsInfo> {
   }
 
   underOneWeek() {
-    return (Date.now() - this.activationTimestamp) / (1000 * 60 * 60 * 24 * 7) < 1;
+    return Date.now() - this.activationTimestamp < 1000 * 60 * 60 * 24 * 7;
   }
 
   private async fetchBanner() {

--- a/app/services/announcements.ts
+++ b/app/services/announcements.ts
@@ -53,8 +53,18 @@ export class AnnouncementsService extends StatefulService<IAnnouncementsInfo> {
     return path.join(this.appService.appDataDirectory, 'log.log');
   }
 
+  private async fileExists(path: string): Promise<boolean> {
+    return new Promise<boolean>(resolve => {
+      fs.exists(path, exists => {
+        resolve(exists);
+      });
+    });
+  }
+
   private async getInstallDateTimestamp(): Promise<number> {
-    if (!fs.existsSync(this.installDateProxyFilePath)) {
+    const exists = await this.fileExists(this.installDateProxyFilePath);
+
+    if (!exists) {
       return Promise.resolve(Date.now());
     }
 

--- a/app/services/announcements.ts
+++ b/app/services/announcements.ts
@@ -32,6 +32,8 @@ export class AnnouncementsService extends StatefulService<IAnnouncementsInfo> {
     closeOnLink: false,
   };
 
+  localStorageKey = 'FirstActivationTimestamp';
+
   async updateBanner() {
     const newBanner = await this.fetchBanner();
     this.SET_BANNER(newBanner);
@@ -45,8 +47,24 @@ export class AnnouncementsService extends StatefulService<IAnnouncementsInfo> {
     await this.postBannerClose();
   }
 
+  get activationTimestamp(): number {
+    if (localStorage.getItem(this.localStorageKey)) {
+      return parseInt(localStorage.getItem(this.localStorageKey), 10);
+    }
+    this.activationTimestamp = Date.now();
+    return this.activationTimestamp;
+  }
+
+  set activationTimestamp(timestamp: number) {
+    localStorage.setItem(this.localStorageKey, timestamp.toString());
+  }
+
+  underOneWeek() {
+    return (Date.now() - this.activationTimestamp) / (1000 * 60 * 60 * 24 * 7) < 1;
+  }
+
   private async fetchBanner() {
-    if (!this.userService.isLoggedIn()) return this.state;
+    if (!this.userService.isLoggedIn() || this.underOneWeek()) return this.state;
     const endpoint = `api/v5/slobs/announcement/get?clientId=${this.userService.getLocalUserId()}`;
     const req = this.formRequest(endpoint);
     try {


### PR DESCRIPTION
The timestamp stored for firstActivationTimestamp won't be set until announcements service updateBanner method is run. This means that the value may not exactly match the install day. In my testing, it seems like announcement service is only called if SLOBS is opened while already logged in. I could look at setting this value in another service which would guarantee it is written on first activation after installing.

This is meant to be the most simple solution, happy to discuss ways of improving it.
