### PR TITLE
store base resolution in scene collections and auto switch

### DIFF
--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -3,8 +3,14 @@ import { SourcesNode } from './sources';
 import { ScenesNode } from './scenes';
 import { TransitionsNode } from './transitions';
 import { HotkeysNode } from './hotkeys';
+import { Inject } from 'services/core';
+import { VideoService } from 'services/video';
 
 interface ISchema {
+  baseResolution: {
+    width: number;
+    height: number;
+  };
   sources: SourcesNode;
   scenes: ScenesNode;
   hotkeys?: HotkeysNode;
@@ -13,7 +19,9 @@ interface ISchema {
 
 // This is the root node of the config file
 export class RootNode extends Node<ISchema, {}> {
-  schemaVersion = 2;
+  schemaVersion = 3;
+
+  @Inject() videoService: VideoService;
 
   async save(): Promise<void> {
     const sources = new SourcesNode();
@@ -31,10 +39,13 @@ export class RootNode extends Node<ISchema, {}> {
       scenes,
       transitions,
       hotkeys,
+      baseResolution: this.videoService.baseResolution,
     };
   }
 
   async load(): Promise<void> {
+    this.videoService.setBaseResolution(this.data.baseResolution);
+
     await this.data.transitions.load();
     await this.data.sources.load({});
     await this.data.scenes.load({});
@@ -47,6 +58,8 @@ export class RootNode extends Node<ISchema, {}> {
   migrate(version: number) {
     if (version === 1) {
       this.data.transitions = this.data['transition'];
+    } else if (version === 2) {
+      this.data.baseResolution = this.videoService.baseResolution;
     }
   }
 }

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -56,7 +56,7 @@ export class RootNode extends Node<ISchema, {}> {
   }
 
   migrate(version: number) {
-    // Added transitions node in version 2
+    // Changed name of transition node in version 2
     if (version < 2) {
       this.data.transitions = this.data['transition'];
     }

--- a/app/services/scene-collections/nodes/root.ts
+++ b/app/services/scene-collections/nodes/root.ts
@@ -56,9 +56,13 @@ export class RootNode extends Node<ISchema, {}> {
   }
 
   migrate(version: number) {
-    if (version === 1) {
+    // Added transitions node in version 2
+    if (version < 2) {
       this.data.transitions = this.data['transition'];
-    } else if (version === 2) {
+    }
+
+    // Added baseResolution in version 3
+    if (version < 3) {
       this.data.baseResolution = this.videoService.baseResolution;
     }
   }

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -232,6 +232,14 @@ export class VideoService extends Service {
     };
   }
 
+  setBaseResolution(resolution: { width: number; height: number }) {
+    this.settingsService.setSettingValue(
+      'Video',
+      'Base',
+      `${resolution.width}x${resolution.height}`,
+    );
+  }
+
   /**
    * @warning DO NOT USE THIS METHOD. Use the Display class instead
    */


### PR DESCRIPTION
We honestly should have had this since the beginning when we added cloud backup.  This prevents weirdness when restoring a backup from a machine that had a different monitor resolution.