### PR TITLE
Fix source releasing on shutdown

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -189,21 +189,20 @@ export class AppService extends StatefulService<IAppState> {
   }
 
   @track('app_close')
-  private shutdownHandler() {
+  private async shutdownHandler() {
     this.START_LOADING();
     obs.NodeObs.StopCrashHandler();
-
     this.crashReporterService.beginShutdown();
 
-    this.ipcServerService.stopListening();
-    this.tcpServerService.stopListening();
-
     window.setTimeout(async () => {
+      this.windowsService.closeChildWindow();
+      await this.windowsService.closeAllOneOffs();
+      this.ipcServerService.stopListening();
+      this.tcpServerService.stopListening();
       await this.userService.flushUserSession();
       await this.sceneCollectionsService.deinitialize();
       this.performanceMonitorService.stop();
       this.transitionsService.shutdown();
-      this.windowsService.closeAllOneOffs();
       await this.gameOverlayService.destroy();
       await this.fileManagerService.flushAll();
       obs.NodeObs.RemoveSourceCallback();

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -189,7 +189,7 @@ export class AppService extends StatefulService<IAppState> {
   }
 
   @track('app_close')
-  private async shutdownHandler() {
+  private shutdownHandler() {
     this.START_LOADING();
     obs.NodeObs.StopCrashHandler();
     this.crashReporterService.beginShutdown();

--- a/main.js
+++ b/main.js
@@ -199,7 +199,6 @@ if (!gotTheLock) {
     mainWindow.on('close', e => {
       if (!shutdownStarted) {
         shutdownStarted = true;
-        childWindow.destroy();
         mainWindow.send('shutdown');
 
         // We give the main window 10 seconds to acknowledge a request

--- a/main.js
+++ b/main.js
@@ -408,7 +408,7 @@ if (!gotTheLock) {
 
   ipcMain.on('window-closeChildWindow', (event) => {
     // never close the child window, hide it instead
-    childWindow.hide();
+    if (!childWindow.isDestroyed()) childWindow.hide();
   });
 
 


### PR DESCRIPTION
Destroying the child on the shutdown window didn't release the projector's source in the OSN. Closing the child window before shutdown resolves this issue. 