### PR TITLE
fix editor/live resizing jank when window is resized

### DIFF
--- a/app/components/pages/Live.vue.ts
+++ b/app/components/pages/Live.vue.ts
@@ -36,6 +36,26 @@ export default class Live extends Vue {
   enablePreviewTooltip = $t('Enable the preview stream');
   disablePreviewTooltip = $t('Disable the preview stream, can help with CPU');
 
+  maxHeight: number = null;
+
+  mounted() {
+    this.handleWindowResize();
+
+    window.addEventListener('resize', this.handleWindowResize);
+  }
+
+  destroyed() {
+    window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  handleWindowResize() {
+    this.maxHeight = this.$root.$el.getBoundingClientRect().height - 400;
+
+    const clampedHeight = Math.min(this.height, this.maxHeight);
+
+    if (clampedHeight !== this.height) this.height = clampedHeight;
+  }
+
   onBrowserViewReady(view: Electron.BrowserView) {
     electron.ipcRenderer.send('webContents-preventPopup', view.webContents.id);
 
@@ -89,12 +109,6 @@ export default class Live extends Vue {
   get displayWidth() {
     // 29 pixels is roughly the size of the title control label
     return (16 / 9) * (this.height - 29);
-  }
-
-  get maxHeight() {
-    // Roughly 400 pixels below the top is a good top limit for
-    // resizing. It allows plenty of room for the title bar and header.
-    return this.$root.$el.getBoundingClientRect().height - 400;
   }
 
   get minHeight() {

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -31,7 +31,13 @@ export default class Studio extends Vue {
 
   sizeCheckInterval: number;
 
+  maxHeight: number = null;
+
   mounted() {
+    this.handleWindowResize();
+
+    window.addEventListener('resize', this.handleWindowResize);
+
     this.sizeCheckInterval = window.setInterval(() => {
       if (this.studioMode && this.$refs.studioModeContainer) {
         const { clientWidth, clientHeight } = this.$refs.studioModeContainer;
@@ -47,6 +53,16 @@ export default class Studio extends Vue {
 
   destroyed() {
     clearInterval(this.sizeCheckInterval);
+
+    window.removeEventListener('resize', this.handleWindowResize);
+  }
+
+  handleWindowResize() {
+    this.maxHeight = this.$root.$el.getBoundingClientRect().height - 400;
+
+    const clampedHeight = Math.min(this.height, this.maxHeight);
+
+    if (clampedHeight !== this.height) this.height = clampedHeight;
   }
 
   get displayEnabled() {
@@ -75,10 +91,6 @@ export default class Studio extends Vue {
 
   set height(value) {
     this.customizationService.setSettings({ bottomdockSize: value });
-  }
-
-  get maxHeight() {
-    return this.$root.$el.getBoundingClientRect().height - 400;
   }
 
   get minHeight() {


### PR DESCRIPTION
Decided not to DRY it up because Live tab is being combined with Editor tab in the near future.