### PR TITLE
Fix store sync

### DIFF
--- a/app/services/api/jsonrpc/jsonrpc-api.ts
+++ b/app/services/api/jsonrpc/jsonrpc-api.ts
@@ -44,6 +44,7 @@ export interface IJsonRpcEvent {
 }
 
 export interface IMutation {
+  id: number;
   type: string;
   payload: any;
 }

--- a/app/services/widgets/settings/widget-settings.ts
+++ b/app/services/widgets/settings/widget-settings.ts
@@ -180,6 +180,7 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
 
   @mutation()
   protected SET_PENDING_REQUESTS(pendingRequestsCnt: number) {
+    console.log('SET_PENDING_REQUESTS', pendingRequestsCnt);
     this.state.pendingRequests = pendingRequestsCnt;
   }
 

--- a/app/services/widgets/settings/widget-settings.ts
+++ b/app/services/widgets/settings/widget-settings.ts
@@ -180,7 +180,6 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
 
   @mutation()
   protected SET_PENDING_REQUESTS(pendingRequestsCnt: number) {
-    console.log('SET_PENDING_REQUESTS', pendingRequestsCnt);
     this.state.pendingRequests = pendingRequestsCnt;
   }
 

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -28,6 +28,7 @@ const actions = {};
 
 const plugins: any[] = [];
 
+let mutationId = 1;
 let makeStoreReady: Function;
 let storeCanReceiveMutations = Util.isMainWindow();
 
@@ -42,6 +43,7 @@ plugins.push((store: Store<any>) => {
     const internalApiService: InternalApiService = InternalApiService.instance;
     if (mutation.payload && !mutation.payload.__vuexSyncIgnore) {
       const mutationToSend: IMutation = {
+        id: mutationId++,
         type: mutation.type,
         payload: mutation.payload,
       };

--- a/test/helpers/widget-helpers.ts
+++ b/test/helpers/widget-helpers.ts
@@ -5,7 +5,7 @@ import { SourcesService } from '../../app/services/sources';
 import { getClient } from './api-client';
 
 export async function waitForWidgetSettingsSync(t: TExecutionContext) {
-  await sleep(1000);
+  await sleep(2000);
   await t.context.app.client.waitForVisible('.saving-indicator', 15000, true);
 }
 

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -3,7 +3,6 @@ import { logIn, logOut } from '../../../helpers/spectron/user';
 import { makeScreenshots, useScreentest } from '../../screenshoter';
 import { FormMonkey } from '../../../helpers/form-monkey';
 import { addWidget, EWidgetType, waitForWidgetSettingsSync } from '../../../helpers/widget-helpers';
-import moment = require('moment');
 
 useSpectron({ appArgs: '--nosync', restartAppAfterEachTest: false });
 useScreentest();

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -27,18 +27,21 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
 
     await makeScreenshots(t, 'Empty Form');
 
-    // set the date to tomorrow
-    const today = new Date();
-    const tomorrow = new Date();
-    tomorrow.setDate(today.getDate() + 1);
-
     const formMonkey = new FormMonkey(t, 'form[name=new-goal-form]');
     await formMonkey.fill({
       title: 'My Goal',
       goal_amount: 100,
       manual_goal_amount: 0,
-      ends_at: moment(tomorrow).format('MM/DD/YYYY'),
+      ends_at: '12/12/2030',
     });
+
+    // because of a different latency of api.streamlabs.com
+    // we may see a different date after goal creation
+    // for example `1 day` or `23 hours`
+    // just disable displaying ends_at field to make screenshots consistent
+    await t.context.app.webContents.executeJavaScript(`
+      $('.goal-row:nth-child(4) span:nth-child(2)').innerText = '2 days to go';
+    `);
 
     await makeScreenshots(t, 'Filled Form');
 

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -3,6 +3,7 @@ import { logIn, logOut } from '../../../helpers/spectron/user';
 import { makeScreenshots, useScreentest } from '../../screenshoter';
 import { FormMonkey } from '../../../helpers/form-monkey';
 import { addWidget, EWidgetType, waitForWidgetSettingsSync } from '../../../helpers/widget-helpers';
+import moment = require('moment');
 
 useSpectron({ appArgs: '--nosync', restartAppAfterEachTest: false });
 useScreentest();
@@ -26,12 +27,17 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
 
     await makeScreenshots(t, 'Empty Form');
 
+    // set the date to tomorrow
+    const today = new Date();
+    const tomorrow = new Date();
+    tomorrow.setDate(today.getDate() + 1);
+
     const formMonkey = new FormMonkey(t, 'form[name=new-goal-form]');
     await formMonkey.fill({
       title: 'My Goal',
       goal_amount: 100,
       manual_goal_amount: 0,
-      ends_at: '12/12/2030',
+      ends_at: moment(tomorrow).format('MM/DD/YYYY'),
     });
 
     await makeScreenshots(t, 'Filled Form');
@@ -62,7 +68,7 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
       bar_bg_color: '#FF0000',
       text_color: '#FF0000',
       bar_text_color: '#FF0000',
-      font: 'Roboto'
+      font: 'Roboto',
     };
     await formMonkey.fill(testSet);
     await waitForWidgetSettingsSync(t);

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -35,6 +35,12 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
       ends_at: '12/12/2030',
     });
 
+    await makeScreenshots(t, 'Filled Form');
+
+    await client.click('button=Start Goal');
+    await client.waitForVisible('button=End Goal');
+    t.true(await client.isExisting('span=My Goal'));
+
     // because of a different latency of api.streamlabs.com
     // we may see a different date after goal creation
     // for example `1 day` or `23 hours`
@@ -42,14 +48,8 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
     await t.context.app.webContents.executeJavaScript(`
       $('.goal-row:nth-child(4) span:nth-child(2)').innerText = '2 days to go';
     `);
-
-    await makeScreenshots(t, 'Filled Form');
-
-    await client.click('button=Start Goal');
-    await client.waitForVisible('button=End Goal');
-    t.true(await client.isExisting('span=My Goal'));
-
     await makeScreenshots(t, 'Created Goal');
+
     await closeWindow(t);
     await logOut(t);
   });

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -46,7 +46,7 @@ function testGoal(goalType: string, widgetType: EWidgetType) {
     // for example `1 day` or `23 hours`
     // just disable displaying ends_at field to make screenshots consistent
     await t.context.app.webContents.executeJavaScript(`
-      $('.goal-row:nth-child(4) span:nth-child(2)').innerText = '2 days to go';
+      document.querySelector('.goal-row:nth-child(4) span:nth-child(2)').innerText = '2 days to go';
     `);
     await makeScreenshots(t, 'Created Goal');
 


### PR DESCRIPTION
Looking on inconsistent goals screentests I found that it's possible to get in the situation where the Main and Child window has a different state. I found a flaw in the mutation skipping mechanism. 

![image](https://user-images.githubusercontent.com/3768346/62808724-c17fd680-baad-11e9-96f9-a25be8e64216.png)
