### PR TITLE
move notifications tooltips to the right

### DIFF
--- a/app/components/NotificationsArea.vue
+++ b/app/components/NotificationsArea.vue
@@ -3,7 +3,7 @@
   <div
     class="notifications__counter notifications__counter--warning"
     v-if="unreadCount"
-    v-tooltip="showUnreadNotificationsTooltip"
+    v-tooltip.right="showUnreadNotificationsTooltip"
     @click="showNotifications">
     <span class="fa fa-exclamation-triangle"></span>
     {{ unreadCount }}
@@ -13,7 +13,7 @@
     class="notifications__counter"
     v-if="!unreadCount"
     @click="showNotifications"
-    v-tooltip="showNotificationsTooltip">
+    v-tooltip.right="showNotificationsTooltip">
     <span class="icon-information"></span>
   </div>
 


### PR DESCRIPTION
Prevents browser views from blocking the tooltip.