### PR TITLE
Refactor youtube service

### DIFF
--- a/app/components/StudioFooter.vue.ts
+++ b/app/components/StudioFooter.vue.ts
@@ -91,7 +91,7 @@ export default class StudioFooterComponent extends Vue {
       const platform = this.userService.platform.type;
       const service = getPlatformService(platform);
       if (service instanceof YoutubeService) {
-        service.verifyAbleToStream();
+        service.prepopulateInfo();
       }
     }
   }

--- a/app/services/platforms/index.ts
+++ b/app/services/platforms/index.ts
@@ -108,10 +108,6 @@ export interface IPlatformService {
 
   fetchViewerCount: () => Promise<number>;
 
-  fetchStreamKey: () => Promise<string>;
-
-  fetchChannelInfo: () => Promise<IChannelInfo>;
-
   fetchUserInfo: () => Promise<IUserInfo>;
 
   putChannelInfo: (channelInfo: IChannelInfo) => Promise<boolean>;
@@ -124,7 +120,7 @@ export interface IPlatformService {
 
   afterGoLive?: (context?: StreamingContext) => Promise<void>;
 
-  prepopulateInfo: () => Promise<any>;
+  prepopulateInfo: () => Promise<IChannelInfo>;
 
   scheduleStream?: (startTime: string, info: IChannelInfo) => Promise<any>;
 

--- a/app/services/stream-info.ts
+++ b/app/services/stream-info.ts
@@ -16,11 +16,6 @@ interface IStreamInfoServiceState {
   channelInfo: IChannelInfo;
 }
 
-interface IStreamInfo {
-  viewerCount: number;
-  channelInfo: IChannelInfo;
-}
-
 const VIEWER_COUNT_UPDATE_INTERVAL = 60 * 1000;
 
 /**
@@ -44,7 +39,7 @@ export class StreamInfoService extends StatefulService<IStreamInfoServiceState> 
 
   init() {
     this.RESET();
-    this.refreshStreamInfo().catch(e => null);
+    this.userService.userLogin.subscribe(_ => this.refreshStreamInfo().catch(e => null));
     this.userService.userLogout.subscribe(_ => this.RESET());
 
     this.viewerCountInterval = window.setInterval(() => {
@@ -72,8 +67,7 @@ export class StreamInfoService extends StatefulService<IStreamInfoServiceState> 
 
     const platform = getPlatformService(this.userService.platform.type);
     try {
-      await platform.prepopulateInfo();
-      const info = await platform.fetchChannelInfo();
+      const info = await platform.prepopulateInfo();
       this.SET_CHANNEL_INFO(info);
 
       if (this.userService.platform.type === 'twitch') {

--- a/test/streaming.js
+++ b/test/streaming.js
@@ -205,11 +205,8 @@ schedulingPlatforms.forEach(platform => {
       date: moment(tomorrow).format('MM/DD/YYYY')
     });
 
-    // TODO: youtube always returns an error: User requests exceed the rate limit
-    if (platform !== 'youtube') {
-      await app.client.click('button=Schedule');
-      await app.client.waitForVisible('.toast-success', 20000);
-    }
+    await app.client.click('button=Schedule');
+    await app.client.waitForVisible('.toast-success', 20000);
 
   });
 });


### PR DESCRIPTION
Streaming to youtube was always very flaky to me if I authorized SLOBS via youtube. However, everything was fine if I just manually insert the stream key in the settings window.  I investigated youtube API and realized we do some things wrong. As a result:
- we can populate and change channel info only if the stream is in the active state
- sometimes we cache incorrect streamId and fetch an incorrect steamKey. As result, nobody can see the stream on youtube
- we do a redundant amount of API calls. In some tests I tried to write for youtube I saw a message that requests limit is exceeded
- the stream scheduling feature created multiple events in the Youtube channel and didn't connect these events with a real stream when it began. 