### PR TITLE
Fix focus bug when deleting a scene collection

### DIFF
--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -4,6 +4,7 @@ import { SceneCollectionsService } from 'services/scene-collections';
 import { Inject } from 'services/core/injector';
 import moment from 'moment';
 import { $t } from 'services/i18n';
+import electron from 'electron';
 
 @Component({})
 export default class EditableSceneCollection extends Vue {
@@ -85,15 +86,17 @@ export default class EditableSceneCollection extends Vue {
   }
 
   remove() {
-    if (
-      !confirm(
-        $t('Are you sure you want to remove %{collectionName}?', {
-          collectionName: this.collection.name,
-        }),
-      )
-    ) {
-      return;
+    const ok = electron.remote.dialog.showMessageBox(electron.remote.getCurrentWindow(), {
+      type: 'warning',
+      message: $t('Are you sure you want to remove %{collectionName}?', {
+        collectionName: this.collection.name,
+      }),
+      buttons: [$t('Cancel'), $t('OK')],
+      noLink: true,
+    });
+
+    if (ok) {
+      this.sceneCollectionsService.delete(this.collectionId);
     }
-    this.sceneCollectionsService.delete(this.collectionId);
   }
 }

--- a/app/components/EditableSceneCollection.vue.ts
+++ b/app/components/EditableSceneCollection.vue.ts
@@ -86,17 +86,21 @@ export default class EditableSceneCollection extends Vue {
   }
 
   remove() {
-    const ok = electron.remote.dialog.showMessageBox(electron.remote.getCurrentWindow(), {
-      type: 'warning',
-      message: $t('Are you sure you want to remove %{collectionName}?', {
-        collectionName: this.collection.name,
-      }),
-      buttons: [$t('Cancel'), $t('OK')],
-      noLink: true,
-    });
-
-    if (ok) {
-      this.sceneCollectionsService.delete(this.collectionId);
-    }
+    electron.remote.dialog.showMessageBox(
+      electron.remote.getCurrentWindow(),
+      {
+        type: 'warning',
+        message: $t('Are you sure you want to remove %{collectionName}?', {
+          collectionName: this.collection.name,
+        }),
+        buttons: [$t('Cancel'), $t('OK')],
+        noLink: true,
+      },
+      index => {
+        if (index === 1) {
+          this.sceneCollectionsService.delete(this.collectionId);
+        }
+      },
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Streamlabs streaming software",
   "author": "General Workings, Inc.",
   "license": "GPL-3.0",
-  "version": "0.17.0-preview.11",
+  "version": "0.17.0-preview.12",
   "main": "main.js",
   "engines": {
     "node": ">= 10 < 12",


### PR DESCRIPTION
Using `confirm` method caused strange focus behavior in the manage scene collections window. Using an electron dialog seems to solve this issue.