### PR TITLE
Fix app icon saving to desktop

### DIFF
--- a/app/components/AppsNav.m.less
+++ b/app/components/AppsNav.m.less
@@ -31,14 +31,16 @@
   overflow: hidden;
 
   i,
-  img {
+  img,
+  div {
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
   }
 
-  img {
+  img,
+  div {
     width: 40px;
     height: 40px;
   }

--- a/app/components/AppsNav.tsx
+++ b/app/components/AppsNav.tsx
@@ -126,10 +126,11 @@ export default class AppsNav extends Vue {
                 draggable
                 // funky casing since vue is dumb
                 onDragend={() => this.popOut(app)}
-                class={cx(styles.appTab)}
+                class={styles.appTab}
               >
                 <i class="icon-integrations" />
                 {app.manifest.icon && <img src={this.iconSrc(app.id, app.manifest.icon)} />}
+                <div />
               </div>
               {this.refreshIcon(h, app)}
             </div>


### PR DESCRIPTION
Default chrome behavior when dragging an image file to the desktop, so just added an empty div over it