### PR TITLE
Fix go-live button in case of error

### DIFF
--- a/app/components/windows/EditStreamInfo.vue.ts
+++ b/app/components/windows/EditStreamInfo.vue.ts
@@ -259,6 +259,11 @@ export default class EditStreamInfo extends Vue {
   }
 
   async handleSubmit() {
+    if (this.infoError || this.updateError) {
+      await this.goLive();
+      return;
+    }
+
     if (await this.$refs.form.validateAndGetErrorsCount()) return;
     if (this.isSchedule) return this.scheduleStream();
     this.updateAndGoLive();
@@ -323,6 +328,7 @@ export default class EditStreamInfo extends Vue {
     if (this.midStreamMode) return $t('Update');
     if (this.isSchedule) return $t('Schedule');
 
+    if (this.infoError || this.updateError) return $t('Go Live');
     return $t('Confirm & Go Live');
   }
 


### PR DESCRIPTION
Fix a sentry error
When a user has an error while updating EditStreamIfno, the `Confirm & Go Live` button should work as `Just Go Live` button