### PR TITLE
fix zombie processes due to electron 6 browser view changes

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -33,6 +33,7 @@ import { GameOverlayService } from 'services/game-overlay';
 import { RunInLoadingMode } from './app-decorators';
 import { CustomizationService } from 'services/customization';
 import Utils from 'services/utils';
+import { Subject } from 'rxjs';
 
 interface IAppState {
   loading: boolean;
@@ -144,6 +145,8 @@ export class AppService extends StatefulService<IAppState> {
     await this.gameOverlayService.initialize();
   }
 
+  shutdownStarted = new Subject();
+
   @track('app_close')
   private shutdownHandler() {
     this.START_LOADING();
@@ -151,6 +154,8 @@ export class AppService extends StatefulService<IAppState> {
     this.crashReporterService.beginShutdown();
 
     window.setTimeout(async () => {
+      this.shutdownStarted.next();
+      this.platformAppsService.unloadAllApps();
       this.windowsService.closeChildWindow();
       await this.windowsService.closeAllOneOffs();
       this.ipcServerService.stopListening();


### PR DESCRIPTION
Since upgrading to electron 6, we have discovered that any browser views that are running while the app quits will be left as zombie processes.  We are working around this by destroying all browser views during the shutdown procedure.