### PR TITLE
Fix selection service

### DIFF
--- a/app/services/api/external-api/scenes/selection.ts
+++ b/app/services/api/external-api/scenes/selection.ts
@@ -30,12 +30,15 @@ export class Selection implements ISceneItemActions {
   @InjectFromExternalApi() private scenesService: ScenesService;
   @Fallback() private internalSelection: InternalSelection;
 
-  constructor(public sceneId?: string, itemsList: string[] = []) {
-    if (!this.sceneId) return;
+  constructor(sceneId: string, itemsList: string[] = []) {
     this.internalSelection = new InternalSelection(sceneId, itemsList);
   }
 
-  get selection(): InternalSelection | InternalSelectionService {
+  get sceneId() {
+    return this.internalSelection.sceneId;
+  }
+
+  protected get selection(): InternalSelection | InternalSelectionService {
     return this.internalSelection;
   }
 

--- a/app/services/api/external-api/selection/selection.ts
+++ b/app/services/api/external-api/selection/selection.ts
@@ -13,7 +13,11 @@ export class SelectionService extends Selection {
   @Inject('SelectionService')
   private internalSelectionService: InternalSelectionService;
 
-  get selection() {
+  get sceneId() {
+    return this.internalSelectionService.sceneId;
+  }
+
+  protected get selection() {
     return this.internalSelectionService;
   }
 }

--- a/app/services/selection/index.ts
+++ b/app/services/selection/index.ts
@@ -44,7 +44,7 @@ export class SelectionService extends StatefulService<ISelectionState> {
 
   updated = new Subject<ISelectionState>();
 
-  private get sceneId() {
+  get sceneId() {
     return this.scenesService.activeSceneId;
   }
 

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -127,11 +127,8 @@ export class Selection {
    * true if selections has only one folder
    */
   isSceneFolder(): boolean {
-    const folders = this.getFolders();
-    if (folders.length !== 1) return false;
-    const folder = folders[0];
-    const isNotFolderChild = this.getItems().find(item => item.parentId !== folder.id);
-    return !isNotFolderChild;
+    const rootNodes = this.getRootNodes();
+    return rootNodes.length === 1 && rootNodes[0].sceneNodeType === 'folder';
   }
 
   getVisualItems(): SceneItem[] {

--- a/test/api/selection.ts
+++ b/test/api/selection.ts
@@ -291,9 +291,7 @@ test('isSceneFolder', async t => {
   `);
 
   selectionService.selectAll();
-
   t.false(selectionService.isSceneFolder());
-  t.pass();
 
   selectionService.select([getNodeId('Folder1')]);
   t.true(selectionService.isSceneFolder());

--- a/test/api/selection.ts
+++ b/test/api/selection.ts
@@ -221,6 +221,9 @@ test('Scale', async t => {
       Item2: color_source
   `);
 
+  // TODO: find a reason why this test fails without `sleep` here
+  await sleep(1000);
+
   selectionService.select([getNodeId('Item1'), getNodeId('Item2')]);
   const item1 = scene.getItem(getNodeId('Item1'));
   const item2 = scene.getItem(getNodeId('Item2'));

--- a/test/api/selection.ts
+++ b/test/api/selection.ts
@@ -221,9 +221,6 @@ test('Scale', async t => {
       Item2: color_source
   `);
 
-  // TODO: find a reason why this test fails without `sleep` here
-  await sleep(1000);
-
   selectionService.select([getNodeId('Item1'), getNodeId('Item2')]);
   const item1 = scene.getItem(getNodeId('Item1'));
   const item2 = scene.getItem(getNodeId('Item2'));
@@ -283,4 +280,30 @@ test('Scale', async t => {
     y: 0.25
   });
 
+});
+
+test('isSceneFolder', async t => {
+  sceneBuilder.build(`
+    Folder1
+    Folder2
+      Folder3
+        Item3:
+  `);
+
+  selectionService.selectAll();
+
+  t.false(selectionService.isSceneFolder());
+  t.pass();
+
+  selectionService.select([getNodeId('Folder1')]);
+  t.true(selectionService.isSceneFolder());
+
+  selectionService.select([getNodeId('Folder2')]);
+  t.true(selectionService.isSceneFolder());
+
+  selectionService.select([getNodeId('Folder3')]);
+  t.true(selectionService.isSceneFolder());
+
+  selectionService.select([getNodeId('Item3')]);
+  t.false(selectionService.isSceneFolder());
 });


### PR DESCRIPTION
Fix the bug when it's not possible to rename a folder if it contains nested folders.
Add tests for the `isSceneFolder` API method