### PR TITLE
Don't clear the cache after language change

### DIFF
--- a/app/services/i18n/i18n.ts
+++ b/app/services/i18n/i18n.ts
@@ -153,7 +153,7 @@ export class I18nService extends PersistentStatefulService<II18nState> implement
 
   setLocale(locale: string) {
     this.SET_LOCALE(locale);
-    electron.remote.app.relaunch();
+    electron.remote.app.relaunch({ args: [] });
     electron.remote.app.quit();
   }
 


### PR DESCRIPTION
QA:
> When clicking on "Delete Cache and Restart" then run the onboarding or skip it (doesn't matter) during the same session and then changing the language will reset cache again upon restart.