### PR TITLE
Various fixes for recent events

### DIFF
--- a/app/components/RecentEvents.tsx
+++ b/app/components/RecentEvents.tsx
@@ -139,7 +139,7 @@ export default class RecentEvents extends TsxComponent<{}> {
         {!!this.recentEvents.length &&
           this.recentEvents.map(event => (
             <EventCell
-              key={event.hash}
+              key={event.uuid}
               event={event}
               repeatAlert={this.repeatAlert.bind(this)}
               eventString={this.eventString.bind(this)}

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -102,13 +102,13 @@ function getHashForRecentEvent(event: IRecentEvent) {
       return [event.type, event.name, event.message, parseInt(event.amount, 10)].join(':');
     case 'treat':
       return [event.type, event.name, event.title, event.message, event.createdAt].join(':');
-    case 'facebook_like':
+    case 'like':
       return [event.type, event.name, event._id].join(':');
-    case 'facebook_share':
+    case 'share':
       return [event.type, event.name, event._id].join(':');
-    case 'facebook_stars':
+    case 'stars':
       return [event.type, event.name, event.message, parseInt(event.amount, 10)].join(':');
-    case 'facebook_support':
+    case 'support':
       return [event.type, event.name, event._id].join(':');
     case 'merch':
       return [event.type, event.message, event.createdAt].join(':');

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -139,10 +139,6 @@ const SUPPORTED_EVENTS = [
   'donordrivedonation',
   'justgivingdonation',
   'treat',
-  'facebook_like',
-  'facebook_share',
-  'facebook_stars',
-  'facebook_support',
 ];
 
 export class RecentEventsService extends StatefulService<IRecentEventsState> {

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -43,6 +43,7 @@ export interface IRecentEvent {
   hash: string;
   isTest?: boolean;
   repeat?: boolean;
+  // uuid is local and will NOT persist across app restarts/ fetches
   uuid: string;
 }
 

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -285,7 +285,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
     );
     const body = JSON.stringify({
       eventHash: event.hash,
-      read: !event.read,
+      read: event.read,
     });
     const request = new Request(url, { headers, body, method: 'POST' });
     return await fetch(request).then(handleResponse);

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -326,7 +326,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       });
     }
     if (event.months > 1) {
-      return $t('has resubscribed (%{tier}) for %{months} months!', {
+      return $t('has resubscribed (%{tier}) for %{months} months', {
         tier: subscriptionMap(event.sub_plan),
         months: event.months,
       });

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -318,10 +318,16 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
         tier: subscriptionMap(event.sub_plan),
       });
     }
-    if (event.months > 1) {
+    if (event.months > 1 && event.streak_months && event.streak_months > 1) {
       return $t('has resubscribed (%{tier}) for %{streak} months in a row! (%{months} total)', {
         tier: subscriptionMap(event.sub_plan),
         streak: event.streak_months,
+        months: event.months,
+      });
+    }
+    if (event.months > 1) {
+      return $t('has resubscribed (%{tier}) for %{months} months!', {
+        tier: subscriptionMap(event.sub_plan),
         months: event.months,
       });
     }

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -277,7 +277,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   async readAlert(event: IRecentEvent) {
-    this.TOGGLE_RECENT_EVENT_READ(event.hash);
+    this.TOGGLE_RECENT_EVENT_READ(event);
     const url = `https://${this.hostsService.streamlabs}/api/v5/slobs/widget/readalert`;
     const headers = authorizedHeaders(
       this.userService.apiToken,
@@ -422,12 +422,8 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   @mutation()
-  private TOGGLE_RECENT_EVENT_READ(eventHash: string) {
-    this.state.recentEvents.forEach((event, index) => {
-      if (event.hash === eventHash) {
-        event.read = !event.read;
-      }
-    });
+  private TOGGLE_RECENT_EVENT_READ(event: IRecentEvent) {
+    event.read = !event.read;
   }
 
   @mutation()


### PR DESCRIPTION
Fix bug where wrong value was being sent as read
Fix subscription related text
Remove facebook prefixed events
Add uuid property to events and use where client side unique identifier is needed