### PR TITLE
Fix Overlays and media-backup tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "tsc -p test && ava -v",
     "test-flaky": "node ./test/helpers/runner.js",
     "test-stress": "yarn test test-dist/test/stress/index.js",
+    "test-screen": "yarn test ./test-dist/test/screentest/tests/**/*.js",
     "test:debug": "tsc -p test && node --inspect ./node_modules/ava/profile.js",
     "test:debug-brk": "tsc -p test && node --inspect --inspect-brk ./node_modules/ava/profile.js",
     "clear": "rimraf bundles/media",

--- a/test/helpers/spectron/index.ts
+++ b/test/helpers/spectron/index.ts
@@ -75,6 +75,11 @@ interface ITestRunnerOptions {
   appArgs?: string;
 
   /**
+   * disable synchronisation of scene-collections and media-backup
+   */
+  noSync?: boolean;
+
+  /**
    * Enable this to show network logs if test failed
    */
   networkLogging?: boolean;
@@ -91,6 +96,7 @@ interface ITestRunnerOptions {
 const DEFAULT_OPTIONS: ITestRunnerOptions = {
   skipOnboarding: true,
   restartAppAfterEachTest: true,
+  noSync: true,
   networkLogging: false,
   pauseIfFailed: false,
 };
@@ -143,6 +149,7 @@ export function useSpectron(options: ITestRunnerOptions = {}) {
     t.context.cacheDir = cacheDir;
     const appArgs = options.appArgs ? options.appArgs.split(' ') : [];
     if (options.networkLogging) appArgs.push('--network-logging');
+    if (options.noSync) appArgs.push('--noSync');
     app = t.context.app = new Application({
       path: path.join(__dirname, '..', '..', '..', '..', 'node_modules', '.bin', 'electron.cmd'),
       args: [

--- a/test/helpers/spectron/user.ts
+++ b/test/helpers/spectron/user.ts
@@ -60,7 +60,7 @@ export async function logIn(
 
   app.webContents.send('testing-fakeAuth', authInfo, isOnboardingTest);
   if (!waitForUI) return true;
-  await t.context.app.client.waitForVisible('.fa-sign-out-alt'); // wait for the log-out button
+  await t.context.app.client.waitForVisible('.fa-sign-out-alt', 20000); // wait for the log-out button
   return true;
 }
 

--- a/test/media-backup.ts
+++ b/test/media-backup.ts
@@ -9,10 +9,9 @@ import os = require('os');
 import { logIn } from './helpers/spectron/user';
 import { SceneCollectionsService } from 'services/api/external-api/scene-collections';
 
-useSpectron();
+useSpectron({ noSync: false });
 
-// TODO: Fix flaky test
-test.skip('Media backup', async t => {
+test('Media backup', async t => {
   // copy images to the temporary folder
   const imagesDir = path.resolve(__dirname, '..', '..', 'test', 'data', 'sources-files', 'images');
   const tmpDir = fs.mkdtempSync(os.tmpdir());

--- a/test/screentest/tests/onboarding.ts
+++ b/test/screentest/tests/onboarding.ts
@@ -6,7 +6,7 @@ import { sleep } from '../../helpers/sleep';
 const path = require('path');
 const _7z = require('7zip')['7z'];
 
-useSpectron({ skipOnboarding: false, appArgs: '--nosync' });
+useSpectron({ skipOnboarding: false });
 useScreentest();
 
 test('Onboarding steps', async t => {

--- a/test/screentest/tests/settings.ts
+++ b/test/screentest/tests/settings.ts
@@ -6,7 +6,7 @@ import { logIn, logOut } from '../../helpers/spectron/user';
 import { sleep } from '../../helpers/sleep';
 
 
-useSpectron({ restartAppAfterEachTest: false });
+useSpectron({ restartAppAfterEachTest: false, pauseIfFailed: true });
 useScreentest();
 
 test('Settings General', async t => {
@@ -74,8 +74,7 @@ test('Settings Appearance', async t => {
   t.pass();
 });
 
-// TODO: Fix flaky test
-test.skip('Settings Game Overlay', async (t: TExecutionContext) => {
+test('Settings Game Overlay', async (t: TExecutionContext) => {
   const client = await getClient();
   const settingsService = client.getResource<ISettingsServiceApi>('SettingsService');
 

--- a/test/screentest/tests/streaming.ts
+++ b/test/screentest/tests/streaming.ts
@@ -6,7 +6,7 @@ import { TPlatform } from '../../../app/services/platforms';
 import { setOutputResolution } from '../../helpers/spectron/output';
 import { fetchMock, resetFetchMock } from '../../helpers/spectron/network';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 useScreentest();
 
 // test streaming for each platform

--- a/test/screentest/tests/widgets/chat-box.ts
+++ b/test/screentest/tests/widgets/chat-box.ts
@@ -4,7 +4,7 @@ import { fillForm } from '../../../helpers/form-monkey';
 import { addWidget, EWidgetType, waitForWidgetSettingsSync } from '../../../helpers/widget-helpers';
 import { useScreentest } from '../../screenshoter';
 
-useSpectron({ appArgs: '--nosync', restartAppAfterEachTest: false });
+useSpectron({ restartAppAfterEachTest: false });
 useScreentest();
 afterAppStart(async t => {
   await logIn(t);

--- a/test/screentest/tests/widgets/goals.ts
+++ b/test/screentest/tests/widgets/goals.ts
@@ -4,7 +4,7 @@ import { makeScreenshots, useScreentest } from '../../screenshoter';
 import { FormMonkey } from '../../../helpers/form-monkey';
 import { addWidget, EWidgetType, waitForWidgetSettingsSync } from '../../../helpers/widget-helpers';
 
-useSpectron({ appArgs: '--nosync', restartAppAfterEachTest: false });
+useSpectron({ restartAppAfterEachTest: false });
 useScreentest();
 
 testGoal('Donation Goal', EWidgetType.DonationGoal);

--- a/test/settings/streaming.ts
+++ b/test/settings/streaming.ts
@@ -2,7 +2,7 @@ import { focusChild, focusMain, test, useSpectron } from '../helpers/spectron';
 import { logIn } from '../helpers/spectron/user';
 import { getFormInput } from '../helpers/spectron/forms';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 test('Populates stream settings while logged in', async t => {
   const { app } = t.context;

--- a/test/streaming/live-dialog.ts
+++ b/test/streaming/live-dialog.ts
@@ -4,7 +4,7 @@ import { sleep } from '../helpers/sleep';
 import { logIn } from '../helpers/spectron/user';
 import { setOutputResolution } from '../helpers/spectron/output';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 // TODO: flaky on CI
 test.skip('Shows optimized encoder for specific games', async t => {

--- a/test/streaming/twitch/tags.ts
+++ b/test/streaming/twitch/tags.ts
@@ -2,7 +2,7 @@ import { focusChild, focusMain, test, useSpectron } from '../../helpers/spectron
 import { logIn } from '../../helpers/spectron/user';
 import { sleep } from '../../helpers/sleep';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 test('Twitch Tags', async t => {
   const app = t.context.app;

--- a/test/themes.ts
+++ b/test/themes.ts
@@ -4,7 +4,7 @@ import { sleep } from './helpers/sleep';
 import { FormMonkey } from './helpers/form-monkey';
 import { sceneExisting } from './helpers/spectron/scenes';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 const OVERLAY_NAME = 'Talon Stream Package by VBI';
 const OVERLAY_SCENES = ['Starting Soon', 'Be Right Back', 'Stream Ending', 'Intermission', 'Main'];

--- a/test/widgets/chat-box.ts
+++ b/test/widgets/chat-box.ts
@@ -4,7 +4,7 @@ import { logIn } from '../helpers/spectron/user';
 import { FormMonkey } from '../helpers/form-monkey';
 import { waitForWidgetSettingsSync } from '../helpers/widget-helpers';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 test('Chatbox Visual Settings', async t => {
   const client = t.context.app.client;

--- a/test/widgets/goals.ts
+++ b/test/widgets/goals.ts
@@ -5,7 +5,7 @@ import { FormMonkey } from '../helpers/form-monkey';
 import { waitForWidgetSettingsSync } from '../helpers/widget-helpers';
 import { sleep } from '../helpers/sleep';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 testGoal('Donation Goal');
 testGoal('Follower Goal');

--- a/test/widgets/stream-boss.ts
+++ b/test/widgets/stream-boss.ts
@@ -4,7 +4,7 @@ import { logIn } from '../helpers/spectron/user';
 import { FormMonkey } from '../helpers/form-monkey';
 import { waitForWidgetSettingsSync } from '../helpers/widget-helpers';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 test('Set stream-boss health', async t => {
   if (!(await logIn(t))) return;

--- a/test/widgets/tip-jar.ts
+++ b/test/widgets/tip-jar.ts
@@ -3,7 +3,7 @@ import { addSource } from '../helpers/spectron/sources';
 import { logIn } from '../helpers/spectron/user';
 import { sleep } from '../helpers/sleep';
 
-useSpectron({ appArgs: '--nosync' });
+useSpectron();
 
 test('Set tip-jar settings', async t => {
   if (!(await logIn(t))) return;


### PR DESCRIPTION
The `logIn()` method can take some time because of collections synchronization.
Passing the `--nosync` flag by default for each test now 