### PR TITLE
reduce the number of synchronous calls while dragging the window

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -54,6 +54,7 @@ import AlertBox from 'components/widgets/AlertBox.vue';
 import SpinWheel from 'components/widgets/SpinWheel.vue';
 
 import PerformanceMetrics from 'components/PerformanceMetrics.vue';
+import { throttle } from 'lodash-decorators';
 
 const { ipcRenderer, remote } = electron;
 const BrowserWindow = remote.BrowserWindow;
@@ -188,6 +189,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
     this.windows.child.on('move', () => this.updateScaleFactor('child'));
   }
 
+  @throttle(500)
   private updateScaleFactor(windowId: string) {
     const window = this.windows[windowId];
     if (window) {

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -192,7 +192,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
   @throttle(500)
   private updateScaleFactor(windowId: string) {
     const window = this.windows[windowId];
-    if (window) {
+    if (window && !window.isDestroyed()) {
       const bounds = window.getBounds();
       const currentDisplay = electron.remote.screen.getDisplayMatching(bounds);
       this.UPDATE_SCALE_FACTOR(windowId, currentDisplay.scaleFactor);


### PR DESCRIPTION
These events were firing very fast and we were making expensive synchronous electron calls in the callback.