### PR TITLE
fix performance mode resizing

### DIFF
--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -14,8 +14,7 @@
   <div
     v-else
     class="no-preview"
-    :class="{ 'perf-mode': performanceMode }"
-    :style="{ height: performanceMode ? '100px' : `calc(100% - ${eventsHeight + controlsHeight + 18}px` }"
+    :style="`calc(100% - ${eventsHeight + controlsHeight + 18}px`"
   >
     <div class="message" v-if="performanceMode">
       {{ $t('Preview is disabled in performance mode') }}
@@ -26,7 +25,7 @@
     </div>
   </div>
   <resize-bar
-    v-if="!performanceMode && isLoggedIn"
+    v-if="isLoggedIn"
     position="top"
     v-model="eventsHeight"
     @onresizestop="onResizeStopHandler()"
@@ -35,8 +34,8 @@
     :min="minEventsHeight"
     :reverse="true"
   />
-  <div :style="{ height: `${eventsHeight + controlsHeight}px` }" class="bottom-half" :class="{ 'perf-mode': performanceMode }">
-    <recent-events v-if="isLoggedIn" :class="{ 'perf-mode': performanceMode }" :style="{ height: `${eventsHeight}px` }" @popout="eventsHeight = minEventsHeight" />
+  <div :style="{ height: `${eventsHeight + controlsHeight}px` }" class="bottom-half">
+    <recent-events v-if="isLoggedIn" :style="{ height: `${eventsHeight}px` }" @popout="eventsHeight = minEventsHeight" />
     <resize-bar
       position="top"
       v-model="controlsHeight"
@@ -134,16 +133,8 @@
   }
 }
 
-.no-preview.perf-mode {
-  flex-grow: 0;
-}
-
 .bottom-half {
   display: flex;
   flex-direction: column;
-}
-
-.bottom-half.perf-mode {
-  flex-grow: 1;
 }
 </style>

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -73,10 +73,10 @@ export default class Studio extends Vue {
    */
   @Watch('performanceMode')
   reconcileHeightsWithinContraints(isControlsResize = false) {
-    // This is the maximum height we can use
-    this.maxHeight = this.$root.$el.getBoundingClientRect().height - 400;
+    const containerHeight = this.$root.$el.getBoundingClientRect().height;
 
-    if (this.performanceMode) this.maxHeight = this.$root.$el.getBoundingClientRect().height - 200;
+    // This is the maximum height we can use
+    this.maxHeight = containerHeight - (this.performanceMode ? 200 : 400);
 
     // Roughly 3 lines of events
     const reasonableMinimumEventsHeight = 156;

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'vue-property-decorator';
+import { Component, Watch } from 'vue-property-decorator';
 import { CustomizationService } from 'services/customization';
 import StudioEditor from 'components/StudioEditor.vue';
 import StudioControls from 'components/StudioControls.vue';
@@ -71,9 +71,12 @@ export default class Studio extends Vue {
    * max height, then the events view will be reduced in size until a reasonable
    * minimum, at which point the controls will start being reduced in size.
    */
+  @Watch('performanceMode')
   reconcileHeightsWithinContraints(isControlsResize = false) {
     // This is the maximum height we can use
     this.maxHeight = this.$root.$el.getBoundingClientRect().height - 400;
+
+    if (this.performanceMode) this.maxHeight = this.$root.$el.getBoundingClientRect().height - 200;
 
     // Roughly 3 lines of events
     const reasonableMinimumEventsHeight = 156;


### PR DESCRIPTION
As part of this I removed the behavior Sean added where the display section automatically collapsed to as small as it could go when in performance mode.  Reasoning:
- New resize code that accounts for all edge cases is much more complex than old code
- Supporting performance mode with this new code was very complex
- Given the above 2 point and low utilization of performance mode, this seemed like the simplest/fastest thing to do.