### PR TITLE
Switch play pause icons in recent events to match web

### DIFF
--- a/app/components/RecentEvents.tsx
+++ b/app/components/RecentEvents.tsx
@@ -261,7 +261,7 @@ class Toolbar extends TsxComponent<IToolbarProps> {
         )}
         {this.native && (
           <i
-            class={`${this.queuePaused ? 'icon-media-share-2' : 'icon-pause'} action-icon`}
+            class={`${this.queuePaused ? 'icon-pause' : 'icon-media-share-2'} action-icon`}
             onClick={this.toggleQueue}
             v-tooltip={{ content: pauseTooltip, placement: 'bottom' }}
           />


### PR DESCRIPTION
Chane the icons for play pause to reflect the action taken by clicking rather than showing the current state. This matches the implementation on the website.