### PR TITLE
Remove disabled class from selective recording icon 

### DIFF
--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -61,7 +61,7 @@
           v-if="selectiveRecordingEnabled"
           class="source-selector-action"
           v-tooltip="selectiveRecordingTooltip(node.data.id)"
-          :class="[selectiveRecordingClassesForSource(node.data.id), streamingService.isStreaming || streamingService.isRecording ? 'disabled' : '']"
+          :class="selectiveRecordingClassesForSource(node.data.id)"
           @click.stop="cycleSelectiveRecording(node.data.id)"
           @dblclick.stop="() => {}" />
         <i class="source-selector-action" :class="lockClassesForSource(node.data.id)" @click.stop="toggleLock(node.data.id)" @dblclick.stop="() => {}"></i>

--- a/app/components/SourceSelector.vue
+++ b/app/components/SourceSelector.vue
@@ -61,7 +61,7 @@
           v-if="selectiveRecordingEnabled"
           class="source-selector-action"
           v-tooltip="selectiveRecordingTooltip(node.data.id)"
-          :class="selectiveRecordingClassesForSource(node.data.id)"
+          :class="[selectiveRecordingClassesForSource(node.data.id), isLocked(node.data.id) ? 'disabled' : '']"
           @click.stop="cycleSelectiveRecording(node.data.id)"
           @dblclick.stop="() => {}" />
         <i class="source-selector-action" :class="lockClassesForSource(node.data.id)" @click.stop="toggleLock(node.data.id)" @dblclick.stop="() => {}"></i>

--- a/app/components/SourceSelector.vue.ts
+++ b/app/components/SourceSelector.vue.ts
@@ -350,6 +350,11 @@ export default class SourceSelector extends Vue {
     selection.setSettings({ locked });
   }
 
+  isLocked(sceneNodeId: string) {
+    const selection = this.scene.getSelection(sceneNodeId);
+    return selection.isLocked();
+  }
+
   get scene() {
     return this.scenesService.activeScene;
   }


### PR DESCRIPTION
Users should be able to cycle through the options on each source even after they've gone live or started recording.