### PR TITLE
Update node-libuihook to v0.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "facemask-plugin": "https://s3-us-west-2.amazonaws.com/faces-internal.streamlabs.com/facemask-plugin-deployment/facemask-plugin-0.9.1.tar.gz",
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
-    "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.13electron6b/iojs-v6.0.3-node-libuiohook.tar.gz",
+    "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
     "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.9-iojs-v6.0.3.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6761,9 +6761,9 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-"node-libuiohook@https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.13electron6b/iojs-v6.0.3-node-libuiohook.tar.gz":
+"node-libuiohook@https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz":
   version "0.0.9"
-  resolved "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.13electron6b/iojs-v6.0.3-node-libuiohook.tar.gz#7b6d95d5abf5ca1a38486534923a9e06129cdff9"
+  resolved "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz#864182a1808ae605e55380bf1118d50ee488fe90"
 
 node-object-hash@^1.2.0:
   version "1.4.2"


### PR DESCRIPTION
This fixes the issue where if you hit a modifier key while holding a single key, it would disable the entire hotkey.