### PR TITLE
Recent events fix pause/ unpause

### DIFF
--- a/app/components/RecentEvents.tsx
+++ b/app/components/RecentEvents.tsx
@@ -30,7 +30,6 @@ export default class RecentEvents extends TsxComponent<{}> {
   @Inject() dismissablesService: DismissablesService;
   @Inject() magicLinkService: MagicLinkService;
 
-  queuePaused = false;
   eventsCollapsed = false;
 
   get native() {
@@ -43,6 +42,10 @@ export default class RecentEvents extends TsxComponent<{}> {
 
   get muted() {
     return this.recentEventsService.state.muted;
+  }
+
+  get queuePaused() {
+    return this.recentEventsService.state.queuePaused;
   }
 
   get mediaShareEnabled() {
@@ -88,13 +91,8 @@ export default class RecentEvents extends TsxComponent<{}> {
     return this.recentEventsService.readAlert(event);
   }
 
-  async toggleQueue() {
-    try {
-      this.queuePaused
-        ? await this.recentEventsService.unpauseAlertQueue()
-        : await this.recentEventsService.pauseAlertQueue();
-      this.queuePaused = !this.queuePaused;
-    } catch (e) {}
+  toggleQueue() {
+    return this.recentEventsService.toggleQueue();
   }
 
   setNative(native: boolean) {
@@ -239,7 +237,7 @@ class Toolbar extends TsxComponent<IToolbarProps> {
   @Prop() native: boolean;
 
   render(h: Function) {
-    const pauseTooltip = this.queuePaused ? $t('Pause Alert Queue') : $t('Unpause Alert Queue');
+    const pauseTooltip = this.queuePaused ? $t('Unpause Alert Queue') : $t('Pause Alert Queue');
     return (
       <div class={styles.topBar}>
         <h2 class="studio-controls__label">{$t('Mini Feed')}</h2>
@@ -265,7 +263,7 @@ class Toolbar extends TsxComponent<IToolbarProps> {
         )}
         {this.native && (
           <i
-            class={`${this.queuePaused ? 'icon-pause' : 'icon-media-share-2'} action-icon`}
+            class={`${this.queuePaused ? 'icon-media-share-2' : 'icon-pause'} action-icon`}
             onClick={this.toggleQueue}
             v-tooltip={{ content: pauseTooltip, placement: 'bottom' }}
           />

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -101,6 +101,7 @@ interface IRecentEventsState {
   muted: boolean;
   mediaShareEnabled: boolean;
   filterConfig: IRecentEventFilterConfig;
+  queuePaused: boolean;
 }
 
 const subscriptionMap = (subPlan: string) => {
@@ -247,6 +248,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       donation: false,
       merch: false,
     },
+    queuePaused: false,
   };
 
   lifecycle: LoginLifecycle;
@@ -587,6 +589,14 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       }
     }
 
+    if (e.type === 'pauseQueue') {
+      this.SET_PAUSED(true);
+    }
+
+    if (e.type === 'unpauseQueue') {
+      this.SET_PAUSED(false);
+    }
+
     if (e.type === 'mediaSharingSettingsUpdate') {
       if (e.message.advanced_settings.enabled != null) {
         this.SET_MEDIA_SHARE(e.message.advanced_settings.enabled);
@@ -747,6 +757,12 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
     return await fetch(new Request(url, { headers, body, method: 'POST' })).then(handleResponse);
   }
 
+  async toggleQueue() {
+    try {
+      this.state.queuePaused ? await this.unpauseAlertQueue() : await this.pauseAlertQueue();
+    } catch (e) {}
+  }
+
   openRecentEventsWindow(isMediaShare?: boolean) {
     this.windowsService.createOneOffWindow(
       {
@@ -808,5 +824,10 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   @mutation()
   private SET_SINGLE_FILTER_CONFIG(key: string, value: boolean | number) {
     this.state.filterConfig[key] = value;
+  }
+
+  @mutation()
+  private SET_PAUSED(queuePaused: boolean) {
+    this.state.queuePaused = queuePaused;
   }
 }

--- a/app/services/websocket.ts
+++ b/app/services/websocket.ts
@@ -16,7 +16,9 @@ export type TSocketEvent =
   | IEventSocketEvent
   | IFmExtEnabledSocketEvent
   | IEventPanelSettingsChangedSocketEvent
-  | IMediaSharingSettingsUpdateSocketEvent;
+  | IMediaSharingSettingsUpdateSocketEvent
+  | IPauseEventQueueSocketEvent
+  | IUnpauseEventQueueSocketEvent;
 
 interface IStreamlabelsSocketEvent {
   type: 'streamlabels';
@@ -66,6 +68,14 @@ export interface IAlertPlayingSocketEvent {
 
 interface IAlertProfileChanged {
   type: 'alertProfileChanged';
+}
+
+interface IPauseEventQueueSocketEvent {
+  type: 'pauseQueue';
+}
+
+interface IUnpauseEventQueueSocketEvent {
+  type: 'unpauseQueue';
 }
 
 interface IEventPanelSettingsChangedSocketEvent {


### PR DESCRIPTION
On the website, paused is initialized to false and subsequent handling of pausing and unpausing is handled through socket events. 

Refactored the pause/ unpause logic for recent events to mirror the behavior on web.

Upon loading SLOBS, users should always see an option to pause their queue by pressing a pause button. Upon pressing the pause button, event queue paused status should sync in real time across all widgets and any other instances of recent events.