### PR TITLE
don't use webgl contexts for inactive sources

### DIFF
--- a/app/components/MixerVolmeter.vue
+++ b/app/components/MixerVolmeter.vue
@@ -1,6 +1,6 @@
 <template>
 <div class="volmeter-container">
-  <canvas class="volmeter" ref="canvas" />
+  <canvas class="volmeter" ref="canvas" v-show="channelCount" />
   <div class="volmeter-spacer" ref="spacer" />
 </div>
 </template>


### PR DESCRIPTION
We only get 16 webgl contexts at any give time (and for a bit until GC runs), so we should conserve them better by not using them for audio sources that haven't and won't play any audio.