### PR TITLE
Add basic test for selective recording

### DIFF
--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -1,6 +1,5 @@
 import { readdir } from 'fs-extra';
-import { focusChild, focusMain, test, useSpectron } from './helpers/spectron';
-import { setFormDropdown } from './helpers/spectron/forms';
+import { focusMain, test, useSpectron } from './helpers/spectron';
 import { sleep } from './helpers/sleep';
 import { setTemporaryRecordingPath } from './helpers/spectron/output';
 import { addSource } from './helpers/spectron/sources';
@@ -21,7 +20,6 @@ test('Selective Recording', async t => {
   await client.click('.studio-controls-top .icon-smart-record');
 
   // Check that selective recording icon is active
-  await sleep(2000);
   t.true(await client.isExisting('.icon-smart-record.icon--active'));
 
   // Check that browser source has a selective recording toggle
@@ -29,14 +27,12 @@ test('Selective Recording', async t => {
 
   // Cycle selective recording mode on browser source
   await client.click('.sl-vue-tree-sidebar .source-selector-action.icon-smart-record');
-  await sleep(2000);
 
   // Check that source is set to stream only
   t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-broadcast'));
 
   // Cycle selective recording mode to record only
   await client.click('.sl-vue-tree-sidebar .source-selector-action.icon-broadcast');
-  await sleep(2000);
 
   // Check that source is set to record only
   t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-studio'));
@@ -46,7 +42,6 @@ test('Selective Recording', async t => {
   await sleep(2000);
 
   // Ensure recording indicator is active
-  await focusMain(t);
   t.true(await client.isExisting('.record-button.active'));
 
   // Stop recording

--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -1,0 +1,59 @@
+import { readdir } from 'fs-extra';
+import { focusChild, focusMain, test, useSpectron } from './helpers/spectron';
+import { setFormDropdown } from './helpers/spectron/forms';
+import { sleep } from './helpers/sleep';
+import { setTemporaryRecordingPath } from './helpers/spectron/output';
+import { addSource } from './helpers/spectron/sources';
+
+useSpectron();
+
+test('Selective Recording', async t => {
+  const sourceType = 'Browser Source';
+  const sourceName = `Example ${sourceType}`;
+  const { client } = t.context.app;
+  const tmpDir = await setTemporaryRecordingPath(t);
+
+  // Add a browser source
+  await addSource(t, sourceType, sourceName);
+
+  // Toggle selective recording
+  await focusMain(t);
+  await client.click('.studio-controls-top .icon-smart-record');
+
+  // Check that selective recording icon is active
+  await sleep(2000);
+  t.true(await client.isExisting('.icon-smart-record.icon--active'));
+
+  // Check that browser source has a selective recording toggle
+  t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-smart-record'));
+
+  // Cycle selective recording mode on browser source
+  await client.click('.sl-vue-tree-sidebar .source-selector-action.icon-smart-record');
+  await sleep(2000);
+
+  // Check that source is set to stream only
+  t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-broadcast'));
+
+  // Cycle selective recording mode to record only
+  await client.click('.sl-vue-tree-sidebar .source-selector-action.icon-broadcast');
+  await sleep(2000);
+
+  // Check that source is set to record only
+  t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-studio'));
+
+  // Start recording
+  await client.click('.record-button');
+  await sleep(2000);
+
+  // Ensure recording indicator is active
+  await focusMain(t);
+  t.true(await client.isExisting('.record-button.active'));
+
+  // Stop recording
+  await client.click('.record-button');
+  await client.waitForVisible('.record-button:not(.active)', 15000);
+
+  // Check that file exists
+  const files = await readdir(tmpDir);
+  t.is(files.length, 1);
+});


### PR DESCRIPTION
Would love some feedback on this test.

creates a temporary recording path
adds a single browser source
enables selective recording
cycles selective recording to record only
records 2s of video
checks that file exists 

I'm concerned that the entire test hinges on css class names for specific icons and treats presence of a given icon as an indicator of proper functionality. It might be better to inspect the customization service to ensure the selective recording mode matches expectations.