### PR TITLE
Prevent moving locked selections with arrow keys

### DIFF
--- a/app/services/editor-commands/editor-commands.ts
+++ b/app/services/editor-commands/editor-commands.ts
@@ -230,7 +230,7 @@ export class EditorCommandsService extends StatefulService<IEditorCommandsServic
     const selection = this.selectionService.getActiveSelection();
 
     if (!selection.getNodes().length) return;
-    if (selection.isLocked()) return;
+    if (selection.isAnyLocked()) return;
 
     this.executeCommand('NudgeItemsCommand', selection, direction);
   }

--- a/app/services/editor-commands/editor-commands.ts
+++ b/app/services/editor-commands/editor-commands.ts
@@ -230,6 +230,7 @@ export class EditorCommandsService extends StatefulService<IEditorCommandsServic
     const selection = this.selectionService.getActiveSelection();
 
     if (!selection.getNodes().length) return;
+    if (selection.isLocked()) return;
 
     this.executeCommand('NudgeItemsCommand', selection, direction);
   }

--- a/app/services/selection/selection.ts
+++ b/app/services/selection/selection.ts
@@ -295,6 +295,14 @@ export class Selection {
     return this.getItems().every(item => item.locked);
   }
 
+  /**
+   * Helper method to check if any items in the selection
+   * are locked.
+   */
+  isAnyLocked(): boolean {
+    return this.getItems().some(item => item.locked);
+  }
+
   isStreamVisible(): boolean {
     return this.getItems().every(item => item.streamVisible);
   }


### PR DESCRIPTION
This is the naive fix for this issue. With this change, if you have multiple sources selected and any one of them isn't locked, all sources in the selection will be nudged by pressing arrow keys.

I don't think many users will try to nudge a selection containing both locked and unlocked sources.