### PR TITLE
Properly filter FB events in minifeed

### DIFF
--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -694,7 +694,18 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
       }
       return this.shouldFilterSubscription(event);
     }
-    return this.state.filterConfig[event.type];
+    return this.transformFilterForFB()[event.type];
+  }
+
+  transformFilterForFB() {
+    const filterMap = this.state.filterConfig;
+    if (this.userService.platform.type === 'facebook') {
+      filterMap['support'] = filterMap['facebook_support'];
+      filterMap['like'] = filterMap['facebook_like'];
+      filterMap['share'] = filterMap['facebook_share'];
+      filterMap['stars'] = filterMap['facebook_stars'];
+    }
+    return filterMap;
   }
 
   onEventSocket(e: IEventSocketEvent) {

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -5,7 +5,7 @@ import { authorizedHeaders, handleResponse } from 'util/requests';
 import { $t } from 'services/i18n';
 import { WindowsService } from 'services/windows';
 import { WebsocketService, TSocketEvent, IEventSocketEvent } from 'services/websocket';
-import pick from 'lodash/pick';
+import { pick, cloneDeep } from 'lodash';
 import uuid from 'uuid/v4';
 import { Subscription } from 'rxjs';
 import mapValues from 'lodash/mapValues';
@@ -698,7 +698,7 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
   }
 
   transformFilterForFB() {
-    const filterMap = this.state.filterConfig;
+    const filterMap = cloneDeep(this.state.filterConfig);
     if (this.userService.platform.type === 'facebook') {
       filterMap['support'] = filterMap['facebook_support'];
       filterMap['like'] = filterMap['facebook_like'];


### PR DESCRIPTION
Facebook events were being erroneously filtered due to inconsistency between the keys used to identify FB alerts (event type) and the setting to filter that event.