### PR TITLE
Hide display by dragging

### DIFF
--- a/app/components/pages/Studio.vue
+++ b/app/components/pages/Studio.vue
@@ -11,11 +11,7 @@
       </div>
     </div>
   </div>
-  <div
-    v-else
-    class="no-preview"
-    :style="`height: calc(100% - ${eventsHeight + controlsHeight}px)`"
-  >
+  <div v-else class="no-preview">
     <div class="message" v-if="performanceMode">
       {{ $t('Preview is disabled in performance mode') }}
       <div class="button button--action button--sm" @click="enablePreview">{{ $t('Disable Performance Mode') }}</div>
@@ -43,7 +39,7 @@
       v-model="controlsHeight"
       @onresizestop="onResizeStopHandler()"
       @onresizestart="onResizeStartHandler()"
-      :max="maxHeight - minControlsHeight"
+      :max="maxHeight"
       :min="minControlsHeight"
       :reverse="true"
     />
@@ -159,15 +155,17 @@
 
 .no-preview {
   width: 100%;
-  height: 100%;
+  height: 0;
   position: relative;
   flex-grow: 1;
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
 
   .message {
     max-width: 50%;
+    position: relative;
 
     .button {
       margin-top: 20px;

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -74,18 +74,20 @@ export default class Studio extends Vue {
    */
   @Watch('performanceMode')
   reconcileHeightsWithinContraints(isControlsResize = false) {
-    const containerHeight = this.$root.$el.getBoundingClientRect().height;
+    const containerHeight = this.$el.getBoundingClientRect().height;
+    // console.log(containerHeight, this.$root.$el, this.$el);
 
     // This is the maximum height we can use
-    this.maxHeight = containerHeight - (this.performanceMode ? 200 : 1);
+    this.maxHeight = containerHeight - this.resizeBarNudgeFactor;
 
     // Roughly 3 lines of events
     const reasonableMinimumEventsHeight = 156;
 
     // Roughly 1 mixer item
     const reasonableMinimumControlsHeight = 150;
-
-    const spaceForDisplay = containerHeight - (this.minEventsHeight + this.controlsHeight);
+    console.log(this.eventsHeight);
+    const spaceForDisplay = containerHeight - (this.eventsHeight + this.controlsHeight);
+    console.log(spaceForDisplay, this.controlsHeight, this.maxHeight);
 
     if (spaceForDisplay < 25) {
       this.showDisplay = false;
@@ -175,6 +177,10 @@ export default class Studio extends Vue {
 
   get minControlsHeight() {
     return 50;
+  }
+
+  get resizeBarNudgeFactor() {
+    return this.isLoggedIn ? 18 : 8;
   }
 
   onResizeStartHandler() {

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -32,6 +32,7 @@ export default class Studio extends Vue {
 
   stacked = false;
   verticalPlaceholder = false;
+  showDisplay = true;
 
   sizeCheckInterval: number;
 
@@ -76,13 +77,21 @@ export default class Studio extends Vue {
     const containerHeight = this.$root.$el.getBoundingClientRect().height;
 
     // This is the maximum height we can use
-    this.maxHeight = containerHeight - (this.performanceMode ? 200 : 400);
+    this.maxHeight = containerHeight - (this.performanceMode ? 200 : 1);
 
     // Roughly 3 lines of events
     const reasonableMinimumEventsHeight = 156;
 
     // Roughly 1 mixer item
     const reasonableMinimumControlsHeight = 150;
+
+    const spaceForDisplay = containerHeight - (this.minEventsHeight + this.controlsHeight);
+
+    if (spaceForDisplay < 25) {
+      this.showDisplay = false;
+    } else {
+      this.showDisplay = true;
+    }
 
     // Something needs to be adjusted to fit
     if (this.controlsHeight + this.eventsHeight > this.maxHeight) {
@@ -116,7 +125,9 @@ export default class Studio extends Vue {
   }
 
   get displayEnabled() {
-    return !this.windowsService.state.main.hideStyleBlockers && !this.performanceMode;
+    return (
+      !this.windowsService.state.main.hideStyleBlockers && !this.performanceMode && this.showDisplay
+    );
   }
 
   get performanceMode() {

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -85,9 +85,10 @@ export default class Studio extends Vue {
     // Roughly 1 mixer item
     const reasonableMinimumControlsHeight = 150;
 
-    const spaceForDisplay = containerHeight - (this.eventsHeight + this.controlsHeight);
+    const spaceForDisplay =
+      containerHeight - (this.eventsHeight + this.controlsHeight + this.resizeBarNudgeFactor);
 
-    if (spaceForDisplay < 25) {
+    if (spaceForDisplay < 50) {
       this.showDisplay = false;
     } else {
       this.showDisplay = true;

--- a/app/components/pages/Studio.vue.ts
+++ b/app/components/pages/Studio.vue.ts
@@ -75,7 +75,6 @@ export default class Studio extends Vue {
   @Watch('performanceMode')
   reconcileHeightsWithinContraints(isControlsResize = false) {
     const containerHeight = this.$el.getBoundingClientRect().height;
-    // console.log(containerHeight, this.$root.$el, this.$el);
 
     // This is the maximum height we can use
     this.maxHeight = containerHeight - this.resizeBarNudgeFactor;
@@ -85,9 +84,8 @@ export default class Studio extends Vue {
 
     // Roughly 1 mixer item
     const reasonableMinimumControlsHeight = 150;
-    console.log(this.eventsHeight);
+
     const spaceForDisplay = containerHeight - (this.eventsHeight + this.controlsHeight);
-    console.log(spaceForDisplay, this.controlsHeight, this.maxHeight);
 
     if (spaceForDisplay < 25) {
       this.showDisplay = false;


### PR DESCRIPTION
Allow users who want to hide their display to hide it by dragging controls or recent events to the top of the window.