### PR TITLE
Pause CI if streaming test failed

### DIFF
--- a/test/streaming.js
+++ b/test/streaming.js
@@ -17,7 +17,7 @@ import { ScenesService } from 'services/api/external-api/scenes';
 import { readdir } from 'fs-extra';
 
 
-useSpectron();
+useSpectron({ pauseIfFailed: true });
 
 async function addColorSource() {
   const api = await getClient();


### PR DESCRIPTION
Need to get obs-logs for failed tests