### PR TITLE
Update osn to v0.5.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7049,9 +7049,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz#8d17624f9b0a78c320e4d32e2583bdd80627c21e"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47-iojs-v6.0.3-release.tar.gz#d14d2c5af792e491ac0b6d0d525560289095045b"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Vladimir	inform crash handler about out of memory crash (#530)
Vladimir	look log to detect ffmpeg error (#532)
Vladimir	do not recreate existing encoder to get settings (#525)
Pablo	Fix removal of cache files in tests (#513)
Vladimir	correctly wait for stream to start to not deleted it too early (#528)
EddyGharbi	Update libobs to v24.17.0 (#541)
Vladimir	let crash handler run again if stackwalker crashed (#531)
EddyGharbi	Put back downloading Sentry binaries (#540)
EddyGharbi	Remove preparing artifacts (#538)
Eddy Gharbi	Remove tag name restriction