### PR TITLE
Make forked typechecking optional

### DIFF
--- a/base.config.js
+++ b/base.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { CheckerPlugin } = require('awesome-typescript-loader')
 
-const plugins = [new CheckerPlugin()];
+const plugins = process.env.SLOBS_FORKED_TYPECHECKING ? [new CheckerPlugin()] : [];
 
 // uncomment and install to watch circular dependencies
 // const CircularDependencyPlugin = require('circular-dependency-plugin');
@@ -67,7 +67,7 @@ module.exports = {
       {
         test: /\.ts$/,
         loader: 'awesome-typescript-loader',
-        options: { useCache: true, reportedFiles: ['app/**/*.ts'] },
+        options: { useCache: true, reportFiles: ['app/**/*.ts'] },
         exclude: /node_modules|vue\/src/
       },
       {
@@ -77,8 +77,7 @@ module.exports = {
           'babel-loader',
           {
             loader: 'awesome-typescript-loader',
-            options: { useCache: true, reportedFiles: ['app/components/**/*.tsx'], configFileName: 'tsxconfig.json', instance: 'tsx-loader' }
-          }
+            options: { useCache: true, reportFiles: ['app/components/**/*.tsx'], configFileName: 'tsxconfig.json', instance: 'tsx-loader' } }
         ],
         exclude: /node_modules/,
       },

--- a/dev.config.js
+++ b/dev.config.js
@@ -4,7 +4,8 @@ const path = require('path');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin');
 const { CheckerPlugin } = require('awesome-typescript-loader')
 
-const plugins = [new HardSourceWebpackPlugin(), new CheckerPlugin()];
+const plugins = process.env.SLOBS_FORKED_TYPECHECKING ?
+  [new HardSourceWebpackPlugin(), new CheckerPlugin()] : [new HardSourceWebpackPlugin()];
 
 module.exports = merge.smart(baseConfig, {
   entry: {
@@ -22,7 +23,7 @@ module.exports = merge.smart(baseConfig, {
       {
         test: /\.ts$/,
         loader: 'awesome-typescript-loader',
-        options: { useCache: true, forceIsolatedModules: true, reportedFiles: ['app/**/*.ts'] },
+        options: { useCache: true, forceIsolatedModules: true, reportFiles: ['app/**/*.ts'] },
         exclude: /node_modules|vue\/src/
       },
       {
@@ -32,7 +33,7 @@ module.exports = merge.smart(baseConfig, {
           'babel-loader',
           {
             loader: 'awesome-typescript-loader',
-            options: { forceIsolatedModules: true, reportedFiles: ['app/components/**/*.tsx'], configFileName: 'tsxconfig.json', instance: 'tsx-loader' }
+            options: { forceIsolatedModules: true, reportFiles: ['app/components/**/*.tsx'], configFileName: 'tsxconfig.json', instance: 'tsx-loader' }
           }
         ],
         exclude: /node_modules/,


### PR DESCRIPTION
uses the env variable `SLOBS_FORKED_TYPECHECKING` to determine if we webpack build in a single or multi-process format