### PR TITLE
Prevent issue with capitalization/ mark as read

### DIFF
--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -186,7 +186,7 @@ function getHashForRecentEvent(event: IRecentEvent) {
     case 'sticker':
       return [event.name, event.type, event.currency].join(':');
     case 'subscription':
-      return [event.type, event.name, event.message].join(':');
+      return [event.type, event.name.toLowerCase(), event.message].join(':');
     case 'superchat':
       return [event.type, event.name, event.message].join(':');
     case 'superheart':


### PR DESCRIPTION
The name property is used for calculating event hashes and for displaying the subscriber's username in the alert. This PR will allow us to restore proper capitalization in subscription alerts while avoiding having some subscriptions get marked as unread in recent events. 