### PR TITLE
Game overlay fixes

### DIFF
--- a/app/components/RecentEvents.tsx
+++ b/app/components/RecentEvents.tsx
@@ -196,7 +196,7 @@ export default class RecentEvents extends TsxComponent<RecentEventsProps> {
             onNativeswitch={val => this.setNative(val)}
           />
         )}
-        {this.native ? this.renderNativeEvents : this.renderEmbeddedEvents}
+        {this.native || this.props.isOverlay ? this.renderNativeEvents : this.renderEmbeddedEvents}
         {!this.props.isOverlay && (
           <HelpTip
             dismissableKey={EDismissable.RecentEventsHelpTip}

--- a/app/services/game-overlay/index.ts
+++ b/app/services/game-overlay/index.ts
@@ -347,7 +347,7 @@ export class GameOverlayService extends PersistentStatefulService<GameOverlaySta
 
   async destroy() {
     if (!this.lifecycle) return;
-    await this.lifecycle.destroy();
+    await this.destroyOverlay();
   }
 
   async destroyOverlay() {


### PR DESCRIPTION
-Display recent events in game overlay when legacy mode is on
-Prevent game overlay from being disabled on app close