### PR TITLE
scene-collections: sync collection test

### DIFF
--- a/test/helpers/spectron/user.ts
+++ b/test/helpers/spectron/user.ts
@@ -48,8 +48,7 @@ export async function logIn(
   features?: ITestUserFeatures, // if not set, pick a random user's account from user-pool
   waitForUI = true,
   isOnboardingTest = false,
-): Promise<boolean> {
-  const app = t.context.app;
+): Promise<IUserAuth> {
   let authInfo: IUserAuth;
 
   if (user) throw 'User already logged in';
@@ -60,14 +59,22 @@ export async function logIn(
     authInfo = getAuthInfoFromEnv();
     if (!authInfo) {
       t.pass();
-      return false;
+      return null;
     }
   }
 
+  await loginWithAuthInfo(t, authInfo, waitForUI, isOnboardingTest);
+  return authInfo;
+}
+
+export async function loginWithAuthInfo(
+  t: TExecutionContext,
+  authInfo: IUserAuth,
+  waitForUI = true,
+  isOnboardingTest = false,
+) {
   await focusMain(t);
-
-  app.webContents.send('testing-fakeAuth', authInfo, isOnboardingTest);
-
+  t.context.app.webContents.send('testing-fakeAuth', authInfo, isOnboardingTest);
   if (!waitForUI) return true;
   await t.context.app.client.waitForVisible('.fa-sign-out-alt', 20000); // wait for the log-out button
   return true;

--- a/test/media-backup.ts
+++ b/test/media-backup.ts
@@ -23,17 +23,6 @@ test('Media backup', async t => {
   const api = await getClient();
   const collectionsService = api.getResource<SceneCollectionsService>('SceneCollectionsService');
 
-  // TODO: user-pool should return clean accounts without any scene-collections
-  // delete all collections for this account
-  const collections = await collectionsService.fetchSceneCollectionsSchema();
-  for (const collection of collections) {
-    try {
-      await collectionsService.delete(collection.id);
-    } catch (e) {
-      // could be switching to an invalid scene-collection
-    }
-  }
-
   // create an new empty collection
   const collection = await collectionsService.create({ name: 'Test collection' });
 

--- a/test/services/scene-collections/cloud-backup.ts
+++ b/test/services/scene-collections/cloud-backup.ts
@@ -7,7 +7,7 @@ useSpectron({ noSync: false });
 
 
 test('Scene-collections cloud-backup', async t => {
-  // log-in and save credentials
+  // log-in and save the credentials
   const authInfo = await logIn(t);
 
   // build the scene
@@ -19,12 +19,12 @@ test('Scene-collections cloud-backup', async t => {
   `;
   sceneBuilder.build(sketch);
 
-  // restart app and delete the cache dir
+  // restart the app and delete the cache dir
   await stopApp(true);
   await startApp(t);
 
   // since we deleted the cache dir we need to login again
-  // use saved credential to login into the same account
+  // use saved credentials to login into the same account
   await loginWithAuthInfo(t, authInfo);
 
   // check the scene-collection is downloaded

--- a/test/services/scene-collections/cloud-backup.ts
+++ b/test/services/scene-collections/cloud-backup.ts
@@ -1,0 +1,32 @@
+import { startApp, stopApp, test, useSpectron } from '../../helpers/spectron/index';
+import { SceneBuilder } from '../../helpers/scene-builder';
+import { getClient } from '../../helpers/api-client';
+import { logIn, loginWithAuthInfo } from '../../helpers/spectron/user';
+
+useSpectron({ noSync: false });
+
+
+test('Scene-collections cloud-backup', async t => {
+  // log-in and save credentials
+  const authInfo = await logIn(t);
+
+  // build the scene
+  const sceneBuilder = new SceneBuilder(await getClient());
+  const sketch = `
+    Folder1
+      Item1: color_source
+      Item2: image
+  `;
+  sceneBuilder.build(sketch);
+
+  // restart app and delete the cache dir
+  await stopApp(true);
+  await startApp(t);
+
+  // since we deleted the cache dir we need to login again
+  // use saved credential to login into the same account
+  await loginWithAuthInfo(t, authInfo);
+
+  // check the scene-collection is downloaded
+  t.true(sceneBuilder.isEqualTo(sketch), 'Scene collection should be downloaded');
+});

--- a/test/services/scene-collections/migrations.ts
+++ b/test/services/scene-collections/migrations.ts
@@ -1,5 +1,5 @@
-import { test, useSpectron } from './helpers/spectron';
-import { sceneExisting } from './helpers/spectron/scenes';
+import { test, useSpectron } from '../../helpers/spectron/index';
+import { sceneExisting } from '../../helpers/spectron/scenes';
 
 const fs = require('fs');
 const path = require('path');


### PR DESCRIPTION
Since `user-pool` returns accounts with an empty scene-collections list, we can implement tests for scene-collection synchronization.