### PR TITLE
Update osn to v0.5.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.48-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/test/recording.ts
+++ b/test/recording.ts
@@ -34,7 +34,7 @@ test('Recording', async t => {
 
     // Stop recording
     await app.client.click('.record-button');
-    await app.client.waitForVisible('.record-button:not(.active)', 15000);
+    await app.client.waitForVisible('.record-button:not(.active)', 60000);
 
     // Wait to ensure that output setting are editable
     await sleep(2000);

--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -46,7 +46,7 @@ test('Selective Recording', async t => {
 
   // Stop recording
   await client.click('.record-button');
-  await client.waitForVisible('.record-button:not(.active)', 15000);
+  await client.waitForVisible('.record-button:not(.active)', 60000);
 
   // Check that file exists
   const files = await readdir(tmpDir);

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -398,7 +398,7 @@ test('Recording when streaming', async t => {
 
   // Stop recording
   await app.client.click('.record-button');
-  await app.client.waitForVisible('.record-button:not(.active)', 15000);
+  await app.client.waitForVisible('.record-button:not(.active)', 60000);
 
   // check that recording has been created
   const files = await readdir(tmpDir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7049,9 +7049,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.48-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz#8d17624f9b0a78c320e4d32e2583bdd80627c21e"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.48-iojs-v6.0.3-release.tar.gz#e3c21a231d813aa75dd1ea90a15403c5ac1b0b33"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Vladimir Sumarov	fix test to include new game capture options
Vladimir	Build with platform (#555)
Vladimir	Update libobs to v24.17.5 (#553)
Vladimir Sumarov	change gamecapture scale to make it fit to output
Pablo	Change Mocha test reporter to list (#546)
Pablo Damasceno	Update failure report
Pablo Damasceno	Add custom list reporter for mocha
Pablo	Isolate test cases and abstract necessary code (#545)
Pablo Damasceno	Add autoconfig step as attribute of getNextProgressInfo
Pablo Damasceno	Instantiate services only when needed
Pablo Damasceno	Reorganize autoconfig test cases
Pablo Damasceno	Use OBS handler filter types in osn-source Set and GetEnable test case
Pablo Damasceno	Remove publish test results step
Pablo Damasceno	Isolate test cases and abstract necessary code
Pablo	Update services.ts to reflect latest changes to user pool (#551)
Pablo Damasceno	Update services.ts to reflect latest changes to user pool
Pablo	Update electron-mocha to 8.1.2 (#543)