### PR TITLE
logging: improve error logging

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -248,7 +248,7 @@ if (Utils.isDevMode()) {
 // ERRORS LOGGING
 
 function logError(...args: unknown[]) {
-  ipcRenderer.send('showErrorAlert');
+  if (Utils.isDevMode()) ipcRenderer.send('showErrorAlert');
   electronLog.error(...args);
 }
 
@@ -261,4 +261,4 @@ Object.assign(console, {
 });
 
 // catch and log unhandled errors/rejected promises:
-electronLog.catchErrors({ onError: () => ipcRenderer.send('showErrorAlert') });
+electronLog.catchErrors({ onError: () => Utils.isDevMode() && ipcRenderer.send('showErrorAlert') });

--- a/app/app.ts
+++ b/app/app.ts
@@ -247,41 +247,18 @@ if (Utils.isDevMode()) {
 
 // ERRORS LOGGING
 
-// catch and log unhandled errors/rejected promises:
-electronLog.catchErrors({ onError: e => electronLog.log(`from ${Utils.getWindowId()}`, e) });
-
-// override console.error
-const consoleError = console.error;
-console.error = function(...args: any[]) {
-  if (Utils.isDevMode()) ipcRenderer.send('showErrorAlert');
-  writeErrorToLog(...args);
-  consoleError.call(console, ...args);
-};
-
-/**
- * Try to serialize error arguments and stack and write them to the log file
- */
-function writeErrorToLog(...errors: (Error | string)[]) {
-  let message = '';
-
-  // format error arguments depending on the type
-  const formattedErrors = errors.map(error => {
-    if (error instanceof Error) {
-      message = error.stack;
-    } else if (typeof error === 'string') {
-      message = error;
-    } else {
-      try {
-        message = JSON.stringify(error);
-      } catch (e) {
-        message = 'UNSERIALIZABLE';
-      }
-    }
-    return message;
-  });
-
-  // send error to the main process via IPC
-  electronLog.error(`Error from ${Utils.getWindowId()} window:
-    ${formattedErrors.join('\n')}
-  `);
+function logError(...args: unknown[]) {
+  ipcRenderer.send('showErrorAlert');
+  electronLog.error(...args);
 }
+
+// override console
+Object.assign(console, {
+  log: electronLog.log,
+  warn: electronLog.warn,
+  info: electronLog.info,
+  error: logError,
+});
+
+// catch and log unhandled errors/rejected promises:
+electronLog.catchErrors({ onError: () => ipcRenderer.send('showErrorAlert') });


### PR DESCRIPTION
- get rid of duplicated errors
- both `console.log` and `console.error` go through `electronLog`, so it should respect the order of messages