### PR TITLE
strictNullsCheck migration: core

### DIFF
--- a/app/services/core/persistent-stateful-service.ts
+++ b/app/services/core/persistent-stateful-service.ts
@@ -20,7 +20,7 @@ export abstract class PersistentStatefulService<TState extends object> extends S
   static defaultState = {};
 
   static get initialState() {
-    const persisted = JSON.parse(localStorage.getItem(this.localStorageKey)) || {};
+    const persisted = JSON.parse(localStorage.getItem(this.localStorageKey) as string) || {};
 
     return merge({}, this.defaultState, persisted);
   }

--- a/app/services/core/stateful-service.ts
+++ b/app/services/core/stateful-service.ts
@@ -94,7 +94,7 @@ export function inheritMutations(target: any) {
       registerMutation(
         target.prototype,
         methodName,
-        Object.getOwnPropertyDescriptor(target.prototype, methodName),
+        Object.getOwnPropertyDescriptor(target.prototype, methodName) as PropertyDescriptor,
         baseClassProto.mutationOptions[methodName],
       );
     });

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,9 @@ jobs:
     - script: 'yarn lint'
       displayName: 'TSLint'
 
+    - script: 'yarn compile:strictnulls'
+      displayName: 'Check regressions in files with strictNullChecks'
+
     - script: 'yarn compile:ci'
       displayName: 'Compile Assets'
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "compile:ci": "yarn clear && yarn compile:updater && yarn webpack-cli --config dev.config.js",
     "compile:production": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config prod.config.js",
     "compile:updater": "rimraf updater/build && tsc -p updater",
+    "compile:strictnulls": "yarn clear && yarn compile:updater && yarn webpack-cli --progress --config strict-null-check.config.js",
     "webpack-cli": "node --max-old-space-size=4096 node_modules/webpack-cli/bin/cli.js",
     "watch": "yarn clear && yarn compile:updater && yarn webpack-cli --watch --progress --config dev.config.js",
     "watch-app": "yarn clear && yarn webpack-cli --watch --progress --config dev-app.config.js",

--- a/strict-null-check-files/core.json
+++ b/strict-null-check-files/core.json
@@ -1,0 +1,8 @@
+{
+  "ts": [
+    "app/services/core/*.ts"
+  ],
+  "tsx": [
+
+  ]
+}

--- a/strict-null-check.config.js
+++ b/strict-null-check.config.js
@@ -1,5 +1,19 @@
 const merge = require('webpack-merge');
 const baseConfig = require('./base.config.js');
+const path = require('path');
+const fs = require('fs');
+
+// read all files eligible for the strictNulls checking
+const filesPath = 'strict-null-check-files';
+const files = fs.readdirSync(filesPath);
+const tsFiles = [];
+const tsxFiles = [];
+files.forEach(file => {
+  const json = JSON.parse(fs.readFileSync(`${filesPath}/${file}`));
+  if (json.ts) tsFiles.push(...json.ts);
+  if (json.tsx) tsxFiles.push(...json.tsx);
+});
+
 
 module.exports = merge.smart(baseConfig, {
   entry: {
@@ -8,6 +22,7 @@ module.exports = merge.smart(baseConfig, {
     'guest-api': './guest-api'
   },
 
+  mode: 'development',
   watchOptions: { ignored: /node_modules/ },
 
   optimization: {
@@ -21,11 +36,32 @@ module.exports = merge.smart(baseConfig, {
         loader: 'awesome-typescript-loader',
         options: {
           useCache: true,
-          reportFiles: ['app/services/core/*.ts'],
+          reportFiles: [
+            ...tsFiles
+          ],
           strictNullChecks: true
         },
         exclude: /node_modules|vue\/src/
       },
-    ]
+      {
+        test: /\.tsx$/,
+        include: path.resolve(__dirname, 'app/components'),
+        loader: [
+          'babel-loader',
+          {
+            loader: 'awesome-typescript-loader',
+            options: {
+              forceIsolatedModules: true,
+              reportFiles: [
+                ...tsxFiles
+              ],
+              configFileName: 'tsxconfig.json',
+              instance: 'tsx-loader'
+            }
+          }
+        ],
+        exclude: /node_modules/,
+      },
+    ],
   }
 });

--- a/strict-null-check.config.js
+++ b/strict-null-check.config.js
@@ -1,0 +1,31 @@
+const merge = require('webpack-merge');
+const baseConfig = require('./base.config.js');
+
+module.exports = merge.smart(baseConfig, {
+  entry: {
+    renderer: './app/app.ts',
+    updater: './updater/ui.js',
+    'guest-api': './guest-api'
+  },
+
+  watchOptions: { ignored: /node_modules/ },
+
+  optimization: {
+    usedExports: true,
+  },
+
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        loader: 'awesome-typescript-loader',
+        options: {
+          useCache: true,
+          reportFiles: ['app/services/core/*.ts'],
+          strictNullChecks: true
+        },
+        exclude: /node_modules|vue\/src/
+      },
+    ]
+  }
+});


### PR DESCRIPTION
To enable strict nulls checking for files in the next PR you need to add a new json file into the `strict-null-check-files` folder with next shape:
```
{
  "ts": [
    "app/services/service-name/**/*.ts"
  ],
  "tsx": [
    "app/components/component-name/**/*.tsx"
  ]
}
```