### PR TITLE
Update osn to v0.5.47_t1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47_t1-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7049,9 +7049,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47_t1-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-v0.5.37-iojs-v6.0.3-release.tar.gz#8d17624f9b0a78c320e4d32e2583bdd80627c21e"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.47_t1-iojs-v6.0.3-release.tar.gz#21570797261c6162746579f8d727851585a4a2b1"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Vladimir	Update util-crashmanager.cpp
Vladimir Sumarov	Update libobs to v24.17.5_t1
Pablo	Get LIBOBS_VERSION from azure script (#544)
Pablo	Add log and error functions (#549)
Pablo Damasceno	Add more stream key related logs
Pablo Damasceno	Update obs handler call on all tests
Pablo Damasceno	Add logs to obs handler and services
Pablo Damasceno	Add log and error functions
Pablo	Change Mocha test reporter to list (#546)
Pablo Damasceno	Update failure report
Pablo Damasceno	Add custom list reporter for mocha
Pablo	Isolate test cases and abstract necessary code (#545)
Pablo Damasceno	Add autoconfig step as attribute of getNextProgressInfo
Pablo Damasceno	Instantiate services only when needed
Pablo Damasceno	Reorganize autoconfig test cases
Pablo Damasceno	Use OBS handler filter types in osn-source Set and GetEnable test case
Pablo Damasceno	Remove publish test results step
Pablo Damasceno	Isolate test cases and abstract necessary code
Pablo	Update services.ts to reflect latest changes to user pool (#551)
Pablo Damasceno	Update services.ts to reflect latest changes to user pool
Pablo	Update electron-mocha to 8.1.2 (#543)