### PR TITLE
Fix for selective recording test

### DIFF
--- a/test/recording.ts
+++ b/test/recording.ts
@@ -34,7 +34,7 @@ test('Recording', async t => {
 
     // Stop recording
     await app.client.click('.record-button');
-    await app.client.waitForVisible('.record-button:not(.active)', 15000);
+    await app.client.waitForVisible('.record-button:not(.active)', 60000);
 
     // Wait to ensure that output setting are editable
     await sleep(2000);

--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -46,7 +46,7 @@ test('Selective Recording', async t => {
 
   // Stop recording
   await client.click('.record-button');
-  await client.waitForVisible('.record-button:not(.active)', 15000);
+  await client.waitForVisible('.record-button:not(.active)', 60000);
 
   // Check that file exists
   const files = await readdir(tmpDir);

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -398,7 +398,7 @@ test('Recording when streaming', async t => {
 
   // Stop recording
   await app.client.click('.record-button');
-  await app.client.waitForVisible('.record-button:not(.active)', 15000);
+  await app.client.waitForVisible('.record-button:not(.active)', 60000);
 
   // check that recording has been created
   const files = await readdir(tmpDir);


### PR DESCRIPTION
Software encoding in tests with default setting takes more than 100% of CPU on azure CI servers. It leads to longer stopping of recording as it have to complete processing recorded frames before stopping. 
Next libobs release has it even slower, and it may exceed 15sec. 

Timeouts for stopping of recording increased to make tests pass. 


 