### PR TITLE
Update osn to v0.5.51

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.50-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "font-manager": "https://github.com/stream-labs/font-manager/releases/download/v1.0.8electron6/iojs-v6.0.3-font-manager.tar.gz",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51b-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/test/recording.ts
+++ b/test/recording.ts
@@ -34,7 +34,7 @@ test('Recording', async t => {
 
     // Stop recording
     await app.client.click('.record-button');
-    await app.client.waitForVisible('.record-button:not(.active)', 60000);
+    await app.client.waitForVisible('.record-button:not(.active)', 15000);
 
     // Wait to ensure that output setting are editable
     await sleep(2000);

--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -37,7 +37,7 @@ test('Selective Recording', async t => {
   // Check that source is set to record only
   t.true(await client.isExisting('.sl-vue-tree-sidebar .source-selector-action.icon-studio'));
 
-  // Start recording
+  // Start recording and wait
   await client.click('.record-button');
   await sleep(2000);
 

--- a/test/selective-recording.ts
+++ b/test/selective-recording.ts
@@ -46,7 +46,7 @@ test('Selective Recording', async t => {
 
   // Stop recording
   await client.click('.record-button');
-  await client.waitForVisible('.record-button:not(.active)', 60000);
+  await client.waitForVisible('.record-button:not(.active)', 15000);
 
   // Check that file exists
   const files = await readdir(tmpDir);

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -398,7 +398,7 @@ test('Recording when streaming', async t => {
 
   // Stop recording
   await app.client.click('.record-button');
-  await app.client.waitForVisible('.record-button:not(.active)', 60000);
+  await app.client.waitForVisible('.record-button:not(.active)', 15000);
 
   // check that recording has been created
   const files = await readdir(tmpDir);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7447,9 +7447,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51b-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz#ba456a0dcf31bf1a9464e205ef7c01eeb381631b"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51b-iojs-v6.0.3-release.tar.gz#874b258ccb4a1cb464e1637ac35348ca0562d94b"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7447,9 +7447,9 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.50-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.50-iojs-v6.0.3-release.tar.gz#6b385bd6ef3786a3a848410565d126c9948a8cfd"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.51-iojs-v6.0.3-release.tar.gz#ba456a0dcf31bf1a9464e205ef7c01eeb381631b"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Vladimir	Update libobs to v24.17.8 (#579)
Pablo	Add osn-volmeter test error messages (#570)
Pablo	Add osn-video test error messages (#569)
Pablo	Add osn-transition test error messages (#568)
Pablo	Add osn-sceneitem test error messages (#566)
Pablo	Add osn-scene test error messages (#565)
Pablo	Add osn-global test error messages (#562)
Pablo	Add osn-source test error messages (#567)
Pablo Damasceno	Add osn-source test error messages
Pablo	Add osn-input test error messages (#563)
Pablo	Add osn-filter test error messages (#561)
Pablo Damasceno	Add osn-filter test error messages
Pablo	Add osn-fader test error messages (#560)
Pablo Damasceno	Add osn-fader test error messages
Pablo	Add nodeobs_settings test error messages (#559)
Pablo Damasceno	Add nodeobs_settings test error messages
Pablo	Add nodeobs_autoconfig test error messages (#557)
Pablo Damasceno	Add nodeobs_autoconfig test error messages
Pablo	Add nodeobs_service test error messages (#558)
Pablo	Add nodeobs_api test error messages (#556)
Pablo Damasceno	Check match result in list-reporter to prevent test lockup
Pablo Damasceno	Add missing SHOW and HIDE ndi_source hotkeys
Pablo Damasceno	Add error messages to nodeobs_api test
Pablo Damasceno	Add nodeobs_service test error messages
Pablo Damasceno	Add osn-global test error messages
Pablo Damasceno	Add osn-input test error messages
Pablo Damasceno	Add osn-scene test error messages
Pablo Damasceno	Add osn-sceneitem test error messages
Pablo Damasceno	Add osn-transition test error messages
Pablo Damasceno	Add osn-video test error messages
Pablo Damasceno	Add osn-volmeter test error messages