### PR TITLE
Revert "logging: improve error logging"

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -247,18 +247,41 @@ if (Utils.isDevMode()) {
 
 // ERRORS LOGGING
 
-function logError(...args: unknown[]) {
-  if (Utils.isDevMode()) ipcRenderer.send('showErrorAlert');
-  electronLog.error(...args);
-}
-
-// override console
-Object.assign(console, {
-  log: electronLog.log,
-  warn: electronLog.warn,
-  info: electronLog.info,
-  error: logError,
-});
-
 // catch and log unhandled errors/rejected promises:
-electronLog.catchErrors({ onError: () => Utils.isDevMode() && ipcRenderer.send('showErrorAlert') });
+electronLog.catchErrors({ onError: e => electronLog.log(`from ${Utils.getWindowId()}`, e) });
+
+// override console.error
+const consoleError = console.error;
+console.error = function(...args: any[]) {
+  if (Utils.isDevMode()) ipcRenderer.send('showErrorAlert');
+  writeErrorToLog(...args);
+  consoleError.call(console, ...args);
+};
+
+/**
+ * Try to serialize error arguments and stack and write them to the log file
+ */
+function writeErrorToLog(...errors: (Error | string)[]) {
+  let message = '';
+
+  // format error arguments depending on the type
+  const formattedErrors = errors.map(error => {
+    if (error instanceof Error) {
+      message = error.stack;
+    } else if (typeof error === 'string') {
+      message = error;
+    } else {
+      try {
+        message = JSON.stringify(error);
+      } catch (e) {
+        message = 'UNSERIALIZABLE';
+      }
+    }
+    return message;
+  });
+
+  // send error to the main process via IPC
+  electronLog.error(`Error from ${Utils.getWindowId()} window:
+    ${formattedErrors.join('\n')}
+  `);
+}


### PR DESCRIPTION
>Here is the summary of issues I have with current logging:
Some errors get suppressed completely (seems to be some specific vue errors like v-on handler issues)
Electron log completely ruins tracability of exceptions by not showing the original stack trace with sources mapped.
Some objects in log messages are serialized extremely strangely like arrays





My recommendation would be to revert the latest round of log changes.  It makes things
Reverts stream-labs/streamlabs-obs#2348