### PR TITLE
Expose recording/replay buffer status changes to external-api

### DIFF
--- a/app/services/api/external-api/streaming/streaming.ts
+++ b/app/services/api/external-api/streaming/streaming.ts
@@ -50,6 +50,14 @@ export class StreamingService implements ISerializable {
     return this.streamingService.streamingStatusChange;
   }
 
+  get recordingStatusChange(): Observable<ERecordingState> {
+    return this.streamingService.recordingStatusChange;
+  }
+
+  get replayBufferStatusChange(): Observable<EReplayBufferState> {
+    return this.streamingService.replayBufferStatusChange;
+  }
+
   /**
    * returns current streaming/recording status
    */


### PR DESCRIPTION
First PR, so I'm not sure if this is setup correctly, couldn't find much info on contribution to this project.

Simple change, exposes recording and replay buffer statuses to the external api, instead of just streaming statuses.