### PR TITLE
Add Facebook to viewercount widget

### DIFF
--- a/app/components/widgets/ViewerCount.vue
+++ b/app/components/widgets/ViewerCount.vue
@@ -5,6 +5,7 @@
         <bool-input title="Twitch Viewers" v-model="wData.settings.twitch "/>
         <bool-input title="Youtube Viewers" v-model="wData.settings.youtube"/>
         <bool-input title="Mixer Viewers" v-model="wData.settings.mixer"/>
+        <bool-input title="Facebook Viewers" v-model="wData.settings.facebook"/>
       </v-form-group>
       <v-form-group title="Background Color" type="color" v-model="wData.settings.background_color" />
     </validated-form>

--- a/app/services/widgets/settings/viewer-count.ts
+++ b/app/services/widgets/settings/viewer-count.ts
@@ -17,6 +17,7 @@ interface IViewerCountSettings extends IWidgetSettings {
   twitch: boolean;
   youtube: boolean;
   mixer: boolean;
+  facebook: boolean;
 }
 
 export interface IViewerCountData extends IWidgetData {
@@ -49,6 +50,7 @@ export class ViewerCountService extends WidgetSettingsService<IViewerCountData> 
         twitch: data.settings.types.twitch.enabled,
         youtube: data.settings.types.youtube.enabled,
         mixer: data.settings.types.mixer.enabled,
+        facebook: data.settings.types.facebook.enabled,
       },
     };
   }
@@ -61,6 +63,7 @@ export class ViewerCountService extends WidgetSettingsService<IViewerCountData> 
         youtube: { enabled: settings.youtube },
         mixer: { enabled: settings.mixer },
         twitch: { enabled: settings.twitch },
+        facebook: { enabled: settings.facebook },
       },
     };
   }


### PR DESCRIPTION
This has not been pushed live to the website yet but will support it once it does. 
Awaiting to push live on website so these go out at the same time.