### PR TITLE
Improve error logging

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -27,6 +27,7 @@ import electronLog from 'electron-log';
 import { UserService, setSentryContext } from 'services/user';
 import { getResource } from 'services';
 import * as obs from '../obs-api';
+import fs from 'fs';
 import path from 'path';
 import uuid from 'uuid/v4';
 import Blank from 'components/windows/Blank.vue';
@@ -61,6 +62,18 @@ if (isProduction) {
 }
 
 let usingSentry = false;
+
+const logDir = path.join(electron.remote.app.getPath('userData'), 'logs');
+
+electronLog.transports.file.file = path.join(logDir, `${Utils.getWindowId()}.log`);
+
+console.log = electronLog.log;
+console.warn = electronLog.warn;
+console.error = electronLog.error;
+
+console.log('=================================');
+console.log(`Streamlabs OBS: ${slobsVersion}`);
+console.log('=================================');
 
 if (
   (isProduction || process.env.SLOBS_REPORT_TO_SENTRY) &&
@@ -272,40 +285,4 @@ if (Utils.isDevMode()) {
 // ERRORS LOGGING
 
 // catch and log unhandled errors/rejected promises:
-electronLog.catchErrors({ onError: e => electronLog.log(`from ${Utils.getWindowId()}`, e) });
-
-// override console.error
-const consoleError = console.error;
-console.error = function(...args: any[]) {
-  if (Utils.isDevMode()) ipcRenderer.send('showErrorAlert');
-  writeErrorToLog(...args);
-  consoleError.call(console, ...args);
-};
-
-/**
- * Try to serialize error arguments and stack and write them to the log file
- */
-function writeErrorToLog(...errors: (Error | string)[]) {
-  let message = '';
-
-  // format error arguments depending on the type
-  const formattedErrors = errors.map(error => {
-    if (error instanceof Error) {
-      message = error.stack;
-    } else if (typeof error === 'string') {
-      message = error;
-    } else {
-      try {
-        message = JSON.stringify(error);
-      } catch (e) {
-        message = 'UNSERIALIZABLE';
-      }
-    }
-    return message;
-  });
-
-  // send error to the main process via IPC
-  electronLog.error(`Error from ${Utils.getWindowId()} window:
-    ${formattedErrors.join('\n')}
-  `);
-}
+electronLog.catchErrors();

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -126,7 +126,6 @@ export class AppService extends StatefulService<IAppState> {
     if (!this.userService.isLoggedIn) {
       // If this user is logged in, this would have already happened as part of login
       // TODO: We should come up with a better way to handle this.
-      console.log('Init: scene collections');
       await this.sceneCollectionsService.initialize();
     }
 

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -126,6 +126,7 @@ export class AppService extends StatefulService<IAppState> {
     if (!this.userService.isLoggedIn) {
       // If this user is logged in, this would have already happened as part of login
       // TODO: We should come up with a better way to handle this.
+      console.log('Init: scene collections');
       await this.sceneCollectionsService.initialize();
     }
 

--- a/main.js
+++ b/main.js
@@ -28,11 +28,6 @@ const overlay = require('@streamlabs/game-overlay');
 // We use a special cache directory for running tests
 if (process.env.SLOBS_CACHE_DIR) {
   app.setPath('appData', process.env.SLOBS_CACHE_DIR);
-  electronLog.transports.file.file = path.join(
-    process.env.SLOBS_CACHE_DIR,
-    'slobs-client',
-    'log.log'
-  );
 }
 
 app.setPath('userData', path.join(app.getPath('appData'), 'slobs-client'));

--- a/test/helpers/spectron/index.ts
+++ b/test/helpers/spectron/index.ts
@@ -313,7 +313,7 @@ export function useSpectron(options: ITestRunnerOptions = {}) {
   });
 
   test.afterEach.always(async t => {
-    await checkErrorsInLogFile();
+    await checkErrorsInAllLogFiles();
     if (!testPassed && options.pauseIfFailed) {
       console.log('Test execution has been paused due `pauseIfFailed` enabled');
       await sleep(ALMOST_INFINITY);


### PR DESCRIPTION
- Don't route all error handling through the main process
- Each process gets its own log
- All log messages, including errors, go to the log files
- Make it obvious where an app restart happens in the log file
- Some hardware information is logged in the main process log