### PR TITLE
fix notifications issue related to services worker race condition

### DIFF
--- a/app/components/NotificationsArea.vue.ts
+++ b/app/components/NotificationsArea.vue.ts
@@ -50,10 +50,6 @@ export default class NotificationsArea extends Vue {
 
       this.showExtendedNotifications = this.$refs.notificationsContainer.offsetWidth >= 150;
     }, 1000);
-
-    if (this.notificationsService.state.notifications.length) {
-      this.notificationsService.state.notifications.forEach(this.onNotificationHandler);
-    }
   }
 
   destroyed() {


### PR DESCRIPTION
This is a services worker issue.  Description of the issue.
- Notifications service is a persistent stateful service because it has some settings it needs to store
- As a side effect, we also persist notifications from last session in this storage
- The notifications service works around this by clearing all notifications when it runs `init`
- The notifications area component "plays" all existing notifications when it mounts
- Due to services worker we have a race condition:
  1) Store is initialized with state from storage including notifications from previous session
  2) Main window loads in and renders footer, which plays all notifications
  3) Notifications service clears notifications from last session, but it is too late
- This is due to the fact that it is possible to access state of a service that has not been fully initialized in the worker window yet.

The fix:
- Remove the functionality that "plays" existing notifications in state when the footer is mounted.  I'm not sure why we added this functionality but it's actually not needed.  We should just be playing notifications as they coming in, and not worry about past ones.