### PR TITLE
tests: try to fix recording tests

### DIFF
--- a/test/recording.ts
+++ b/test/recording.ts
@@ -2,7 +2,7 @@ import { readdir } from 'fs-extra';
 import { focusChild, focusMain, test, useSpectron } from './helpers/spectron';
 import { setFormDropdown } from './helpers/spectron/forms';
 import { sleep } from './helpers/sleep';
-import { setTemporaryRecordingPath } from './helpers/spectron/output';
+import { setOutputResolution, setTemporaryRecordingPath } from './helpers/spectron/output';
 
 useSpectron();
 
@@ -10,6 +10,9 @@ test('Recording', async t => {
 
   const { app } = t.context;
   const tmpDir = await setTemporaryRecordingPath(t);
+
+  // low resolution reduces CPU usage
+  await setOutputResolution(t, '100x100');
 
   const formats = ['flv', 'mp4', 'mov', 'mkv', 'ts', 'm3u8'];
 

--- a/test/replay-buffer.ts
+++ b/test/replay-buffer.ts
@@ -4,12 +4,13 @@ import { mkdtemp, readdir } from 'fs-extra';
 import { focusChild, focusMain, test, useSpectron } from './helpers/spectron';
 import { setFormDropdown, setFormInput } from './helpers/spectron/forms';
 import { sleep } from './helpers/sleep';
-import { setTemporaryRecordingPath } from './helpers/spectron/output';
+import { setOutputResolution, setTemporaryRecordingPath } from './helpers/spectron/output';
 
 useSpectron();
 
 test('Replay Buffer', async t => {
   const tmpDir = await setTemporaryRecordingPath(t);
+  await setOutputResolution(t, '100x100');
   const { client } = t.context.app;
 
   await client.click('button .icon-replay-buffer');


### PR DESCRIPTION
Recording tests use 100% CPU. That could make SLOBS responsible.
Using lower resolution should decrease the CPU usage  