### PR TITLE
bundle releases v2

### DIFF
--- a/base.config.js
+++ b/base.config.js
@@ -3,6 +3,7 @@ const { CheckerPlugin } = require('awesome-typescript-loader');
 const webpack = require('webpack');
 const cp = require('child_process');
 const ManifestPlugin = require('webpack-manifest-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const plugins = process.env.SLOBS_FORKED_TYPECHECKING ? [new CheckerPlugin()] : [];
 
@@ -22,6 +23,8 @@ plugins.push(
     filter: file => file.isChunk,
   }),
 );
+
+plugins.push(new CleanWebpackPlugin());
 
 // uncomment and install to watch circular dependencies
 // const CircularDependencyPlugin = require('circular-dependency-plugin');

--- a/base.config.js
+++ b/base.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { CheckerPlugin } = require('awesome-typescript-loader');
 const webpack = require('webpack');
 const cp = require('child_process');
+const ManifestPlugin = require('webpack-manifest-plugin');
 
 const plugins = process.env.SLOBS_FORKED_TYPECHECKING ? [new CheckerPlugin()] : [];
 
@@ -13,6 +14,12 @@ const commit = cp
 plugins.push(
   new webpack.DefinePlugin({
     SLOBS_BUNDLE_ID: JSON.stringify(commit),
+  }),
+);
+
+plugins.push(
+  new ManifestPlugin({
+    filter: file => file.isChunk,
   }),
 );
 
@@ -170,6 +177,7 @@ module.exports = {
     splitChunks: {
       chunks: chunk => chunk.name === 'renderer',
     },
+    moduleIds: 'hashed',
   },
 
   plugins,

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <link href="vendor/roboto.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="vendor/fontawesome-free-5.1.0-web/css/all.css" />
     <link rel="stylesheet" href="vendor/flexboxgrid.min.css" type="text/css" >
-    <script src="https://slobs-cdn.streamlabs.com/bundles/vendors~renderer.js"></script>
-    <script src="https://slobs-cdn.streamlabs.com/bundles/renderer.js"></script>
+    <script defer src="https://slobs-cdn.streamlabs.com/bundles/vendors~renderer.js"></script>
+    <script defer src="https://slobs-cdn.streamlabs.com/bundles/renderer.js"></script>
   </head>
   <body style="background-color: transparent;">
     <div id="app"></div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link href="vendor/roboto.css" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="vendor/fontawesome-free-5.1.0-web/css/all.css" />
     <link rel="stylesheet" href="vendor/flexboxgrid.min.css" type="text/css" >
-    <script src="bundles/vendors~renderer.js"></script>
+    <script src="https://slobs-cdn.streamlabs.com/bundles/vendors~renderer.js"></script>
     <script src="https://slobs-cdn.streamlabs.com/bundles/renderer.js"></script>
   </head>
   <body style="background-color: transparent;">

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "webdriverio": "4.14.1",
     "webpack": "4.26.1",
     "webpack-cli": "3.1.2",
+    "webpack-manifest-plugin": "^2.2.0",
     "webpack-merge": "4.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.5",
     "classnames": "2.2.6",
+    "clean-webpack-plugin": "^3.0.0",
     "css-element-queries": "1.2.2",
     "css-loader": "2.1.1",
     "devtron": "1.4.0",

--- a/prod.config.js
+++ b/prod.config.js
@@ -6,18 +6,24 @@ module.exports = merge.smart(baseConfig, {
   entry: {
     renderer: './app/app.ts',
     updater: './updater/ui.js',
-    'guest-api': './guest-api'
+    'guest-api': './guest-api',
+  },
+
+  output: {
+    filename: '[name].[contenthash].js',
   },
 
   mode: 'production',
   devtool: 'source-map',
 
   optimization: {
-    minimizer: [new TerserPlugin({
-      parallel: true,
-      sourceMap: true,
-      terserOptions: { mangle: false }
-    })],
+    minimizer: [
+      new TerserPlugin({
+        parallel: true,
+        sourceMap: true,
+        terserOptions: { mangle: false },
+      }),
+    ],
     usedExports: true,
-  }
+  },
 });

--- a/prod.config.js
+++ b/prod.config.js
@@ -10,7 +10,10 @@ module.exports = merge.smart(baseConfig, {
   },
 
   output: {
-    filename: '[name].[contenthash].js',
+    filename: chunkData => {
+      return chunkData.chunk.name === 'renderer' ? '[name].[contenthash].js' : '[name].js';
+    },
+    chunkFilename: '[name].[contenthash].js',
   },
 
   mode: 'production',

--- a/updater/bundle-updater.ts
+++ b/updater/bundle-updater.ts
@@ -1,5 +1,6 @@
 import fetch from 'node-fetch';
 import * as electron from 'electron';
+import * as path from 'path';
 
 module.exports = async (basePath: string) => {
   const cdnBase = `https://slobs-cdn.streamlabs.com/${process.env.SLOBS_VERSION}/bundles/`;
@@ -15,32 +16,29 @@ module.exports = async (basePath: string) => {
     useLocalBundles = true;
   }
 
+  const localManifest = require(path.join(`${basePath}/bundles/manifest.json`));
+
+  console.log('Local bundle info:', localManifest);
+
   // Check if bundle updates are available
-  // TODO: In the future, support other bundles than just renderer.js
   // TODO: Cache the latest bundle name for offline use?
-  let latestBundle: string | undefined;
+  let serverManifest: { [bundle: string]: string } | undefined;
 
   if (!useLocalBundles) {
     try {
-      const response = await fetch(`${cdnBase}latest.json`);
+      const response = await fetch(`${cdnBase}manifest.json`);
 
       if (response.status / 100 >= 4) {
-        console.log('Bundle update not available, using local bundles');
+        console.log('Bundle manifest not available, using local bundles');
         useLocalBundles = true;
       } else {
         const parsed = await response.json();
         console.log('Latest bundle info:', parsed);
 
-        latestBundle = parsed.renderer;
-
-        if (parsed.renderer) {
-          latestBundle = parsed.renderer;
-        } else {
-          useLocalBundles = true;
-        }
+        serverManifest = parsed;
       }
     } catch (e) {
-      console.log('Bundle prefetch error', e);
+      console.log('Bundle manifest fetch error', e);
       useLocalBundles = true;
     }
   }
@@ -48,11 +46,18 @@ module.exports = async (basePath: string) => {
   electron.session.defaultSession?.webRequest.onBeforeRequest(
     { urls: ['https://slobs-cdn.streamlabs.com/bundles/*.js'] },
     (request, cb) => {
-      if (useLocalBundles) {
-        cb({ redirectURL: `${localBase}renderer.js` });
-      } else {
-        cb({ redirectURL: `${cdnBase}${latestBundle}` });
+      const bundleName = request.url.split('/')[4];
+
+      if (!useLocalBundles && serverManifest && serverManifest[bundleName]) {
+        if (serverManifest[bundleName] !== localManifest[bundleName]) {
+          console.log(`Newer version of ${bundleName} is available`);
+          cb({ redirectURL: `${cdnBase}${serverManifest[bundleName]}` });
+          return;
+        }
       }
+
+      console.log(`Using local bundle for ${bundleName}`);
+      cb({ redirectURL: `${localBase}${localManifest[bundleName]}` });
     },
   );
 
@@ -60,38 +65,39 @@ module.exports = async (basePath: string) => {
   // If something goes wrong while fetching bundles even when the pre-fetch
   // succeeded, then we restart the app and force it to use local bundles.
 
-  let appRelaunching = false;
+  // TODO
+  // let appRelaunching = false;
 
-  function revertToLocalBundles() {
-    if (appRelaunching) return;
-    appRelaunching = true;
-    console.log('Reverting to local bundles and restarting app');
-    electron.app.relaunch({ args: ['--localBundles'] });
-    electron.app.quit();
-  }
+  // function revertToLocalBundles() {
+  //   if (appRelaunching) return;
+  //   appRelaunching = true;
+  //   console.log('Reverting to local bundles and restarting app');
+  //   electron.app.relaunch({ args: ['--localBundles'] });
+  //   electron.app.quit();
+  // }
 
-  if (!useLocalBundles && latestBundle) {
-    electron.session.defaultSession?.webRequest.onHeadersReceived(
-      { urls: [`${cdnBase}${latestBundle}`] },
-      (info, cb) => {
-        if (info.statusCode / 100 < 4) {
-          cb({});
-          return;
-        }
+  // if (!useLocalBundles && latestBundle) {
+  //   electron.session.defaultSession?.webRequest.onHeadersReceived(
+  //     { urls: [`${cdnBase}${latestBundle}`] },
+  //     (info, cb) => {
+  //       if (info.statusCode / 100 < 4) {
+  //         cb({});
+  //         return;
+  //       }
 
-        console.log(`Caught error fetching bundle with status ${info.statusCode}`);
+  //       console.log(`Caught error fetching bundle with status ${info.statusCode}`);
 
-        revertToLocalBundles();
-      },
-    );
+  //       revertToLocalBundles();
+  //     },
+  //   );
 
-    electron.session.defaultSession?.webRequest.onErrorOccurred(
-      { urls: [`${cdnBase}${latestBundle}`] },
-      info => {
-        console.log('Caught error fetching bundle', info.error);
+  //   electron.session.defaultSession?.webRequest.onErrorOccurred(
+  //     { urls: [`${cdnBase}${latestBundle}`] },
+  //     info => {
+  //       console.log('Caught error fetching bundle', info.error);
 
-        revertToLocalBundles();
-      },
-    );
-  }
+  //       revertToLocalBundles();
+  //     },
+  //   );
+  // }
 };

--- a/updater/bundle-updater.ts
+++ b/updater/bundle-updater.ts
@@ -65,39 +65,38 @@ module.exports = async (basePath: string) => {
   // If something goes wrong while fetching bundles even when the pre-fetch
   // succeeded, then we restart the app and force it to use local bundles.
 
-  // TODO
-  // let appRelaunching = false;
+  let appRelaunching = false;
 
-  // function revertToLocalBundles() {
-  //   if (appRelaunching) return;
-  //   appRelaunching = true;
-  //   console.log('Reverting to local bundles and restarting app');
-  //   electron.app.relaunch({ args: ['--localBundles'] });
-  //   electron.app.quit();
-  // }
+  function revertToLocalBundles() {
+    if (appRelaunching) return;
+    appRelaunching = true;
+    console.log('Reverting to local bundles and restarting app');
+    electron.app.relaunch({ args: ['--localBundles'] });
+    electron.app.quit();
+  }
 
-  // if (!useLocalBundles && latestBundle) {
-  //   electron.session.defaultSession?.webRequest.onHeadersReceived(
-  //     { urls: [`${cdnBase}${latestBundle}`] },
-  //     (info, cb) => {
-  //       if (info.statusCode / 100 < 4) {
-  //         cb({});
-  //         return;
-  //       }
+  if (!useLocalBundles) {
+    electron.session.defaultSession?.webRequest.onHeadersReceived(
+      { urls: [`${cdnBase}*.js`] },
+      (info, cb) => {
+        if (info.statusCode / 100 < 4) {
+          cb({});
+          return;
+        }
 
-  //       console.log(`Caught error fetching bundle with status ${info.statusCode}`);
+        console.log(`Caught error fetching bundle with status ${info.statusCode}`);
 
-  //       revertToLocalBundles();
-  //     },
-  //   );
+        revertToLocalBundles();
+      },
+    );
 
-  //   electron.session.defaultSession?.webRequest.onErrorOccurred(
-  //     { urls: [`${cdnBase}${latestBundle}`] },
-  //     info => {
-  //       console.log('Caught error fetching bundle', info.error);
+    electron.session.defaultSession?.webRequest.onErrorOccurred(
+      { urls: [`${cdnBase}*.js`] },
+      info => {
+        console.log('Caught error fetching bundle', info.error);
 
-  //       revertToLocalBundles();
-  //     },
-  //   );
-  // }
+        revertToLocalBundles();
+      },
+    );
+  }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5374,7 +5374,7 @@ fs-extra@^4.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.1:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -7218,7 +7218,7 @@ lodash@4.17.14, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+"lodash@>=3.5 <5", lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -11623,6 +11623,16 @@ webpack-log@^1.2.0:
     log-symbols "^2.1.0"
     loglevelnext "^1.0.1"
     uuid "^3.1.0"
+
+webpack-manifest-plugin@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.2.0.tgz#19ca69b435b0baec7e29fbe90fb4015de2de4f16"
+  integrity sha512-9S6YyKKKh/Oz/eryM1RyLVDVmy3NSPV0JXMRhZ18fJsq+AwGxUY34X54VNwkzYcEmEkDwNxuEOboCZEebJXBAQ==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    object.entries "^1.1.0"
+    tapable "^1.0.0"
 
 webpack-merge@4.2.1:
   version "4.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,6 +1396,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/anymatch@*":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
+  integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
 "@types/archiver@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@types/archiver/-/archiver-2.1.3.tgz#3370bcfd205dcdef022531f0ae4c1dbce37912ca"
@@ -1537,10 +1542,27 @@
   resolved "https://registry.yarnpkg.com/@types/socket.io-client/-/socket.io-client-1.4.32.tgz#988a65a0386c274b1c22a55377fab6a30789ac14"
   integrity sha512-Vs55Kq8F+OWvy1RLA31rT+cAyemzgm0EWNeax6BWF8H7QiiOYMJIdcwSDdm5LVgfEkoepsWkS+40+WNb7BUMbg==
 
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/tapable@*":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.5.tgz#9adbc12950582aa65ead76bffdf39fe0c27a3c02"
+  integrity sha512-/gG2M/Imw7cQFp8PGvz/SwocNrmKFjFsm5Pb8HdbHkZ1K8pmuPzOX4VeVoiEecFCVf4CsN1r3/BRvx+6sNqwtQ==
+
 "@types/tough-cookie@*":
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.3.tgz#7f226d67d654ec9070e755f46daebf014628e9d9"
   integrity sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==
+
+"@types/uglify-js@*":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.9.0.tgz#4490a140ca82aa855ad68093829e7fd6ae94ea87"
+  integrity sha512-3ZcoyPYHVOCcLpnfZwD47KFLr8W/mpUcgjpf1M4Q78TMJIw7KMAHSjiCLJp1z3ZrBR9pTLbe191O0TldFK5zcw==
+  dependencies:
+    source-map "^0.6.1"
 
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.3"
@@ -1577,6 +1599,27 @@
   integrity sha512-AfSQM1xTO9Ax+u9uSQPDuw69DQ0qA2RMoKHn86jCgWNcwKVUjGMSP4sfSl3JOfcZN8X/gWvn7znVPp2/g9zcJA==
   dependencies:
     "@types/node" "*"
+
+"@types/webpack-sources@*":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"
+  integrity sha512-XyaHrJILjK1VHVC4aVlKsdNN5KBTwufMb43cQs+flGxtPAf/1Qwl8+Q0tp5BwEGaI8D6XT1L+9bSWXckgkjTLw==
+  dependencies:
+    "@types/node" "*"
+    "@types/source-list-map" "*"
+    source-map "^0.6.1"
+
+"@types/webpack@^4.4.31":
+  version "4.41.11"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.11.tgz#7b7f725397d3b630bede05415d34e9ff30d9771f"
+  integrity sha512-PtEZISfBMWL05qOpZN19hztZPt0rPuGQh5sbBP3bB4RrJgzdb0SScn47hdcMaoN1IgaU7NZWeDO6reFcKTK2iQ==
+  dependencies:
+    "@types/anymatch" "*"
+    "@types/node" "*"
+    "@types/tapable" "*"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    source-map "^0.6.0"
 
 "@typescript-eslint/eslint-plugin@^2.11.0":
   version "2.19.2"
@@ -3364,6 +3407,14 @@ clean-stack@^2.0.0:
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.0.0.tgz#301bfa9e8dd2d3d984c0e542f7aa67b996f63e0a"
   integrity sha512-VEoL9Qh7I8s8iHnV53DaeWSt8NJ0g3khMfK6NiCPB7H657juhro+cSw2O88uo3bo0c0X5usamtXk0/Of0wXa5A==
 
+clean-webpack-plugin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz#a99d8ec34c1c628a4541567aa7b457446460c62b"
+  integrity sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==
+  dependencies:
+    "@types/webpack" "^4.4.31"
+    del "^4.1.1"
+
 clean-yaml-object@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz#63fb110dc2ce1a84dc21f6d9334876d010ae8b68"
@@ -4121,7 +4172,7 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-del@^4.0.0:
+del@^4.0.0, del@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/del/-/del-4.1.1.tgz#9e8f117222ea44a31ff3a156c049b99052a9f0b4"
   integrity sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==


### PR DESCRIPTION
- Add contenthash to renderer and vendors bundles
- Use hashed module ids so adding new imports in the app doesn't change module ids therefore changing the vendor bundle
- Use webpack manifest plugin to generate a JSON manifest of bundles generated
- Compare manifest on server with manifest in packaged version
- If server manifest contains newer versions, use them only if contenthashed filename is different from the local version