### PR TITLE
optimize scene items

### DIFF
--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -67,7 +67,10 @@ export class Scene {
   getNode(sceneNodeId: string): TSceneNode | null {
     // try to get a node instance from cache
     const cachedNode = this.scenesService.getNodeFromCache(sceneNodeId);
-    if (cachedNode) return cachedNode;
+    if (cachedNode) {
+      if (cachedNode.sceneId !== this.id) return null;
+      return cachedNode;
+    }
 
     // otherwise create a new instance
     const nodeModel = this.state.nodes.find(

--- a/app/services/scenes/scene.ts
+++ b/app/services/scenes/scene.ts
@@ -65,6 +65,11 @@ export class Scene {
   }
 
   getNode(sceneNodeId: string): TSceneNode | null {
+    // try to get a node instance from cache
+    const cachedNode = this.scenesService.getNodeFromCache(sceneNodeId);
+    if (cachedNode) return cachedNode;
+
+    // otherwise create a new instance
     const nodeModel = this.state.nodes.find(
       sceneItemModel => sceneItemModel.id === sceneNodeId,
     ) as ISceneItem;
@@ -369,11 +374,15 @@ export class Scene {
       if (nodeModel.sceneNodeType === 'folder') {
         this.createFolder(nodeModel.name, { id: nodeModel.id });
       } else {
-        this.ADD_SOURCE_TO_SCENE(nodeModel.id, nodeModel.sourceId, obsSceneItems[itemIndex].id);
-        const item = this.getItem(nodeModel.id)!;
-        item.loadItemAttributes(nodeModel);
+        this.ADD_SOURCE_TO_SCENE(
+          nodeModel.id,
+          nodeModel.sourceId,
+          obsSceneItems[itemIndex].id,
+          nodeModel,
+        );
         itemIndex++;
       }
+      this.scenesService.addItemToCache(this.id, nodeModel.id);
     });
 
     // add items to folders
@@ -475,13 +484,42 @@ export class Scene {
   }
 
   @mutation()
-  private SET_NAME(newName: string) {
-    this.state.name = newName;
-  }
+  private ADD_SOURCE_TO_SCENE(
+    sceneItemId: string,
+    sourceId: string,
+    obsSceneItemId: number,
+    customSceneItem?: ISceneItemInfo,
+  ) {
+    // define default attributes
+    let visible = true;
+    // Position in video space
+    let position = { x: 0, y: 0 };
+    let crop = {
+      top: 0,
+      bottom: 0,
+      left: 0,
+      right: 0,
+    };
+    let locked = false;
+    // Scale between 0 and 1
+    let scale = { x: 1.0, y: 1.0 };
+    let rotation = 0;
+    let streamVisible = true;
+    let recordingVisible = true;
 
-  @mutation()
-  private ADD_SOURCE_TO_SCENE(sceneItemId: string, sourceId: string, obsSceneItemId: number) {
-    this.state.nodes.unshift({
+    // set custom attributes if provided
+    if (customSceneItem) {
+      visible = customSceneItem.visible;
+      position = { x: customSceneItem.x, y: customSceneItem.y };
+      crop = customSceneItem.crop;
+      scale = { x: customSceneItem.scaleX, y: customSceneItem.scaleY };
+      rotation = customSceneItem.rotation || 0;
+      locked = !!customSceneItem.locked;
+      streamVisible = !!customSceneItem.streamVisible;
+      recordingVisible = !!customSceneItem.recordingVisible;
+    }
+
+    const sceneItem: ISceneItem = {
       sceneItemId,
       sourceId,
       obsSceneItemId,
@@ -492,31 +530,31 @@ export class Scene {
 
       transform: {
         // Position in video space
-        position: { x: 0, y: 0 },
-
+        position,
         // Scale between 0 and 1
-        scale: { x: 1.0, y: 1.0 },
-
-        crop: {
-          top: 0,
-          bottom: 0,
-          left: 0,
-          right: 0,
-        },
-
-        rotation: 0,
+        scale,
+        crop,
+        rotation,
       },
+      visible,
+      locked,
+      streamVisible,
+      recordingVisible,
+    };
 
-      visible: true,
-      locked: false,
-      streamVisible: true,
-      recordingVisible: true,
-    });
+    this.state.nodes.unshift(sceneItem);
+    this.state.nodesMap[sceneItemId] = sceneItem;
+  }
+
+  @mutation()
+  private SET_NAME(newName: string) {
+    this.state.name = newName;
   }
 
   @mutation()
   private ADD_FOLDER_TO_SCENE(folderModel: ISceneItemFolder) {
     this.state.nodes.unshift(folderModel);
+    this.state.nodesMap[folderModel.id] = folderModel;
   }
 
   @mutation()
@@ -524,15 +562,11 @@ export class Scene {
     this.state.nodes = this.state.nodes.filter(item => {
       return item.id !== nodeId;
     });
+    delete this.state.nodesMap[nodeId];
   }
 
   @mutation()
   private SET_NODES_ORDER(order: string[]) {
-    // TODO: This is O(n^2)
-    this.state.nodes = order.map(id => {
-      return this.state.nodes.find(item => {
-        return item.id === id;
-      })!;
-    });
+    this.state.nodes = order.map(id => this.state.nodesMap[id]);
   }
 }

--- a/app/services/scenes/scenes.ts
+++ b/app/services/scenes/scenes.ts
@@ -5,7 +5,7 @@ import { Subject } from 'rxjs';
 import { mutation, StatefulService } from 'services/core/stateful-service';
 import { TransitionsService } from 'services/transitions';
 import { WindowsService } from 'services/windows';
-import { Scene, SceneItem } from './index';
+import { Scene, SceneItem, TSceneNode } from './index';
 import { ISource, SourcesService, ISourceAddOptions } from 'services/sources';
 import { Inject } from 'services/core/injector';
 import * as obs from '../../../obs-api';
@@ -14,13 +14,19 @@ import namingHelpers from 'util/NamingHelpers';
 import uuid from 'uuid/v4';
 import { ViewHandler } from 'services/core';
 import { lazyModule } from 'util/lazy-module';
+import { assertIsDefined } from '../../util/properties-type-guards';
 
 export type TSceneNodeModel = ISceneItem | ISceneItemFolder;
 
 export interface IScene {
   id: string;
   name: string;
+
+  // array of nodes with preserved order
   nodes: (ISceneItem | ISceneItemFolder)[];
+
+  // dictionary of nodes where key is nodeId
+  nodesMap: Dictionary<ISceneItem | ISceneItemFolder>;
 }
 
 export interface ISceneNodeAddOptions {
@@ -184,6 +190,16 @@ export class ScenesService extends StatefulService<IScenesState> {
     scenes: {},
   };
 
+  // keeps instances of SceneItem and SceneFolder to speed-up API calls
+  private cachedNodes: Dictionary<TSceneNode> = {};
+
+  /**
+   * return TSceneNode from the cache
+   */
+  getNodeFromCache(id: string): TSceneNode {
+    return this.cachedNodes[id];
+  }
+
   get views() {
     return new ScenesViews(this.state);
   }
@@ -199,12 +215,31 @@ export class ScenesService extends StatefulService<IScenesState> {
   @Inject() private sourcesService: SourcesService;
   @Inject() private transitionsService: TransitionsService;
 
+  protected init() {
+    // subscribe to itemAdded and itemRemoved event to sync cachedNodes
+    this.itemAdded.subscribe(itemModel => {
+      this.addItemToCache(itemModel.sceneId, itemModel.id);
+    });
+    this.itemRemoved.subscribe(itemModel => {
+      delete this.cachedNodes[itemModel.id];
+    });
+  }
+
+  addItemToCache(sceneId: string, itemId: string) {
+    const scene = this.views.getScene(sceneId);
+    assertIsDefined(scene);
+    const node = scene.getNode(itemId);
+    assertIsDefined(node);
+    this.cachedNodes[itemId] = node;
+  }
+
   @mutation()
   private ADD_SCENE(id: string, name: string) {
     Vue.set<IScene>(this.state.scenes, id, {
       id,
       name,
       nodes: [],
+      nodesMap: {},
     });
     this.state.displayOrder.push(id);
   }

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -129,6 +129,7 @@ export function commitMutation(mutation: IMutation) {
 }
 
 const mutationsQueue: IMutation[] = [];
+let timeoutId = 0;
 
 /**
  * Add mutation to the queue so we can send it to the renderer windows along with other
@@ -138,10 +139,11 @@ const mutationsQueue: IMutation[] = [];
 function sendMutationToRendererWindows(mutation: IMutation) {
   // we need to `cloneDeep` to avoid sending modified data from the state
   mutationsQueue.push(cloneDeep(mutation));
-  setTimeout(() => flushMutations());
+  if (!timeoutId) timeoutId = setTimeout(() => flushMutations());
 }
 
 function flushMutations() {
   ipcRenderer.send('vuex-mutation', JSON.stringify(mutationsQueue));
   mutationsQueue.length = 0;
+  timeoutId = 0;
 }

--- a/test/api/selection.ts
+++ b/test/api/selection.ts
@@ -89,9 +89,9 @@ test('Invalid selection', async t => {
   const client = await getClient();
   const scenesService = client.getResource<ScenesService>('ScenesService');
   const selection = client.getResource<SelectionService>('SelectionService');
+  const colorSource = scenesService.activeScene.createAndAddSource('MyColor1', 'color_source');
   const anotherScene = scenesService.createScene('Another scene');
-  const colorFromAnotherScene = anotherScene.createAndAddSource('MyColor', 'color_source');
-  const [colorSource] = scenesService.activeScene.getItems();
+  const colorFromAnotherScene = anotherScene.createAndAddSource('MyColor2', 'color_source');
 
   // invalid ids must be ignored
   selection.select([colorSource.sceneItemId, 'this_is_an_invalid_id']);


### PR DESCRIPTION
frontend-only optimizations for scene-items

- Use a dictionary as storage for `sceneNodes`
- Cache instances of `sceneNodes` to minimize the amount of `new` calls
- reduce the amount of redundant `flushMutations` calls