### PR TITLE
Added performance mode option in source menu

### DIFF
--- a/app/util/menus/EditMenu.ts
+++ b/app/util/menus/EditMenu.ts
@@ -240,6 +240,18 @@ export class EditMenu extends Menu {
 
       this.append({ type: 'separator' });
 
+      this.append({
+        label: $t('Performance Mode'),
+        type: 'checkbox',
+        checked: this.customizationService.state.performanceMode,
+        click: () =>
+          this.customizationService.setSettings({
+            performanceMode: !this.customizationService.state.performanceMode,
+          }),
+      });
+
+      this.append({ type: 'separator' });
+
       const filtersCount = this.sourceFiltersService.getFilters(this.source.sourceId).length;
 
       this.append({


### PR DESCRIPTION
Just like in OBS, you can enable/disable performance mode by right-clicking on the source instead of the scene. This is easier instead of doing this on the scene.