### PR TITLE
silent fallback warning for vue i18n

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -199,6 +199,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     fallbackLocale: 'en-US',
     messages: {},
     silentTranslationWarn: false,
+    silentFallbackWarn: true,
     missing: (language: string, key: string) => {
       if (isProduction) return;
       console.error(`Missing translation found for ${language} -- "${key}"`);

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "vue": "2.6.9",
     "vue-codemirror": "4.0.5",
     "vue-color": "2.7.0",
-    "vue-i18n": "7.6.0",
+    "vue-i18n": "8.17.4",
     "vue-js-modal": "1.3.28",
     "vue-loader": "14.1.1",
     "vue-multiselect": "https://github.com/stream-labs/vue-multiselect.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11712,10 +11712,10 @@ vue-hot-reload-api@^2.2.0:
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.2.4.tgz#683bd1d026c0d3b3c937d5875679e9a87ec6cd8f"
   integrity sha512-e+ThJMYmZg4D9UnrLcr6LQxGu6YlcxkrmZGPCyIN4malcNhdeGGKxmFuM5y6ICMJJxQywLfT8MM1rYZr4LpeLw==
 
-vue-i18n@7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-7.6.0.tgz#8745807756f6ca5090fd85629e9cab99b1c6e442"
-  integrity sha512-IqyGj4nOFrGopCCpRucfMPJSgp5WauuI8HTaAQc7XIpHT7iOH4flndy1g09FiUzidi0lRVKJME+S7sPJny/t/A==
+vue-i18n@8.17.4:
+  version "8.17.4"
+  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.17.4.tgz#d314df7a3fa0780f86cff46a02752668f89b3935"
+  integrity sha512-wpk/drIkPf6gHCtvHc8zAZ1nsWBZ+/OOJYtJxqhYD6CKT0FJAG5oypwgF9kABt30FBWhl8NEb/QY+vaaBARlFg==
 
 vue-js-modal@1.3.28:
   version "1.3.28"


### PR DESCRIPTION
Don't warn when using a fallback translation.  This creates a ton of "noise" in the logs and is expected until translations are complete.