### PR TITLE
ci: fix tests timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,9 @@ jobs:
     - script: yarn install --frozen-lockfile --check-files 2>&1
       displayName: 'Install Dependencies'
 
+    - script: node node_modules/electron/install.js
+      displayName: 'Install Electron'
+
     - script: 'yarn eslint'
       displayName: 'ESLint'
 
@@ -59,6 +62,9 @@ jobs:
     - script: yarn install --frozen-lockfile --check-files 2>&1
       displayName: 'Install Dependencies'
 
+    - script: node node_modules/electron/install.js
+      displayName: 'Install Electron'
+
     - script: 'yarn ci:screentests'
       displayName: 'Snapshot testing'
       env:
@@ -93,6 +99,9 @@ jobs:
 
       - script: yarn install --frozen-lockfile --check-files 2>&1
         displayName: 'Install Dependencies'
+
+      - script: node node_modules/electron/install.js
+        displayName: 'Install Electron'
 
       - script: 'yarn ci:compile'
         displayName: 'Compile Assets'


### PR DESCRIPTION
Sometimes Electron installation silently fails
https://github.com/electron/electron/issues/20731#issuecomment-546616376
Most likely this started happening after we updated Node to v12. According to the commit in the Github issue, this problem doesn't exist in Node `v13.8.0` 
I manually call the `electron/install.js` to fix the issue