### PR TITLE
Add memoryUsage extra parameters to crashReporter

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -35,6 +35,7 @@ import Blank from 'components/windows/Blank.vue';
 import Main from 'components/windows/Main.vue';
 import CustomLoader from 'components/CustomLoader';
 import { MetricsService } from 'services/metrics';
+import { updateMemoryUsageCrashParameters } from 'util/CrashReportingHelpers';
 
 const crashHandler = window['require']('crash-handler');
 
@@ -61,6 +62,10 @@ if (isProduction) {
       processType: 'renderer',
     },
   });
+
+  // Because crashReporter doesn't add any memoryUsage stats,
+  // need to update them regularly to have better picture of memory usage
+  setInterval(updateMemoryUsageCrashParameters, 1000, electron.crashReporter);
 }
 
 let usingSentry = false;

--- a/app/util/CrashReportingHelpers.ts
+++ b/app/util/CrashReportingHelpers.ts
@@ -1,0 +1,58 @@
+import electron from 'electron';
+
+// Utility functions for extending crash reporting functionality
+
+/**
+ * Convert input bytes into string representation with human-redable form with corresponding bytes (KB, MB, GB, etc.) suffix.
+ * @param bytes Input bytes as a number
+ * @param decimals Control length of fractional part of a number.
+ */
+export function beautifyBytes(bytes: number, decimals: number = 2) {
+  const divider = 1024;
+  if (Math.abs(bytes) < divider) {
+    return bytes + ' B';
+  }
+
+  const suffixes = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  let suffixIndex = -1;
+  do {
+    bytes /= divider;
+    ++suffixIndex;
+  } while (Math.abs(bytes) >= divider && suffixIndex < suffixes.length - 1);
+
+  const fractionDigits = decimals < 0 ? 0 : decimals;
+  return bytes.toFixed(fractionDigits) + ' ' + suffixes[suffixIndex];
+}
+
+/**
+ * Helper method to update memory usage stats and commit charge of crashReporter by adding corresponding extra parameters.
+ */
+export function updateMemoryUsageCrashParameters(crashReporter: Electron.CrashReporter) {
+  const memUsage = process.memoryUsage();
+  const heapStats = process.getHeapStatistics();
+  const systemMemInfo = process.getSystemMemoryInfo();
+
+  crashReporter.addExtraParameter('mem_rss', beautifyBytes(memUsage.rss));
+  crashReporter.addExtraParameter('mem_heapUsed', beautifyBytes(memUsage.heapUsed));
+  crashReporter.addExtraParameter('mem_heapTotal', beautifyBytes(memUsage.heapTotal));
+  crashReporter.addExtraParameter('mem_external', beautifyBytes(memUsage.external));
+
+  // all the values from getHeapStatistics() are in kB, thus need to convert manually to bytes
+  crashReporter.addExtraParameter(
+    'mem_totalAvailableSize',
+    beautifyBytes(heapStats.totalAvailableSize * 1024),
+  );
+  crashReporter.addExtraParameter(
+    'mem_heapSizeLimit',
+    beautifyBytes(heapStats.heapSizeLimit * 1024),
+  );
+
+  // calculate commit charge in %
+  // for some reason, the total commit limit (swap + heap)
+  // is stored in swapTotal and swapFree - maybe bug of electron?
+  const commitCharge = (
+    (100 * (systemMemInfo.swapTotal - systemMemInfo.swapFree)) /
+    Math.max(1, systemMemInfo.swapTotal)
+  ).toFixed(2);
+  crashReporter.addExtraParameter('mem_commitCharge', commitCharge + '%');
+}


### PR DESCRIPTION
Add memoryUsage and commit charge extra parameters to renderer's crashReporter in app.ts in order to have better picture of OOM errors on Sentry. Currently implemented as workaround -  Timeout object, which update memory usage stats each second.