### PR TITLE
Update osn to v0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "node-fetch": "^2.6.0",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.137-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.4-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8441,9 +8441,9 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.137-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.4-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.5.137-iojs-v6.0.3-release.tar.gz#90d397eabe662bda7bbd03e9e277472706cfa3d6"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.4-iojs-v6.0.3-release.tar.gz#339a50e1865229545a7df7de41713248f1a2933b"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
EddyGharbi	Update obs 25.0.8 (#635)
Bohdan Kurylovych	Add commit memory limit to sentry logs (#633)
Pablo	Rename services.ts to better represent what it does (#591)
Pablo	Use invalid paths for test cases inside Azure source folder (#632)
Pablo	Increase timeout value of electron-mocha test runner (#625)
Pablo	Fix stream only sources not showing on additional displays (#612)
Pablo	Fix throw of obs init and shutdown errors in tests (#596)
Pablo	Add output type and signal to getNextSignalInfo (#595)
dependabot[bot]	Bump acorn from 5.7.3 to 5.7.4 (#614)
dependabot[bot]	Bump handlebars from 4.1.2 to 4.5.3 (#577)
EddyGharbi	Upgrade cpp standard and fix compilcation error (#630)
Pablo	Add OSN_SECRET_ACCESS_KEY env variable to Debug test run (#631)