### PR TITLE
Fix resizing from the top of the screen

### DIFF
--- a/app/components/TitleBar.m.less
+++ b/app/components/TitleBar.m.less
@@ -7,7 +7,6 @@
   height: 30px;
   flex: 0 0 30px;
   background: var(--titlebar);
-  -webkit-app-region: drag;
 }
 
 .titlebar-icon {
@@ -34,6 +33,7 @@
   flex-grow: 1;
   padding-left: 10px;
   color: var(--icon);
+  -webkit-app-region: drag;
 }
 
 .titlebar-actions {


### PR DESCRIPTION
I think the drag region was changed to the entire titlebar component recently.  We can't do this because if the drag region extends fully to the edge of the window it becomes impossible to resize the window from that edge.