### PR TITLE
MINOR: add `windowId` to crashReporter parameters

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -58,7 +58,7 @@ if (isProduction) {
       'https://sentry.io/api/1283430/minidump/?sentry_key=01fc20f909124c8499b4972e9a5253f2',
     extra: {
       'sentry[release]': slobsVersion,
-      processType: 'renderer',
+      windowId: Utils.getWindowId(),
     },
   });
 }


### PR DESCRIPTION
- add 'windowId' to renderer process crashReporter parameters to distinguish on Sentry which process crashes;
- remove `processType` parameter, as it is provided already by electron in crash logs.