### PR TITLE
fix electron confirm windows for going live / ending stream

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -153,7 +153,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
         buttons: [$t('Cancel'), $t('Go Live')],
       });
 
-      if (!goLive) return;
+      if (!goLive.response) return;
     }
 
     this.powerSaveId = electron.remote.powerSaveBlocker.start('prevent-display-sleep');
@@ -253,7 +253,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
           buttons: [$t('Cancel'), $t('End Stream')],
         });
 
-        if (!endStream) return;
+        if (!endStream.response) return;
       }
 
       if (this.powerSaveId) {


### PR DESCRIPTION
electron dialog boxes return an object, not an integer, and so they were being ignored