### PR TITLE
Update osn to v0.6.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node-fetch": "^2.6.0",
     "node-fontinfo": "https://github.com/stream-labs/node-fontinfo/releases/download/v0.0.12electron6/iojs-v6.0.3-node-fontinfo.tar.gz",
     "node-libuiohook": "https://github.com/stream-labs/node-libuiohook/releases/download/v0.0.14/iojs-v6.0.3-node-libuiohook.tar.gz",
-    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.11-iojs-v6.0.3-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.14-iojs-v6.0.3-release.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8465,9 +8465,9 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.11-iojs-v6.0.3-release.tar.gz":
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.14-iojs-v6.0.3-release.tar.gz":
   version "0.3.99"
-  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.11-iojs-v6.0.3-release.tar.gz#8dd076d60d2ac9c65af09d4319baf0deb6b5f6e1"
+  resolved "https://obsstudionodes3.streamlabs.com/obs-studio-node-0.6.14-iojs-v6.0.3-release.tar.gz#99da42ccdf6083e4af18b9a41c95efd05463bcd9"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
EddyGharbi	Load old amd encoder if the new one failed to load (#648)
EddyGharbi	Update libobs to v25.18.14 (#649)
EddyGharbi	Upgrade some dependencies (#647)
EddyGharbi	Remove dead code in server/osn-source (#646)
EddyGharbi	Remove unused scripts (#645)
EddyGharbi	Use debug version of libobs by default when running tests locally (#644)