### PR TITLE
fix restart command format

### DIFF
--- a/updater/bootstrap.ts
+++ b/updater/bootstrap.ts
@@ -268,7 +268,7 @@ async function entry(info: IUpdateInfo) {
     '--version',
     `"${latestVersion.version}"`,
     '--exec',
-    `"${info.exec}"`,
+    `"${info.exec.join(' ')}"`,
     '--cwd',
     `"${info.cwd}"`,
     '--app-dir',


### PR DESCRIPTION
Instead of "app.exe,param1,param2" send "app.exe param1 param2" what can correctly be used by updater to launch slobs after update is finished. 