### PR TITLE
sentry: save the API request

### DIFF
--- a/app/services/api/internal-api-client.ts
+++ b/app/services/api/internal-api-client.ts
@@ -36,6 +36,8 @@ export class InternalApiClient {
 
   private skippedMutations: number[] = [];
 
+  private windowId = Utils.getWindowId();
+
   constructor() {
     this.listenWorkerWindowMessages();
   }
@@ -141,7 +143,7 @@ export class InternalApiClient {
         this.jsonrpc.createRequestWithOptions(
           isHelper ? target['_resourceId'] : serviceName,
           methodName,
-          { compactMode: true, fetchMutations: true },
+          { compactMode: true, fetchMutations: true, windowId: this.windowId },
           ...args,
         ),
       );

--- a/app/services/api/internal-api.ts
+++ b/app/services/api/internal-api.ts
@@ -1,5 +1,6 @@
 import { RpcApi } from './rpc-api';
 import { IJsonRpcRequest, IJsonRpcResponse } from 'services/api/jsonrpc';
+import * as Sentry from '@sentry/browser';
 
 /**
  * Internal SLOBS API for usage inside SLOBS itself
@@ -21,6 +22,7 @@ export class InternalApiService extends RpcApi {
   ): IJsonRpcResponse<any> {
     // the errors for the child-window API are anomaly
     // re-raise error for Raven to log these errors
+    Sentry.setExtra('API request', request);
     errors
       .filter(e => e instanceof Error)
       .forEach(e => {

--- a/app/services/api/jsonrpc/jsonrpc-api.ts
+++ b/app/services/api/jsonrpc/jsonrpc-api.ts
@@ -20,6 +20,7 @@ export interface IJsonRpcRequest {
     fetchMutations?: boolean;
     compactMode?: boolean;
     noReturn?: boolean;
+    windowId?: string;
   };
 }
 

--- a/app/services/api/jsonrpc/jsonrpc.ts
+++ b/app/services/api/jsonrpc/jsonrpc.ts
@@ -46,7 +46,12 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
   static createRequestWithOptions(
     resourceId: string,
     method: string,
-    options: { compactMode: boolean; fetchMutations: boolean; noReturn?: boolean },
+    options: {
+      compactMode: boolean;
+      fetchMutations: boolean;
+      noReturn?: boolean;
+      windowId?: string;
+    },
     ...args: any[]
   ): IJsonRpcRequest {
     const request = this.createRequest(resourceId, method, ...args);


### PR DESCRIPTION
Save API request and the Id of the window that emitted this request.
