### PR TITLE
Wipe widget data on logout

### DIFF
--- a/app/services/widgets/settings/base-goal.ts
+++ b/app/services/widgets/settings/base-goal.ts
@@ -17,8 +17,8 @@ export abstract class BaseGoalService<
   TGoalData extends IBaseGoalData,
   TGoalCreateOptions
 > extends WidgetSettingsService<TGoalData> {
-  init() {
-    super.init();
+  subToWebsocket() {
+    super.subToWebsocket();
 
     this.websocketService.socketEvent.subscribe(event => {
       const apiSettings = this.getApiSettings();

--- a/app/services/widgets/settings/widget-settings.ts
+++ b/app/services/widgets/settings/widget-settings.ts
@@ -1,7 +1,7 @@
 import cloneDeep from 'lodash/cloneDeep';
 import { HostsService } from 'services/hosts';
 import { Inject } from '../../core/injector';
-import { UserService } from 'services/user';
+import { UserService, LoginLifecycle } from 'services/user';
 import { handleResponse, authorizedHeaders } from '../../../util/requests';
 import {
   IWidgetApiSettings,
@@ -47,7 +47,17 @@ export abstract class WidgetSettingsService<TWidgetData extends IWidgetData>
 
   abstract getApiSettings(): IWidgetApiSettings;
 
-  init() {
+  lifecycle: LoginLifecycle;
+
+  async init() {
+    this.lifecycle = await this.userService.withLifecycle({
+      init: () => Promise.resolve(this.subToWebsocket()),
+      destroy: () => Promise.resolve(this.RESET_WIDGET_DATA()),
+      context: this,
+    });
+  }
+
+  subToWebsocket() {
     this.websocketService.socketEvent.subscribe(event => {
       const apiSettings = this.getApiSettings();
       if (event.type === 'alertProfileChanged') this.onWidgetThemeChange();


### PR DESCRIPTION
Stops users from seeing the wrong data preserved in state when logging into a different platform or account