### PR TITLE
Blackmagic Device Support For MacOS

### DIFF
--- a/app/services/sources/sources.ts
+++ b/app/services/sources/sources.ts
@@ -98,6 +98,7 @@ export const macSources: TSourceType[] = [
   'vlc_source',
   'window_capture',
   'syphon-input',
+  'decklink-input',
 ];
 
 class SourcesViews extends ViewHandler<ISourcesState> {


### PR DESCRIPTION
I have a Blackmagic Mini Recorder using in Mac. But every time I restart Streamlabs it well be remove, and I got a message:

> The scene collection you are loading has sources that are not supported by your current operating system. These sources will be removed before loading the scene collection. A backup of this collection with the original sources preserved has been created with the name: Togo Gaming - Backup

I add 'decklink-input' into macSources list in sources.ts, then it fixed! Please pull this fix and release in next version, thanks!