### PR TITLE
Update osn to v0.7.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "node-fontinfo": "https://slobs-node-fontinfo.s3-us-west-2.amazonaws.com/node-fontinfo-0.0.0.tar.gz",
     "node-libuiohook": "https://slobs-node-libuiohook.s3-us-west-2.amazonaws.com/node-libuiohook-0.0.0.tar.gz",
     "node-window-rendering": "https://slobs-node-window-rendering.s3-us-west-2.amazonaws.com/node-window-rendering-0.0.0.tar.gz",
-    "obs-studio-node": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.0.0-release.tar.gz",
+    "obs-studio-node": "https://obsstudionodes3.streamlabs.com/osn-0.7.10-release-win64.tar.gz",
     "raven": "^2.6.4",
     "request": "^2.88.0",
     "rimraf": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8648,9 +8648,9 @@ object.values@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-"obs-studio-node@https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.0.0-release.tar.gz":
-  version "0.3.99"
-  resolved "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/osn-0.0.0-release.tar.gz#75cce3c4e7ca2b16e1c1a5e209681d4a26979b22"
+"obs-studio-node@https://obsstudionodes3.streamlabs.com/osn-0.7.10-release-win64.tar.gz":
+  version "0.7.10"
+  resolved "https://obsstudionodes3.streamlabs.com/osn-0.7.10-release-win64.tar.gz#a1e2a369db901385d27ef83410a171f3e8051a07"
 
 observable-to-promise@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Vladimir	Impr analytics crash (#693)
Vladimir	fix crash on updating settings while output still initialized (#682)
EddyGharbi	Update libobs to v25.19.11 (#694)
Vladimir	use long ipc wait timeout as a way to detect freez (#687)