### PR TITLE
Multistream fixes

### DIFF
--- a/app/components/windows/go-live/EditStreamWindow.tsx
+++ b/app/components/windows/go-live/EditStreamWindow.tsx
@@ -79,7 +79,7 @@ export default class EditStreamWindow extends TsxComponent<{}> {
     const lifecycle = this.view.info.lifecycle;
     const shouldShowUpdateButton = lifecycle === 'live';
     const shouldShowGoBackButton = !shouldShowUpdateButton && this.view.info.error;
-    const shouldShowAdvancedSwitch = shouldShowUpdateButton && this.view.isMutliplatformMode;
+    const shouldShowAdvancedSwitch = shouldShowUpdateButton && this.view.isMultiplatformMode;
 
     return (
       <div class="controls" style={{ display: 'flex', 'flex-direction': 'row-reverse' }}>

--- a/app/components/windows/go-live/GoLive.m.less
+++ b/app/components/windows/go-live/GoLive.m.less
@@ -35,6 +35,11 @@
   padding-right: 16px;
 }
 
+// window should have less height if only one platform is linked
+.settings-container-one-platform {
+  height: 550px;
+}
+
 .mode-toggle {
   display: flex;
   margin-top: 6px;

--- a/app/components/windows/go-live/GoLiveChecklist.tsx
+++ b/app/components/windows/go-live/GoLiveChecklist.tsx
@@ -68,7 +68,7 @@ export default class GoLiveChecklist extends TsxComponent<Props> {
 
   private render() {
     const checklist = this.view.info.checklist;
-    const { isMutliplatformMode, goLiveSettings } = this.view;
+    const { isMultiplatformMode, goLiveSettings } = this.view;
     const isUpdateMode = this.props.isUpdateMode;
     const shouldPublishYT = !isUpdateMode && goLiveSettings.platforms.youtube?.enabled;
     const shouldShowOptimizedProfile =
@@ -93,7 +93,7 @@ export default class GoLiveChecklist extends TsxComponent<Props> {
 
           {/* RESTREAM */}
           {!isUpdateMode &&
-            isMutliplatformMode &&
+            isMultiplatformMode &&
             this.renderCheck($t('Configure the Restream service'), checklist.setupRestream)}
 
           {/* OPTIMIZED PROFILE */}

--- a/app/components/windows/go-live/GoLiveSettings.tsx
+++ b/app/components/windows/go-live/GoLiveSettings.tsx
@@ -67,8 +67,8 @@ export default class GoLiveSettings extends TsxComponent<GoLiveProps> {
     const isErrorMode = view.info.error;
     const isLoadingMode = !isErrorMode && ['empty', 'prepopulate'].includes(view.info.lifecycle);
     const shouldShowSettings = !isErrorMode && !isLoadingMode && hasPlatforms;
-    const isAdvancedMode = view.goLiveSettings.advancedMode && view.isMutliplatformMode;
-    const shouldShowAddDestination = view.allPlatforms.length !== view.linkedPlatforms.length;
+    const isAdvancedMode = view.goLiveSettings.advancedMode && view.isMultiplatformMode;
+    const shouldShowAddDestination = view.linkedPlatforms.length < 3;
     const shouldShowPrimeLabel = !this.restreamService.state.grandfathered;
     const shouldShowLeftCol = this.streamSettingsService.state.protectedModeEnabled;
     return (

--- a/app/components/windows/go-live/GoLiveSettings.tsx
+++ b/app/components/windows/go-live/GoLiveSettings.tsx
@@ -71,6 +71,7 @@ export default class GoLiveSettings extends TsxComponent<GoLiveProps> {
     const shouldShowAddDestination = view.linkedPlatforms.length < 3;
     const shouldShowPrimeLabel = !this.restreamService.state.grandfathered;
     const shouldShowLeftCol = this.streamSettingsService.state.protectedModeEnabled;
+    const onlyOnePlatformIsLinked = view.linkedPlatforms.length === 1;
     return (
       <ValidatedForm class="flex">
         {/*LEFT COLUMN*/}
@@ -100,7 +101,12 @@ export default class GoLiveSettings extends TsxComponent<GoLiveProps> {
           <GoLiveError />
 
           {shouldShowSettings && (
-            <div class={styles.settingsContainer}>
+            <div
+              class={{
+                [styles.settingsContainer]: true,
+                [styles.settingsContainerOnePlatform]: onlyOnePlatformIsLinked,
+              }}
+            >
               {/*PLATFORM SETTINGS*/}
               <PlatformSettings vModel={this.settings} />
 

--- a/app/components/windows/go-live/GoLiveWindow.tsx
+++ b/app/components/windows/go-live/GoLiveWindow.tsx
@@ -128,7 +128,7 @@ export default class GoLiveWindow extends TsxComponent<{}> {
       this.lifecycle === 'runChecklist' &&
       this.view.info.error &&
       this.view.info.checklist.startVideoTransmission !== 'done';
-    const shouldShowAdvancedSwitch = shouldShowConfirm && this.view.isMutliplatformMode;
+    const shouldShowAdvancedSwitch = shouldShowConfirm && this.view.isMultiplatformMode;
 
     return (
       <div class="controls" style={{ display: 'flex', 'flex-direction': 'row-reverse' }}>

--- a/app/components/windows/go-live/PlatformSettings.tsx
+++ b/app/components/windows/go-live/PlatformSettings.tsx
@@ -81,7 +81,7 @@ export default class PlatformSettings extends TsxComponent<Props> {
    * Renders settings for one platform
    */
   private renderPlatformSettings(platform: TPlatform) {
-    const isAdvancedMode = this.view.goLiveSettings.advancedMode && this.view.isMutliplatformMode;
+    const isAdvancedMode = this.view.goLiveSettings.advancedMode && this.view.isMultiplatformMode;
     const title = $t('%{platform} Settings', { platform: this.getPlatformName(platform) });
     return (
       <Section title={title} isSimpleMode={!isAdvancedMode}>

--- a/app/components/windows/settings/StreamSettings.tsx
+++ b/app/components/windows/settings/StreamSettings.tsx
@@ -131,8 +131,8 @@ export default class StreamSettings extends TsxComponent {
     }[platform];
     const isPrimary = this.streamingView.isPrimaryPlatform(platform);
     const shouldShowPrimaryBtn = isPrimary;
-    const shouldShowConnectBtn = !isMerged;
-    const shouldShowUnlinkBtn = !isPrimary && isMerged;
+    const shouldShowConnectBtn = !isMerged && this.canEditSettings;
+    const shouldShowUnlinkBtn = !isPrimary && isMerged && this.canEditSettings;
     const shouldShowPrimeLabel =
       !this.userService.state.isPrime && !this.restreamService.state.grandfathered;
 

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -94,7 +94,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
   }
 
   get shouldGoLiveWithRestream() {
-    return this.streamInfo.isMutliplatformMode;
+    return this.streamInfo.isMultiplatformMode;
   }
 
   fetchUserSettings() {

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -58,7 +58,7 @@ export class StreamInfoView extends ViewHandler<IStreamingServiceState> {
     ) as TPlatform[];
   }
 
-  get isMutliplatformMode(): boolean {
+  get isMultiplatformMode(): boolean {
     return (
       this.streamSettingsService.state.protectedModeEnabled && this.enabledPlatforms.length > 1
     );

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -252,7 +252,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     }
 
     // setup restream
-    if (this.views.isMutliplatformMode) {
+    if (this.views.isMultiplatformMode) {
       // check the Restream service is available
       let ready = false;
       try {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -645,7 +645,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   }
 
   showGoLiveWindow() {
-    const height = this.views.linkedPlatforms.length > 1 ? 750 : 600;
+    const height = this.views.linkedPlatforms.length > 1 ? 750 : 650;
     const width = 900;
 
     this.windowsService.showWindow({


### PR DESCRIPTION
- Don't show "add destination" button when all platforms are connected
- Smaller GoLive window in the case when the user has only one platform linked
- Fix typo "isMutliplatformMode"
- don't allow to link/unlink platform while being live