### PR TITLE
fix game selector

### DIFF
--- a/app/components/shared/inputs/TagsInput.tsx
+++ b/app/components/shared/inputs/TagsInput.tsx
@@ -92,16 +92,24 @@ export default class TagsInput extends BaseInput<
     // so bind a native listener for the search input
     this.$el.querySelector('input[type=text]').addEventListener('keyup', (e: InputEvent) => {
       this.onSearchChangeHandler(e.currentTarget['value']);
-
-      // vue multiselect don't can't forbid adding tags outside the options list
-      // just hide this option
-      const tagEl = this.$el.querySelector('[data-select="Add this as new tag"]');
-      if (tagEl) tagEl.parentElement.style.display = 'none';
     });
   }
 
   private render() {
     const isEmpty = this.isEmpty;
+    const el = this.$el;
+
+    // a hack that prevents adding tags outside the options list
+    this.$nextTick().then(() => {
+      if (!el) return;
+      const tagEl = el.querySelector('[data-select="Add this as new tag"]');
+      if (tagEl) {
+        el.querySelector('li').style.display = 'none';
+      } else {
+        el.querySelector('li').style.display = 'inline-block';
+      }
+    });
+
     return (
       <div
         class={cx('input-wrapper', styles.container, {


### PR DESCRIPTION
Fixes a bug when the first game from the GameSelector could be hidden

How to reproduce:
- Click Go Live and Enable Twitch and Facebook
- Type "fortnite" in the GameSelector
- Only "Fortnite" from the Twitch list will be shown
- Delete one character in the GameSelector
- Both "Fortnite" options will be shown