### PR TITLE
Update game overlay module version

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -52,7 +52,7 @@
             "name": "game-overlay",
             "url": "https://obs-studio-deployment.s3-us-west-2.amazonaws.com/",
             "archive": "game-overlay-[VERSION].tar.gz",
-            "version": "v0.0.41",
+            "version": "0.0.42",
             "win64": true,
             "osx": false
         }


### PR DESCRIPTION
Removed "v" character from module version number to minimize chance of mistake versions with and without this character as different. 
And to get unification with other our modules . 