### PR TITLE
remove mixer from viewercount widget properties

### DIFF
--- a/app/components/widgets/ViewerCount.vue
+++ b/app/components/widgets/ViewerCount.vue
@@ -4,7 +4,6 @@
       <v-form-group title="Enabled Streams">
         <bool-input title="Twitch Viewers" v-model="wData.settings.twitch "/>
         <bool-input title="YouTube Viewers" v-model="wData.settings.youtube"/>
-        <bool-input title="Mixer Viewers" v-model="wData.settings.mixer"/>
       </v-form-group>
       <v-form-group title="Background Color" type="color" v-model="wData.settings.background_color" />
     </validated-form>


### PR DESCRIPTION
literally just removing mixer from viewercount widget properties. Eric has a ticket to do the same on the site. 