### PR TITLE
fix shouldShowToggles

### DIFF
--- a/app/components/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components/windows/go-live/DestinationSwitchers.tsx
@@ -76,7 +76,7 @@ export class DestinationSwitchers extends TsxComponent<Props> {
 
     // don't show toggle inputs if we have only one platform to stream
     const shouldShowToggles =
-      Object.keys(this.props.platforms).length > 1 || this.props.customDestinations?.length;
+      Object.keys(this.props.platforms).length > 1 || this.props.customDestinations?.length > 0;
     return (
       <div
         class={cx(styles.platformSwitcher, { [styles.platformDisabled]: !enabled })}


### PR DESCRIPTION
if you had no other platforms linked, the value of shouldShowToggles would be a number instead of true or false, causing it to render in the app (see screenshot)

![image](https://user-images.githubusercontent.com/1477223/90939216-13ee1580-e3d9-11ea-89ea-646897ea5afd.png)
