### PR TITLE
[mac] Add Preferences Menu Item

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,9 @@
             "name": "Launch",
             "protocol": "inspector",
             "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd",
+            "osx": {
+                "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
+            },
             "runtimeArgs": [
                 "."
             ],

--- a/app/services/application-menu.ts
+++ b/app/services/application-menu.ts
@@ -7,6 +7,7 @@ import { SelectionService } from './selection';
 import { AppService } from './app';
 import { WindowsService } from './windows';
 import { NavigationService } from './navigation';
+import { SettingsService } from './settings';
 
 /**
  * Manages the application menu and shortcuts on Mac OS
@@ -18,6 +19,7 @@ export class ApplicationMenuService extends Service {
   @Inject() appService: AppService;
   @Inject() windowsService: WindowsService;
   @Inject() navigationService: NavigationService;
+  @Inject() settingsService: SettingsService;
 
   init() {
     if (process.platform !== OS.Mac) return;
@@ -31,7 +33,27 @@ export class ApplicationMenuService extends Service {
   private buildMenu(): electron.Menu {
     // TODO: i18n
     return electron.remote.Menu.buildFromTemplate([
-      { role: 'appMenu' },
+      {
+        label: 'Streamlabs OBS',
+        submenu: [
+          { role: 'about' },
+          {
+            label: 'Preferences…',
+            accelerator: 'Command+,',
+            click: () => {
+              this.settingsService.showSettings();
+            },
+          },
+          { type: 'separator' },
+          { role: 'services' },
+          { type: 'separator' },
+          { role: 'hide' },
+          { role: 'hideOthers' },
+          { role: 'unhide' },
+          { type: 'separator' },
+          { role: 'quit' },
+        ],
+      },
       { role: 'fileMenu' },
       {
         id: 'edit',

--- a/app/services/application-menu.ts
+++ b/app/services/application-menu.ts
@@ -41,6 +41,7 @@ export class ApplicationMenuService extends Service {
             label: 'Preferences…',
             accelerator: 'Command+,',
             click: () => {
+              if (this.appService.state.loading) return;
               this.settingsService.showSettings();
             },
           },


### PR DESCRIPTION
Hello! First off, thank you all for the work you put into Streamlabs OBS. I've been using it since the release for MacOS and I'm a big fan of the work you're doing so thank you for your efforts. I would love to help if I can and as a first contribution would love to add the "Preferences" menu item for MacOS. I'm also here to learn so please let me know how I can adhere to the correct process of contributing code and navigating the codebase.

## Summary

This PR adds the "Preferences" menu item with shortcut key as standard on most Mac desktop apps as well as adheres to [Apple's Human Interface Guidelines for App Menus](https://developer.apple.com/design/human-interface-guidelines/macos/menus/menu-bar-menus#app-menu).

For reference, the [Electron docs](https://github.com/electron/electron/blob/v6.1.11/docs/api/menu.md#main-process) show an example of what `role: 'appMenu'` looks like.

## Open Questions


~I'm currently not able to run the app locally on MacOS properly so if possible please verify my changes~ I was able to very my changes 👍🏻 . Has anyone had success running the app locally on MacOS? I'm still trying to debug but could use some help if anyone has any ideas. It's currently crashing on app load with the following error:

```shell
error: av_capture_input_cd3d656a-5c35-4582-bc84-06e2d656711e: CMMediaType '' is unsupported
[37332:1770501:20200822,130558.997028:WARNING system_snapshot_mac.cc:42] sysctlbyname kern.nx: No such file or directory (2)
[37332:1770501:20200822,130559.006798:WARNING crash_report_exception_handler.cc:239] UniversalExceptionRaise: (os/kern) failure (5)
```

**UPDATE:** It seems to be working now while I was trying to debug. Unclear what it was. My suspicion is it was during the process of reading/writing a Scene Collection data file. 🤔 

**UPDATE 2:** Okay I think I've narrowed it down to calling `obs.createSource` below. More specifically `const newSource = obs.Input.create(source.type, source.name, source.settings);` in the library itself only when adding a "Video Capture Device".

https://github.com/stream-labs/streamlabs-obs/blob/faa6450a2c32bf1eb73a19942d11ea98275dbc5f/app/services/scene-collections/nodes/sources.ts#L219 