### PR TITLE
Let callback thread to start closing before removing callbacks

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -176,13 +176,12 @@ export class AppService extends StatefulService<IAppState> {
 
   @track('app_close')
   private shutdownHandler() {
-    obs.NodeObs.StopCallbackWorkers();
     this.START_LOADING();
     this.loadingChanged.next(true);
     this.tcpServerService.stopListening();
 
     window.setTimeout(async () => {
-      obs.NodeObs.StopCrashHandler();
+      obs.NodeObs.InitShutdownSequence();
       this.crashReporterService.beginShutdown();
       this.shutdownStarted.next();
       this.keyListenerService.shutdown();

--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -176,6 +176,7 @@ export class AppService extends StatefulService<IAppState> {
 
   @track('app_close')
   private shutdownHandler() {
+    obs.NodeObs.StopCallbackWorkers();
     this.START_LOADING();
     this.loadingChanged.next(true);
     this.tcpServerService.stopListening();

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.9.16",
+            "version": "0.9.17",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
Each wolmeter callback have a worker thread and waiting for them to stop when removing callback takes time at app shutdown. 

Depend on backend PR https://github.com/stream-labs/obs-studio-node/pull/744