### PR TITLE
separate bundle updates for mac/win

### DIFF
--- a/updater/bundle-updater.ts
+++ b/updater/bundle-updater.ts
@@ -5,7 +5,9 @@ import * as fs from 'fs-extra';
 import * as stream from 'stream';
 
 module.exports = async (basePath: string) => {
-  const cdnBase = `https://slobs-cdn.streamlabs.com/${process.env.SLOBS_VERSION}/bundles/`;
+  const cdnBase = `https://slobs-cdn.streamlabs.com/${process.env.SLOBS_VERSION}${
+    process.platform === 'darwin' ? '-mac' : ''
+  }/bundles/`;
   const localBase = `file://${basePath}/bundles/`;
   const bundlesBaseDirectory = path.join(electron.app.getPath('userData'), 'bundles');
   const bundleDirectory = path.join(bundlesBaseDirectory, process.env.SLOBS_VERSION!);


### PR DESCRIPTION
Going forward 0.24.0 could mean a different commit on mac than it does on windows.  This separates the CDN path for bundle updates, ensuring bundle updates only hit exactly the commit we are targeting.