### PR TITLE
Prevent the stream from launching if machine is locked

### DIFF
--- a/app/components/windows/go-live/GoLiveError.tsx
+++ b/app/components/windows/go-live/GoLiveError.tsx
@@ -240,7 +240,7 @@ export default class GoLiveError extends TsxComponent<{}> {
       </ErrorLayout>
     );
   }
-  
+
   private renderMachineLockedError(error: IStreamError) {
     return (
       <ErrorLayout error={error}>

--- a/app/components/windows/go-live/GoLiveError.tsx
+++ b/app/components/windows/go-live/GoLiveError.tsx
@@ -87,6 +87,8 @@ export default class GoLiveError extends TsxComponent<{}> {
         return this.renderYoutubeStreamingDisabled(error);
       case 'YOUTUBE_PUBLISH_FAILED':
         return this.renderYoutubePublishError(error);
+      case 'MACHINE_LOCKED':
+        return this.renderMachineLockedError(error);
       default:
         return <ErrorLayout error={error} />;
     }
@@ -235,6 +237,14 @@ export default class GoLiveError extends TsxComponent<{}> {
             ),
           }}
         />
+      </ErrorLayout>
+    );
+  }
+  
+  private renderMachineLockedError(error: IStreamError) {
+    return (
+      <ErrorLayout error={error}>
+        {$t('You could try locking and unlocking your computer to fix this error.')}
       </ErrorLayout>
     );
   }

--- a/app/services/streaming/stream-error.ts
+++ b/app/services/streaming/stream-error.ts
@@ -36,6 +36,9 @@ const errorTypes = {
   PRIME_REQUIRED: {
     message: 'This feature is for Prime members only',
   },
+  MACHINE_LOCKED: {
+    message: 'Your computer is locked',
+  },
   UNKNOWN_ERROR: {
     // show this error if we caught a runtime error
     // we should threat this error as a bug in the codebase

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -224,17 +224,15 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       this.finishStartStreaming();
       return;
     }
-	
-    if (
-    electron.remote.powerMonitor.getSystemIdleState(3) === 'locked'
-    ) {
+
+    if (electron.remote.powerMonitor.getSystemIdleState(3) === 'locked') {
       console.log('Machine locked, did not start stream.');
       this.setError('MACHINE_LOCKED');
-	  this.UPDATE_STREAM_INFO({ lifecycle: 'empty' });
-	  return;
+      this.UPDATE_STREAM_INFO({ lifecycle: 'empty' });
+      return;
     }
-	
-	// clear the current stream info
+
+    // clear the current stream info
     this.RESET_STREAM_INFO();
 
     // if settings are not provided then GoLive window has been not shown

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -224,8 +224,17 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       this.finishStartStreaming();
       return;
     }
-
-    // clear the current stream info
+	
+    if (
+    electron.remote.powerMonitor.getSystemIdleState(1000) == 'locked'
+    ) {
+      console.log('Machine locked, did not start stream.');
+      this.setError('MACHINE_LOCKED');
+	  this.UPDATE_STREAM_INFO({ lifecycle: 'empty' });
+	  return;
+    }
+	
+	// clear the current stream info
     this.RESET_STREAM_INFO();
 
     // if settings are not provided then GoLive window has been not shown

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -226,7 +226,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     }
 	
     if (
-    electron.remote.powerMonitor.getSystemIdleState(1000) == 'locked'
+    electron.remote.powerMonitor.getSystemIdleState(3) === 'locked'
     ) {
       console.log('Machine locked, did not start stream.');
       this.setError('MACHINE_LOCKED');


### PR DESCRIPTION
In certain (very specific) situations, Streamlabs OBS can be commanded to start a stream while the host machine is locked. This should be prevented, and this PR aims to do so. By using Electron's [powerMonitor.getSystemIdleState](https://www.electronjs.org/docs/api/power-monitor), we can find out whether or not the machine is locked when the "go live" attempt is made, and if so, prevent it from doing so.