### PR TITLE
transitions window optimization

### DIFF
--- a/app/components/TransitionSettings.vue.ts
+++ b/app/components/TransitionSettings.vue.ts
@@ -46,7 +46,7 @@ export default class SceneTransitions extends Vue {
   }
 
   get typeOptions() {
-    return this.transitionsService.getTypes();
+    return this.transitionsService.views.getTypes();
   }
 
   get durationModel(): number {

--- a/app/components/windows/SceneTransitions.vue.ts
+++ b/app/components/windows/SceneTransitions.vue.ts
@@ -55,6 +55,8 @@ export default class SceneTransitions extends Vue {
     return this.scenesService.views.scenes.length > 1;
   }
 
+  lockStates: Dictionary<boolean>;
+
   /**
    * Scene transitions created from apps should not be editable
    * if the app developer specified `shouldLock` as part of their
@@ -63,7 +65,11 @@ export default class SceneTransitions extends Vue {
    * @param id ID of the scene transition
    */
   isEditable(id: string) {
-    return this.transitionsService.getPropertiesManagerSettings(id).locked !== true;
+    if (!this.lockStates) {
+      this.lockStates = this.transitionsService.getLockedStates();
+    }
+
+    return !this.lockStates[id];
   }
 
   getEditableMessage(id: string) {
@@ -164,11 +170,11 @@ export default class SceneTransitions extends Vue {
   }
 
   isConnectionRedundant(id: string) {
-    return this.transitionsService.isConnectionRedundant(id);
+    return this.transitionsService.views.isConnectionRedundant(id);
   }
 
   nameForType(type: ETransitionType) {
-    return this.transitionsService.getTypes().find(t => t.value === type).title;
+    return this.transitionsService.views.getTypes().find(t => t.value === type).title;
   }
 
   done() {

--- a/app/services/editor-commands/commands/edit-connection.ts
+++ b/app/services/editor-commands/commands/edit-connection.ts
@@ -16,7 +16,9 @@ export class EditConnectionCommand extends Command {
   }
 
   execute() {
-    this.beforeConnection = cloneDeep(this.transitionsService.getConnection(this.connectionId));
+    this.beforeConnection = cloneDeep(
+      this.transitionsService.views.getConnection(this.connectionId),
+    );
 
     this.transitionsService.updateConnection(this.connectionId, this.changes);
   }

--- a/app/services/editor-commands/commands/remove-connection.ts
+++ b/app/services/editor-commands/commands/remove-connection.ts
@@ -17,7 +17,7 @@ export class RemoveConnectionCommand extends Command {
   }
 
   execute() {
-    const connection = this.transitionsService.getConnection(this.connectionId);
+    const connection = this.transitionsService.views.getConnection(this.connectionId);
 
     this.fromId = connection.fromSceneId;
     this.toId = connection.toSceneId;


### PR DESCRIPTION
Removes a lot of synchronous IPC when opening the transitions window and when editing transitions.