### PR TITLE
Fix facebook

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -26,7 +26,7 @@ interface IFacebookPage {
   id: string;
 }
 
-export interface IFacebookLiveVideo {
+interface IFacebookLiveVideo {
   status: 'SCHEDULED_UNPUBLISHED' | 'LIVE_STOPPED' | 'LIVE';
   id: string;
   stream_url: string;
@@ -63,7 +63,6 @@ export interface IFacebookStartStreamOptions {
   title: string;
   game: string;
   description?: string;
-  scheduledVideoId?: string;
 }
 
 export interface IFacebookChannelInfo extends IFacebookStartStreamOptions {

--- a/test/streaming.ts
+++ b/test/streaming.ts
@@ -69,8 +69,7 @@ test('Streaming to Twitch', async t => {
   t.pass();
 });
 
-// TODO: Flaky
-test.skip('Streaming to Facebook', async t => {
+test('Streaming to Facebook', async t => {
   await logIn(t, 'facebook');
   await goLive(t, {
     title: 'SLOBS Test Stream',


### PR DESCRIPTION
Accounts that have scheduled videos sometimes have a wrong stream key because of unreliable code in `FacebookService:prepopulateInfo`