### PR TITLE
track failed userpool requests

### DIFF
--- a/test/helpers/spectron/user.ts
+++ b/test/helpers/spectron/user.ts
@@ -145,6 +145,7 @@ export async function reserveUserFromPool(
   while (attempts--) {
     try {
       let urlPath = 'reserve';
+      const getParams: string[] = [];
       // request a specific platform
       if (platformType) urlPath += `/${platformType}`;
       // request a user with a specific feature
@@ -156,8 +157,15 @@ export async function reserveUserFromPool(
           const filterValue = enabled ? true : null; // convert false to null, since DB doesn't have `false` as a value for features
           filter[feature] = filterValue;
         });
-        urlPath += `?filter=${JSON.stringify(filter)}`;
+        getParams.push(`filter=${JSON.stringify(filter)}`);
       }
+
+      if (attempts === 0) {
+        // notify the user-pool that it's the last attempt before failure
+        getParams.push('isLastCall=true');
+      }
+
+      if (getParams.length) urlPath = `${urlPath}?${getParams.join('&')}`;
       reservedUser = await requestUserPool(urlPath);
       break;
     } catch (e) {

--- a/test/regular/streaming.ts
+++ b/test/regular/streaming.ts
@@ -257,7 +257,6 @@ test('Migrate the twitch account to the protected mode', async t => {
 const schedulingPlatforms = ['facebook', 'youtube'];
 schedulingPlatforms.forEach(platform => {
   test(`Schedule stream to ${platform}`, async t => {
-
     if (platform === 'facebook') {
       // TODO test.skip
       console.log('Schedule facebook test is flaky');


### PR DESCRIPTION
Send `isLastCall=true` parameter on the last attempt of getting a user from the user-pool. That tracks failed requests on the user-pool-size