### PR TITLE
GoLiveWindow fixes

### DIFF
--- a/app/components/windows/go-live/GoLiveWindow.tsx
+++ b/app/components/windows/go-live/GoLiveWindow.tsx
@@ -41,10 +41,16 @@ export default class GoLiveWindow extends TsxComponent<{}> {
     return this.view.info.lifecycle;
   }
 
-  async created() {
-    // fetch platforms' data
-    if (this.lifecycle === 'empty') {
+  created() {
+    if (['empty', 'waitingForNewSettings'].includes(this.lifecycle)) {
       this.streamingService.actions.prepopulateInfo();
+    }
+  }
+
+  destroyed() {
+    // clear failed checks on window close
+    if (this.view.hasFailedChecks() && this.view.info.checklist.startVideoTransmission !== 'done') {
+      this.streamingService.actions.resetInfo();
     }
   }
 

--- a/app/components/windows/settings/StreamSettings.tsx
+++ b/app/components/windows/settings/StreamSettings.tsx
@@ -61,8 +61,12 @@ export default class StreamSettings extends TsxComponent {
     this.streamSettingsService.setSettings({ protectedModeEnabled: false });
   }
 
-  restoreDefaults() {
-    this.streamSettingsService.resetStreamSettings();
+  private enableProtectedMode() {
+    this.streamSettingsService.actions.setSettings({
+      protectedModeEnabled: true,
+      key: '',
+      streamType: 'rtmp_common',
+    });
   }
 
   get protectedModeEnabled(): boolean {
@@ -189,7 +193,7 @@ export default class StreamSettings extends TsxComponent {
             <br />
 
             {this.canEditSettings && (
-              <button class="button button--warn" onClick={this.restoreDefaults}>
+              <button class="button button--warn" onClick={() => this.enableProtectedMode()}>
                 {$t('Use recommended settings')}
               </button>
             )}

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -229,6 +229,15 @@ export class StreamInfoView extends ViewHandler<IStreamingServiceState> {
   }
 
   /**
+   * Return true if one of the checks has been failed
+   */
+  hasFailedChecks(): boolean {
+    return !!Object.keys(this.state.info.checklist).find(
+      check => this.state.info.checklist[check] === 'failed',
+    );
+  }
+
+  /**
    * Returns Go-Live settings for a given platform
    */
   private getPlatformSettings(platform: TPlatform) {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -456,6 +456,10 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     }
   }
 
+  resetInfo() {
+    this.RESET_STREAM_INFO();
+  }
+
   resetError() {
     this.RESET_ERROR();
     if (this.state.info.checklist.startVideoTransmission === 'done') {
@@ -531,7 +535,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     this.toggleStreaming();
   }
 
-  async finishStartStreaming() {
+  async finishStartStreaming(): Promise<unknown> {
     // register a promise that we should reject or resolve in the `handleObsOutputSignal`
     const startStreamingPromise = new Promise((resolve, reject) => {
       this.resolveStartStreaming = resolve;
@@ -549,8 +553,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       });
 
       if (!goLive.response) {
-        this.rejectStartStreaming();
-        return;
+        return Promise.reject();
       }
     }
 


### PR DESCRIPTION
This PR resolves multiple issues with GoLiveWindow


**Go Live Window Jank 1 - YT Disabling itself**

> Steps to Reproduce: 
> 1. be logged in w/ Twitch and have YT linked and enabled for multistream
> 2. open Go Live window
> 3. go to Settings > Stream, switch to custom ingest and then back to recommended
> 4. open Go Live window again
> 5. toggle Show Advanced Settings
> 
> Actual Behavior: when you toggle Show Advanced Settings after doing the above steps, YT destination gets disabled. 
> 
> Expected behavior: not this lol

**Go Live Window Jank 2 - Custom RTMP Destinations Removing Themselves**

> Steps to reproduce: 
> 1. be logged in w/ Twitch, have YT linked and enabled for multistreaming, and have at least one custom destination
> 2. open go live window, ensure that both YT and custom destination are turned on
> 3. close go live window, open Settings > Stream
> 4. toggle custom ingest and back to recommended
> 5. open go live window again and toggle show advanced settings
> 6. YT will disable itself (referenced in this ticket: Go Live Window Jank #1 - YT Disabling itself
> 7. close the go live window WITHOUT re-enabling YT
> 8. open Settings > Stream
> 
> Actual behavior: custom rtmp destinations are now gone
> 
> Expected behavior: custom destinations do not get removed

**Go Live Window Jank 3 - Stream Info Fields not Showing**

> Steps to Repro: 
> 1. be logged into Twitch w/ YT linked and enabled for multistream
> 2. go to Settings > Stream and switch to custom ingest
> 3. close SLOBS
> 4. re-open SLOBS, go to Settings > Stream and switch back to Recommended
> 5. open Go Live window
> 
> Actual behavior: stream info fields are not showing (can be fixed by toggling YT off and back on)
> 
> Expected behavior: not this

**Go Live Window in Bad State (complicated)**

> Steps to repro: 
> 1. Have the "Show confirmation dialog when starting streams" option enabled
> 2. have the "Confirm stream title and game before going live" option enabled
> 3. click Go Live button, fill out stream info, then click "Confirm and Go Live"
> 4. when confirmation dialog pops up, hit cancel
> 5. hit Go Live button again
> 
> Expected behavior: The go live window opens to the stream info page again, since you didn't actually go live. 
> 
> Actual behavior: it's stuck on the checklist page. this can be worked around by clicking the pencil icon to edit stream info, close that and then click Go Live again, or by relaunching the app. otherwise, the go live window is stuck on the checklist until you do either of these things. 