### PR TITLE
Allow to run performance tests locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "package:preview": "yarn generate-agreement && rimraf dist && electron-builder build -w --x64 --config electron-builder/preview.config.js",
     "eslint": "eslint {app,guest-api,obs-api,updater}/**/*.ts app/**/*.tsx main.js",
     "test": "tsc -p test && ava -v --timeout=3m ./test-dist/test/regular/**/*.js",
-    "test:file": "tsc -p test && ava -v --timeout=10m",
+    "test:file": "tsc -p test && ava -v --timeout=60m",
     "test:stress": "yarn test test-dist/test/stress/index.js",
     "test:screen": "yarn test:file ./test-dist/test/screentest/tests/**/*.js",
     "test:performance": "yarn test:file ./test-dist/test/performance/tests/**/*.js",


### PR DESCRIPTION
Just run `ci:performance`

Note: on CI agents test will compare results with DB for faster tests execution