### PR TITLE
remove locked error for now

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -225,13 +225,6 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
       return;
     }
 
-    if (electron.remote.powerMonitor.getSystemIdleState(3) === 'locked') {
-      console.log('Machine locked, did not start stream.');
-      this.setError('MACHINE_LOCKED');
-      this.UPDATE_STREAM_INFO({ lifecycle: 'empty' });
-      return;
-    }
-
     // clear the current stream info
     this.RESET_STREAM_INFO();
 


### PR DESCRIPTION
We are seeing this firing in cases where the machine is not actually locked.  We are removing the check until we can understand the problem better.