### PR TITLE
allow the worker process to call actions

### DIFF
--- a/app/services/selection/global-selection.ts
+++ b/app/services/selection/global-selection.ts
@@ -77,12 +77,7 @@ export class GlobalSelection extends Selection {
       throw new Error('Attempted to modify frozen selection');
     }
 
-    // TODO: Allow calling of actions from the worker window
-    if (Utils.isWorkerWindow()) {
-      this.selectionService.select(items);
-    } else {
-      this.selectionService.actions.select(items);
-    }
+    this.selectionService.actions.select(items);
 
     return this;
   }


### PR DESCRIPTION
This addresses a major piece of tech debt from the services worker refactor.  We can now safely call actions from the worker process without worry which process certain utility code will be executed in.