### PR TITLE
fix infinite loop with folders inside themselves

### DIFF
--- a/app/services/scenes/scene-node.ts
+++ b/app/services/scenes/scene-node.ts
@@ -48,7 +48,7 @@ export abstract class SceneItemNode implements ISceneItemNode {
   get childrenIds(): string[] {
     return this.getScene()
       .getModel()
-      .nodes.filter(node => node.parentId === this.id)
+      .nodes.filter(node => node.parentId === this.id && node.id !== this.id)
       .map(node => node.id);
   }
 


### PR DESCRIPTION
Simplest and safest sanity check is to make sure `childrenIds` do not include itself.  Note that this does not fix deeply nested folder loops.