### PR TITLE
fix dashboard magic link

### DIFF
--- a/app/services/magic-link.ts
+++ b/app/services/magic-link.ts
@@ -17,7 +17,9 @@ export class MagicLinkService extends Service {
   async getDashboardMagicLink(subPage = '', source?: string) {
     const token = (await this.fetchNewToken()).login_token;
     const sourceString = source ? `&refl=${source}` : '';
-    return `https://${this.hostsService.streamlabs}/slobs/magic/dashboard?login_token=${token}&r=${subPage}${sourceString}`;
+    return `https://${
+      this.hostsService.streamlabs
+    }/slobs/magic/dashboard?login_token=${token}&r=${subPage ?? ''}${sourceString}`;
   }
 
   private fetchNewToken(): Promise<ILoginTokenResponse> {


### PR DESCRIPTION
The server wants us to send an empty string instead of `null` or `undefined`.  This ensures we always send an empty string when a `null` or `undefined` value is passed for the `subPage`.