### PR TITLE
Fix YT settings reactivity

### DIFF
--- a/app/services/platforms/base-platform.ts
+++ b/app/services/platforms/base-platform.ts
@@ -66,7 +66,7 @@ export abstract class BasePlatformService<T extends IPlatformState> extends Stat
     const savedSettings: IFacebookStartStreamOptions = JSON.parse(
       localStorage.getItem(this.serviceName) as string,
     );
-    if (savedSettings) this.SET_STREAM_SETTINGS(savedSettings);
+    if (savedSettings) this.UPDATE_STREAM_SETTINGS(savedSettings);
     this.store.watch(
       () => this.state.settings,
       () => {


### PR DESCRIPTION

**IMPORTANT**!  we should not release the new YT workflow without this fix

YT settings have been overridden from saved settings from the local storage. This caused issue where default values for some options have not been set.

How to reproduce: 
- Start slobs from the branch before YT updates
- Clear cache directory
- Start streaming to YT
- Switch to master
- Try to update new options and go live
- options will not be updated

