### PR TITLE
Fix sentry error when removing source while properties are open

### DIFF
--- a/app/components/windows/SourceProperties.vue
+++ b/app/components/windows/SourceProperties.vue
@@ -6,7 +6,7 @@
   :cancel-handler="cancel"
   :fixedSectionHeight="200">
   <display slot="fixed" v-if="source && !hideStyleBlockers" :sourceId="source.id" />
-  <div slot="content">
+  <div slot="content" v-if="source">
     <component
       v-if="propertiesManagerUI"
       :is="propertiesManagerUI"

--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -45,6 +45,7 @@ export default class SourceProperties extends Vue {
     this.properties = this.source ? this.source.getPropertiesFormData() : [];
     this.sourceRemovedSub = this.sourcesService.sourceRemoved.subscribe(source => {
       if (source.sourceId === this.sourceId) {
+        this.source = null;
         electron.remote.getCurrentWindow().close();
       }
     });


### PR DESCRIPTION
Fixes https://sentry.io/organizations/streamlabs-obs/issues/1643294584/?project=251674&query=is%3Aunresolved&sort=freq&statsPeriod=14d

Prevents the child window from re-rendering after a source is already destroyed.  Closing it is not instant and the window will still try to re-render, causing exceptions.