### PR TITLE
Update osn to v0.11.14

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.11.5",
+            "version": "0.11.14",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
EddyGharbi	Merge branch 'staging' of github.com:stream-labs/obs-studio-node into register-input-only
EddyGharbi	mac/ci: remove nvm and install directly correct node version (#774)
EddyGharbi	Only monitor input sources size