### PR TITLE
Update osn to v0.12.0

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.11.5",
+            "version": "0.12.0",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
EddyGharbi	Update libobs to v26.1.10 (#783)
EddyGharbi	Do not show RecRescale option if using the stream encoder (#782)
EddyGharbi	Vcam uninstall (#780)
Vladimir	fix for osx sentry info upload  (#779)
Vladimir	Print a number of allocated objects to log at app shutdown (#778)
Vladimir	release settings object after use (#777)
EddyGharbi	mac/ci: remove nvm and install directly correct node version (#774)