### PR TITLE
Enable streaming tests for FB groups and timeline

### DIFF
--- a/app/components/windows/go-live/platforms/FacebookEditStreamInfo.tsx
+++ b/app/components/windows/go-live/platforms/FacebookEditStreamInfo.tsx
@@ -331,7 +331,7 @@ export default class FacebookEditStreamInfo extends BaseEditSteamInfo<Props> {
               imageSize={{ width: 44, height: 44 }}
             />
             <p>
-              {$t('Make sure Streamlabs app is added to your Group.')}
+              {$t('Make sure the Streamlabs app is added to your Group.')}
               <a onClick={() => this.verifyGroup()}> {$t('Click here to verify.')}</a>
             </p>
           </HFormGroup>

--- a/test/helpers/spectron/user.ts
+++ b/test/helpers/spectron/user.ts
@@ -49,6 +49,14 @@ interface ITestUserFeatures {
    */
   prime?: boolean;
   /**
+   * This account is eligible to stream into their FB group
+   */
+  hasFBGroup?: boolean;
+  /**
+   * This account is eligible to stream into their FB personal timeline
+   */
+  allowStreamingToFBTimeline?: boolean;
+  /**
    * Streaming is not available for this account
    * User pool does not return accounts with this flag unless you explicitly set this flag to true in the request
    */

--- a/test/regular/streaming/facebook.ts
+++ b/test/regular/streaming/facebook.ts
@@ -26,9 +26,8 @@ test('Streaming to a Facebook Page', async t => {
   t.pass();
 });
 
-// TODO: setup FB permissions in the user-pool to run this test
-test.skip('Streaming to a Facebook User`s timeline', async t => {
-  await logIn(t, 'facebook');
+test('Streaming to a Facebook User`s timeline', async t => {
+  await logIn(t, 'facebook', { allowStreamingToFBTimeline: true });
   await goLive(t, {
     title: 'SLOBS Test Stream',
     facebookGame: selectTitle('Fortnite'),
@@ -38,9 +37,8 @@ test.skip('Streaming to a Facebook User`s timeline', async t => {
   t.pass();
 });
 
-// TODO: setup FB permissions in the user-pool to run this test
-test.skip('Streaming to a Facebook User`s group', async t => {
-  await logIn(t, 'facebook');
+test('Streaming to a Facebook User`s group', async t => {
+  await logIn(t, 'facebook', { hasFBGroup: true });
   await goLive(t, {
     title: 'SLOBS Test Stream',
     facebookGame: selectTitle('Fortnite'),


### PR DESCRIPTION
I updated FB accounts and we can enable autotests for streaming into FB groups and timelines