### PR TITLE
Prevent infinity loading of the child window and fix the error-message for YT when the livestreaming is disabled

### DIFF
--- a/app/services/api/ipc-server/ipc-server.ts
+++ b/app/services/api/ipc-server/ipc-server.ts
@@ -25,9 +25,17 @@ export class IpcServerService extends Service {
     ipcRenderer.on('services-request', this.requestHandler);
     ipcRenderer.send('services-ready');
 
-    this.servicesEventsSubscription = this.internalApiService.serviceEvent.subscribe(event =>
-      this.sendEvent(event),
-    );
+    this.servicesEventsSubscription = this.internalApiService.serviceEvent.subscribe(event => {
+      // wrap in try/catch to prevent un-subscribing in the case of failure
+      try {
+        this.sendEvent(event);
+      } catch (e) {
+        console.error(
+          'Failed to send event to an IPC client. Make sure the object is serializable',
+          e,
+        );
+      }
+    });
   }
 
   exec(request: IJsonRpcRequest) {

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -374,6 +374,9 @@ export class YoutubeService extends BasePlatformService<IYoutubeServiceState>
    * returns perilled data for the GoLive window
    */
   async prepopulateInfo(): Promise<void> {
+    if (!this.state.liveStreamingEnabled) {
+      throw throwStreamError('YOUTUBE_STREAMING_DISABLED', '', 'youtube');
+    }
     const settings = this.state.settings;
     this.UPDATE_STREAM_SETTINGS({
       description: settings.description || (await this.fetchDefaultDescription()),

--- a/test/regular/streaming/youtube.ts
+++ b/test/regular/streaming/youtube.ts
@@ -5,9 +5,10 @@ import {
   clickGoLive,
   goLive,
   prepareToGoLive,
-  scheduleStream, stopStream,
+  scheduleStream,
+  stopStream,
   submit,
-  waitForStreamStart
+  waitForStreamStart,
 } from '../../helpers/spectron/streaming';
 import { FormMonkey, selectTitle } from '../../helpers/form-monkey';
 import moment = require('moment');
@@ -78,9 +79,15 @@ test('Start stream twice to the same YT event', async t => {
 
 test('Youtube streaming is disabled', async t => {
   skipCheckingErrorsInLog();
+  const client = t.context.app.client;
   await logIn(t, 'youtube', { streamingIsDisabled: true, notStreamable: true });
   t.true(
-    await t.context.app.client.isExisting('span=YouTube account not enabled for live streaming'),
+    await client.isExisting('span=YouTube account not enabled for live streaming'),
     'The streaming-disabled message should be visible',
+  );
+  await clickGoLive(t);
+  t.true(
+    await client.isVisible('button=Enable Live Streaming'),
+    'The enable livestreaming button should be visible',
   );
 });

--- a/test/regular/streaming/youtube.ts
+++ b/test/regular/streaming/youtube.ts
@@ -85,6 +85,7 @@ test('Youtube streaming is disabled', async t => {
     await client.isExisting('span=YouTube account not enabled for live streaming'),
     'The streaming-disabled message should be visible',
   );
+  await prepareToGoLive(t);
   await clickGoLive(t);
   t.true(
     await client.isVisible('button=Enable Live Streaming'),


### PR DESCRIPTION
Failed `ipcRenderer.send('services-message', event);` call broke communications between worker and child windows. This should not happen with a `try/catch` statement now
The error message for YT accounts with disabled livestreaming was broken too. I fixed it and added a tests