### PR TITLE
fix widget installs

### DIFF
--- a/app/components/pages/BrowseOverlays.vue.ts
+++ b/app/components/pages/BrowseOverlays.vue.ts
@@ -105,7 +105,7 @@ export default class BrowseOverlays extends Vue {
         return;
       }
 
-      const path = await this.overlaysPersistenceService.downloadOverlay(url, progressCallback);
+      const path = await this.overlaysPersistenceService.downloadOverlay(url);
       await this.widgetsService.loadWidgetFile(path, this.scenesService.views.activeSceneId);
     }
 


### PR DESCRIPTION
Electron IPC can no longer handle callback functions.  For now, just don't pass along the download progress callback, as these downloads are very small anyway.