### PR TITLE
downgrade to electron 9.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "css-element-queries": "1.2.3",
     "css-loader": "2.1.1",
     "dotenv": "8.2.0",
-    "electron": "9.3.4",
+    "electron": "9.3.3",
     "electron-builder": "22.7.0",
     "electron-devtools-installer": "2.2.4",
     "electron-notarize": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,10 +4424,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@9.3.4:
-  version "9.3.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-9.3.4.tgz#d62dd9f8abc93c009878714de9e60db030361a05"
-  integrity sha512-OHP8qMKgW8D8GtH+altB22WJw/lBOyyVdoz5e8D0/iPBmJU3Jm93vO4z4Eh/9DvdSXlH8bMHUCMLL9PVW6f+tw==
+electron@9.3.3:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-9.3.3.tgz#99a6619d5df68f97697a5d1d82ef3a8a63fcdf36"
+  integrity sha512-xghKeUY1qgnEcJ5w2rXo/toH+8NT2Dktx2aAxBNPV7CIJr3mejJJAPwLbycwtddzr37tgKxHeHlc8ivfKtMkJQ==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
This issue: https://github.com/electron/electron/issues/26681 is preventing interaction with chat on electron 9.3.4+ on macOS.  We are dowgrading to 9.3.3 for the macOS release.