### PR TITLE
fix audio settings

### DIFF
--- a/app/components/windows/settings/Settings.vue.ts
+++ b/app/components/windows/settings/Settings.vue.ts
@@ -148,10 +148,6 @@ export default class Settings extends Vue {
     this.$refs.settingsContainer.scrollTop = 0;
   }
 
-  getSettingsData(categoryName: string) {
-    return this.settingsService.state[categoryName].formData;
-  }
-
   originalCategory: string = null;
 
   onBeforePageScanHandler(page: string) {


### PR DESCRIPTION
Fix audio settings (broken during settings refactor).

Also, fixes the the `sceneCollectionsService.collectionSwitched` event to only fire after all sources for the new scene collection have been loaded (otherwise event would be uselss).