### PR TITLE
GoLiveWindow: fix `try again` logic

### DIFF
--- a/app/components/windows/go-live/GoLiveError.tsx
+++ b/app/components/windows/go-live/GoLiveError.tsx
@@ -166,7 +166,10 @@ export default class GoLiveError extends TsxComponent<{}> {
           message={$t('updateStreamSettingsError')}
           scopedSlots={{
             tryAgainLink: (text: string) => (
-              <a class={styles.link} onClick={() => this.streamingService.actions.goLive()}>
+              <a
+                class={styles.link}
+                onClick={() => this.streamingService.actions.goLive(this.view.info.settings)}
+              >
                 {{ text }}
               </a>
             ),

--- a/app/services/streaming/streaming-api.ts
+++ b/app/services/streaming/streaming-api.ts
@@ -39,6 +39,7 @@ export interface IStreamInfo {
     | 'live'; // stream has been successfully started
   error: IStreamError | null;
   warning: 'YT_AUTO_START_IS_DISABLED' | '';
+  settings: IGoLiveSettings | null; // settings for the current attempt of going live
   checklist: {
     applyOptimizedSettings: TGoLiveChecklistItemState;
     twitch: TGoLiveChecklistItemState;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -110,6 +110,7 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
     replayBufferStatusTime: new Date().toISOString(),
     selectiveRecording: false,
     info: {
+      settings: null,
       lifecycle: 'empty',
       error: null,
       warning: '',
@@ -231,6 +232,9 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
 
     // save enabled platforms to reuse setting with the next app start
     this.streamSettingsService.setSettings({ goLiveSettings: settings });
+
+    // save current settings in store so we can re-use them if something will go wrong
+    this.SET_GO_LIVE_SETTINGS(settings);
 
     // show the GoLive checklist
     this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
@@ -1081,5 +1085,10 @@ export class StreamingService extends StatefulService<IStreamingServiceState>
   @mutation()
   private SET_WARNING(warningType: 'YT_AUTO_START_IS_DISABLED') {
     this.state.info.warning = warningType;
+  }
+
+  @mutation()
+  private SET_GO_LIVE_SETTINGS(settings: IGoLiveSettings) {
+    this.state.info.settings = settings;
   }
 }


### PR DESCRIPTION
`try again` logic used previous successfully saved settings instead of new ones 