### PR TITLE
fix the dragover overlay persisting after file upload

### DIFF
--- a/app/components/windows/MediaGallery.vue.ts
+++ b/app/components/windows/MediaGallery.vue.ts
@@ -163,6 +163,7 @@ export default class MediaGallery extends Vue {
   handleFileDrop(e: DragEvent) {
     const mappedFiles = Array.from(e.dataTransfer.files).map(file => file.path);
     this.upload(mappedFiles);
+    this.dragOver = false;
   }
 
   handleTypeFilter(type: 'audio' | 'image', category: 'stock' | 'uploads') {


### PR DESCRIPTION
the yellow overlay when dragging and dropping a file wasn't going away after you dropped the file. this fixes that :) 