### PR TITLE
fix endless loading on overlay/widget import

### DIFF
--- a/app/components/windows/settings/OverlaySettings.tsx
+++ b/app/components/windows/settings/OverlaySettings.tsx
@@ -58,7 +58,7 @@ export default class OverlaySettings extends Vue {
       })
     ).filePaths;
 
-    if (!chosenPath) return;
+    if (!chosenPath[0]) return;
 
     this.busy = true;
     this.message = '';
@@ -79,7 +79,7 @@ export default class OverlaySettings extends Vue {
       })
     ).filePaths;
 
-    if (!chosenPath) return;
+    if (!chosenPath[0]) return;
 
     this.busy = true;
     this.message = '';


### PR DESCRIPTION
the button to import an overlay or widget file would load endlessly (until you closed Settings) if you hit "cancel" on the file dialog. this fixes that. 