### PR TITLE
convert guest API to work with isolated contexts

### DIFF
--- a/app/components/pages/AlertboxLibrary.tsx
+++ b/app/components/pages/AlertboxLibrary.tsx
@@ -37,10 +37,8 @@ export default class AlertboxLibrary extends TsxComponent<AlertboxLibraryProps> 
   @Inject() private restreamService: RestreamService;
 
   onBrowserViewReady(view: Electron.BrowserView) {
-    view.webContents.on('did-finish-load', () => {
-      new GuestApiHandler().exposeApi(view.webContents.id, {
-        installWidgets: this.installWidgets,
-      });
+    new GuestApiHandler().exposeApi(view.webContents.id, {
+      installWidgets: this.installWidgets,
     });
 
     electron.ipcRenderer.send('webContents-preventPopup', view.webContents.id);

--- a/app/components/pages/BrowseOverlays.vue.ts
+++ b/app/components/pages/BrowseOverlays.vue.ts
@@ -37,15 +37,13 @@ export default class BrowseOverlays extends Vue {
   };
 
   onBrowserViewReady(view: Electron.BrowserView) {
-    view.webContents.on('did-finish-load', () => {
-      new GuestApiHandler().exposeApi(view.webContents.id, {
-        installOverlay: this.installOverlay,
-        installWidgets: this.installWidgets,
-        eligibleToRestream: () => {
-          // assume all users are eligible
-          return Promise.resolve(true);
-        },
-      });
+    new GuestApiHandler().exposeApi(view.webContents.id, {
+      installOverlay: this.installOverlay,
+      installWidgets: this.installWidgets,
+      eligibleToRestream: () => {
+        // assume all users are eligible
+        return Promise.resolve(true);
+      },
     });
 
     electron.ipcRenderer.send('webContents-preventPopup', view.webContents.id);

--- a/app/components/pages/PlatformAppStore.vue.ts
+++ b/app/components/pages/PlatformAppStore.vue.ts
@@ -26,16 +26,17 @@ export default class PlatformAppStore extends Vue {
   };
 
   onBrowserViewReady(view: Electron.BrowserView) {
+    new GuestApiHandler().exposeApi(view.webContents.id, {
+      reloadProductionApps: this.reloadProductionApps,
+      openLinkInBrowser: this.openLinkInBrowser,
+      onPaypalAuthSuccess: this.onPaypalAuthSuccessHandler,
+      navigateToApp: this.navigateToApp,
+    });
+
     view.webContents.on('did-finish-load', () => {
       if (Utils.isDevMode()) {
         view.webContents.openDevTools();
       }
-      new GuestApiHandler().exposeApi(view.webContents.id, {
-        reloadProductionApps: this.reloadProductionApps,
-        openLinkInBrowser: this.openLinkInBrowser,
-        onPaypalAuthSuccess: this.onPaypalAuthSuccessHandler,
-        navigateToApp: this.navigateToApp,
-      });
     });
   }
 

--- a/app/components/shared/BrowserView.tsx
+++ b/app/components/shared/BrowserView.tsx
@@ -48,6 +48,7 @@ export default class BrowserView extends TsxComponent<BrowserViewProps> {
 
     if (this.props.enableGuestApi) {
       options.webPreferences.enableRemoteModule = true;
+      options.webPreferences.contextIsolation = true;
       options.webPreferences.preload = path.resolve(
         electron.remote.app.getAppPath(),
         'bundles',

--- a/app/services/platform-apps/container-manager.ts
+++ b/app/services/platform-apps/container-manager.ts
@@ -188,6 +188,8 @@ export class PlatformContainerManager {
   private createContainer(app: ILoadedApp, slot: EAppPageSlot, persistent = false): IContainerInfo {
     const view = new electron.remote.BrowserView({
       webPreferences: {
+        contextIsolation: true,
+        enableRemoteModule: true,
         nodeIntegration: false,
         partition: this.getAppPartition(app),
         preload: path.resolve(electron.remote.app.getAppPath(), 'bundles', 'guest-api'),
@@ -210,9 +212,7 @@ export class PlatformContainerManager {
 
     if (app.unpacked) view.webContents.openDevTools();
 
-    view.webContents.on('did-finish-load', () => {
-      this.exposeApi(app, view.webContents.id, info.transform);
-    });
+    this.exposeApi(app, view.webContents.id, info.transform);
 
     /**
      * This has to be done from the main process to work properly

--- a/main.js
+++ b/main.js
@@ -654,6 +654,20 @@ ipcMain.on('streamlabels-writeFile', (e, info) => {
   });
 });
 
+const guestApiInfo = {};
+
+ipcMain.on('guestApi-setInfo', (e, info) => {
+  guestApiInfo[info.webContentsId] = {
+    schema: info.schema,
+    hostWebContentsId: info.hostWebContentsId,
+    ipcChannel: info.ipcChannel,
+  };
+});
+
+ipcMain.on('guestApi-getInfo', e => {
+  e.returnValue = guestApiInfo[e.sender.id];
+});
+
 /* The following 3 methods need to live in the main process
     because events bound using the remote module are not
     executed synchronously and therefore default actions


### PR DESCRIPTION
This allows us to use context isolation (https://www.electronjs.org/docs/tutorial/context-isolation) in all embedded content that uses the guest API.