### PR TITLE
Fix facebook live events

### DIFF
--- a/app/components/windows/go-live/platforms/FacebookEditStreamInfo.tsx
+++ b/app/components/windows/go-live/platforms/FacebookEditStreamInfo.tsx
@@ -1,4 +1,4 @@
-import { Component, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 import { Inject } from 'services/core/injector';
 import ValidatedForm from 'components/shared/inputs/ValidatedForm';
 import HFormGroup from 'components/shared/inputs/HFormGroup.vue';
@@ -70,7 +70,6 @@ export default class FacebookEditStreamInfo extends BaseEditSteamInfo<Props> {
     if (this.fbSettings.groupId) this.loadPicture(this.fbSettings.groupId);
   }
 
-  @Watch('settings.platforms.facebook.destinationType')
   private async loadScheduledBroadcasts() {
     const fbSettings = this.fbSettings;
     let destinationId = this.facebookService.views.getDestinationId(this.fbSettings);
@@ -304,6 +303,7 @@ export default class FacebookEditStreamInfo extends BaseEditSteamInfo<Props> {
                 vModel={this.settings.platforms.facebook.destinationType}
                 metadata={this.formMetadata.destinationType}
                 imageSize={{ width: 35, height: 35 }}
+                onInput={() => this.loadScheduledBroadcasts()}
               />
             </HFormGroup>
           </div>
@@ -317,6 +317,7 @@ export default class FacebookEditStreamInfo extends BaseEditSteamInfo<Props> {
               handleOpen={() => this.loadPictures('page')}
               showImagePlaceholder={true}
               imageSize={{ width: 44, height: 44 }}
+              onInput={() => this.loadScheduledBroadcasts()}
             />
           </HFormGroup>
         )}

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -37,7 +37,7 @@ interface IFacebookGroup {
 }
 
 export interface IFacebookLiveVideo {
-  status: 'SCHEDULED_UNPUBLISHED' | 'LIVE_STOPPED' | 'LIVE';
+  status: 'UNPUBLISHED' | 'SCHEDULED_UNPUBLISHED' | 'LIVE_STOPPED' | 'LIVE';
   id: string;
   stream_url: string;
   title: string;
@@ -433,7 +433,7 @@ export class FacebookService extends BasePlatformService<IFacebookServiceState>
 
     const videos = (
       await this.requestFacebook<{ data: IFacebookLiveVideo[] }>(
-        `${this.apiBase}/${destinationId}/live_videos?broadcast_status=["SCHEDULED_UNPUBLISHED"]&fields=title,description,planned_start_time,permalink_url,from${sourceParam}&since=${minDateUnix}&until=${maxDateUnix}`,
+        `${this.apiBase}/${destinationId}/live_videos?broadcast_status=["UNPUBLISHED","SCHEDULED_UNPUBLISHED"]&fields=title,description,status,planned_start_time,permalink_url,from${sourceParam}&since=${minDateUnix}&until=${maxDateUnix}`,
         token,
       )
     ).data;
@@ -441,6 +441,9 @@ export class FacebookService extends BasePlatformService<IFacebookServiceState>
     // the FB filter doesn't work for some livevideos,
     // filter manually here
     return videos.filter(v => {
+      // videos created in the new Live Producer don't have `planned_start_time`
+      if (!v.planned_start_time) return true;
+
       const videoDate = new Date(v.planned_start_time).valueOf();
       return videoDate >= minDate && videoDate <= maxDate;
     });


### PR DESCRIPTION
- fix an issue when some events are not shown when the user has multiple pages
- show events in the `UNPUBLISHED` state. These kinds of events have been created in the new Live Producer