### PR TITLE
fix sentry object destroyed error

### DIFF
--- a/main.js
+++ b/main.js
@@ -529,7 +529,7 @@ app.on('second-instance', (event, argv, cwd) => {
     }
 
     mainWindow.focus();
-  } else {
+  } else if (!shutdownStarted) {
     // This instance is a zombie and we should shut down.
     app.exit();
   }

--- a/main.js
+++ b/main.js
@@ -523,12 +523,15 @@ app.on('second-instance', (event, argv, cwd) => {
   });
 
   // Someone tried to run a second instance, we should focus our window.
-  if (mainWindow) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
     if (mainWindow.isMinimized()) {
       mainWindow.restore();
     }
 
     mainWindow.focus();
+  } else {
+    // This instance is a zombie and we should shut down.
+    app.exit();
   }
 });
 


### PR DESCRIPTION
It seems like we are getting into a state where the main window has been closed or crashed, but the app is still running and therefore we show this error when a second instance tries to run.

We handle it like this: On second instance, if main window is destroyed, then hard exit the app if shutdown has been started already (this is an error situation), otherwise let the shutdown procedure finish as normal.