### PR TITLE
Properly display an erased custom ingest when toggling protected mode

### DIFF
--- a/app/components/windows/settings/StreamSettings.tsx
+++ b/app/components/windows/settings/StreamSettings.tsx
@@ -58,13 +58,12 @@ export default class StreamSettings extends TsxComponent {
   }
 
   disableProtectedMode() {
-    this.streamSettingsService.setSettings({ protectedModeEnabled: false });
+    this.streamSettingsService.actions.setSettings({ protectedModeEnabled: false });
   }
 
   private enableProtectedMode() {
     this.streamSettingsService.actions.setSettings({
       protectedModeEnabled: true,
-      key: '',
       streamType: 'rtmp_common',
     });
   }

--- a/app/components/windows/settings/StreamSettings.tsx
+++ b/app/components/windows/settings/StreamSettings.tsx
@@ -37,7 +37,6 @@ export default class StreamSettings extends TsxComponent {
     customDestForm: ValidatedForm;
   };
 
-  private obsSettings = this.streamSettingsService.views.obsStreamSettings;
   private customDestModel: ICustomStreamDestination = {
     name: '',
     url: '',
@@ -54,7 +53,10 @@ export default class StreamSettings extends TsxComponent {
 
   saveObsSettings(obsSettings: ISettingsSubCategory[]) {
     this.streamSettingsService.setObsStreamSettings(obsSettings);
-    this.obsSettings = this.streamSettingsService.views.obsStreamSettings;
+  }
+
+  get obsSettings() {
+    return this.streamSettingsService.views.obsStreamSettings;
   }
 
   disableProtectedMode() {
@@ -64,6 +66,7 @@ export default class StreamSettings extends TsxComponent {
   private enableProtectedMode() {
     this.streamSettingsService.actions.setSettings({
       protectedModeEnabled: true,
+      key: '',
       streamType: 'rtmp_common',
     });
   }

--- a/app/services/settings/streaming/stream-settings.ts
+++ b/app/services/settings/streaming/stream-settings.ts
@@ -3,7 +3,9 @@ import { Inject } from 'services/core/injector';
 import { InitAfter, mutation, PersistentStatefulService, ViewHandler } from '../../core';
 import { UserService } from 'services/user';
 import { TPlatform, getPlatformService } from 'services/platforms';
-import { invert, pick } from 'lodash';
+import pick from 'lodash/pick';
+import invert from 'lodash/invert';
+import cloneDeep from 'lodash/cloneDeep';
 import { TwitchService } from 'services/platforms/twitch';
 import { PlatformAppsService } from 'services/platform-apps';
 import { IGoLiveSettings, IPlatformFlags } from 'services/streaming';
@@ -135,7 +137,7 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
     });
 
     // save settings related to "Settings->Stream" window
-    let streamFormData = this.views.obsStreamSettings;
+    let streamFormData = cloneDeep(this.views.obsStreamSettings);
 
     streamFormData.forEach(subCategory => {
       subCategory.parameters.forEach(parameter => {
@@ -153,7 +155,7 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
       ['platform', 'key', 'server'].includes(key),
     );
     if (!mustUpdateObsSettings) return;
-    streamFormData = this.views.obsStreamSettings;
+    streamFormData = cloneDeep(this.views.obsStreamSettings);
 
     streamFormData.forEach(subCategory => {
       subCategory.parameters.forEach(parameter => {


### PR DESCRIPTION
~~Causes weird behavior when toggling between protected and unprotected mode, and if in protected mode we replace the stream key dynamically before they go live anyway~~

After conferring with Alex we decided the most consistent fix with the least issues is to actually properly clear the stream key whenever switching to protected mode, which was left in the FE due to a vue reactivity bug