### PR TITLE
Remove test logs

### DIFF
--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -206,6 +206,7 @@ export class SourceFiltersService extends Service {
     obsFilter.release();
 
     if (this.presetFilter(sourceId)) {
+      this.usageStatisticsService.recordFeatureUsage('PresetFilter');
       this.setOrder(sourceId, '__PRESET', 1);
     }
     this.filterAdded.next({ sourceId, name: filterName });

--- a/test/helpers/spectron/index.ts
+++ b/test/helpers/spectron/index.ts
@@ -356,7 +356,6 @@ export function useSpectron(options: ITestRunnerOptions = {}) {
       // consider this test succeed and remove from the `failedTests` list
       removeFailedTestFromFile(testName);
       // save the test execution time
-      console.log('calc stats');
       testStats[testName] = {
         duration: Date.now() - testStartTime,
         syncIPCCalls: getSyncIPCCalls(),

--- a/test/helpers/spectron/runner-utils.ts
+++ b/test/helpers/spectron/runner-utils.ts
@@ -120,7 +120,6 @@ function isTestEligibleToRun(testName: string) {
 }
 
 export function saveTestStatsToFile(stats: Record<string, ITestStats>) {
-  console.log('save test stats', stats);
   if (!process.env.SLOBS_TEST_RUN_CHUNK) {
     // don't save timings for tests that are not sliced
     return;


### PR DESCRIPTION
We should never be logging in tests except in the case of error, because it gets forwarded to `stderr` by AVA and muddies up the test output.