### PR TITLE
explicitly set streaming server when recommended settings are enabled

### DIFF
--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -196,6 +196,7 @@ export class FacebookService extends BasePlatformService<IFacebookServiceState>
       key: streamKey,
       platform: 'facebook',
       streamType: 'rtmp_common',
+      server: 'rtmps://rtmp-api.facebook.com:443/rtmp/',
     });
     this.SET_STREAM_KEY(streamKey);
     this.SET_STREAM_PAGE_URL(`https://facebook.com/${liveVideo.permalink_url}`);

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -154,6 +154,7 @@ export class TwitchService extends BasePlatformService<ITwitchServiceState>
         key,
         platform: 'twitch',
         streamType: 'rtmp_common',
+        server: 'auto',
       });
     }
 

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -293,6 +293,7 @@ export class YoutubeService extends BasePlatformService<IYoutubeServiceState>
       platform: 'youtube',
       key: streamKey,
       streamType: 'rtmp_common',
+      server: 'rtmp://a.rtmp.youtube.com/live2',
     });
 
     // update the local state


### PR DESCRIPTION
This will force the server back to the default server, which is the best option for most people, and reflects "recommended settings".