### PR TITLE
fix empty checkboxes in Jar widget

### DIFF
--- a/app/components/widgets/TipJar.vue.ts
+++ b/app/components/widgets/TipJar.vue.ts
@@ -29,6 +29,7 @@ const nameMap = () => ({
   facebook_shares: $t('Facebook Shares'),
   facebook_stars: $t('Facebook Stars'),
   facebook_supports: $t('Facebook Supports'),
+  facebook_support_gifters: $t('Facebook Support Gifters')
 });
 
 const mediaGalleryInputs = {
@@ -69,7 +70,7 @@ export default class TipJar extends WidgetSettings<ITipJarData, TipJarService> {
   }
 
   get iterableTypes() {
-    return Object.keys(this.wData.settings.types).filter(key => key !== '_id');
+    return Object.keys(this.wData.settings.types).filter(key => key !== '_id' && key !== 'priority');
   }
 
   get platform() {

--- a/app/components/widgets/TipJar.vue.ts
+++ b/app/components/widgets/TipJar.vue.ts
@@ -29,7 +29,7 @@ const nameMap = () => ({
   facebook_shares: $t('Facebook Shares'),
   facebook_stars: $t('Facebook Stars'),
   facebook_supports: $t('Facebook Supports'),
-  facebook_support_gifters: $t('Facebook Support Gifters')
+  facebook_support_gifters: $t('Facebook Support Gifters'),
 });
 
 const mediaGalleryInputs = {
@@ -70,7 +70,9 @@ export default class TipJar extends WidgetSettings<ITipJarData, TipJarService> {
   }
 
   get iterableTypes() {
-    return Object.keys(this.wData.settings.types).filter(key => key !== '_id' && key !== 'priority');
+    return Object.keys(this.wData.settings.types).filter(
+      key => key !== '_id' && key !== 'priority',
+    );
   }
 
   get platform() {

--- a/app/components/windows/WidgetEditor.vue
+++ b/app/components/windows/WidgetEditor.vue
@@ -264,7 +264,7 @@
   }
 
   .display {
-    transform: scale(0.82, 0.8) translate(-10%);
+    transform: scale(0.7, 0.7) translate(-21.4%);
   }
 }
 
@@ -280,7 +280,7 @@
   }
 
   .display {
-    transform: scale(1, 0.63) translate(0, -29%);
+    transform: scale(0.7, 0.7) translate(-21.4%);
   }
 }
 
@@ -291,13 +291,13 @@
   }
 
   .display {
-    transform: scale(0.7, 0.7) translate(-3.7%);
+    transform: scale(0.5, 0.5) translate(-10%);
   }
 }
 
 .content-container.has-leftbar.vertical {
   .display {
-    transform: scale(0.6, 0.6) translate(5%, -31%);
+    transform: scale(0.5, 0.5) translate(-10%);
   }
 }
 

--- a/app/i18n/en-US/widget-tip-jar.json
+++ b/app/i18n/en-US/widget-tip-jar.json
@@ -19,5 +19,6 @@
   "Periscope Super Hearts": "Periscope Super Hearts",
   "Picarto Follows": "Picarto Follows",
   "Picarto Subscriptions": "Picarto Subscriptions",
+  "Facebook Support Gifters": "Facebook Support Gifters",
   "Manage Jar": "Manage Jar"
 }

--- a/app/i18n/en-US/widgets.json
+++ b/app/i18n/en-US/widgets.json
@@ -95,6 +95,7 @@
   "Facebook Shares": "Facebook Shares",
   "Facebook Stars": "Facebook Stars",
   "Facebook Supports": "Facebook Supports",
+  "Facebook Support Gifters": "Facebook Support Gifters",
   "Likes": "Likes",
   "Shares": "Shares",
   "Stars": "Stars",


### PR DESCRIPTION
Issue: 
![image](https://user-images.githubusercontent.com/1477223/112497576-227c2100-8d5c-11eb-98c8-557ac92d8b2b.png)

Two fixes: added support for Facebook Support Gifters value, and for merged accounts API was returning a `priority` value that we weren't filtering out (looked on the site and don't see it anywhere there either) so I just filtered it like we do `_id`. 

Marking as draft for now, going to double check with Eric to make sure that `priority` value isn't important. 