### PR TITLE
Add Support for Several New Train Types

### DIFF
--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -43,6 +43,12 @@ interface ITrains {
   subscription: ITrainInfo;
   follow: ITrainInfo;
   support: ITrainInfo;
+  bits: ITrainInfo;
+  stars: ITrainInfo;
+  sponsor: ITrainInfo;
+  superchat: ITrainInfo;
+  youtube_subscriber: ITrainInfo;
+  facebook_follow: ITrainInfo;
 }
 
 export interface IStreamlabelSet {
@@ -69,7 +75,7 @@ export interface IStreamlabelSettingsDefinition {
   settingsWhitelist?: string[];
 }
 
-type TTrainType = 'donation' | 'follow' | 'subscription' | 'support';
+type TTrainType = 'donation' | 'follow' | 'subscription' | 'support' | 'bits' | 'stars' | 'sponsor' | 'superchat' | 'youtube_subscriber' | 'facebook_follow';
 
 interface IStreamlabelsServiceState {
   definitions: IStreamlabelSet;
@@ -136,18 +142,54 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
       counter: 0,
       setting: 'train_twitch_subscriptions',
     },
+    youtube_subscriber: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_youtube_subscribers',
+    },
     follow: {
       mostRecentEventAt: null,
       mostRecentName: null,
       counter: 0,
       setting: 'train_twitch_follows',
     },
+    facebook_follow: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_facebook_follows',
+    },
     support: {
       mostRecentEventAt: null,
       mostRecentName: null,
       counter: 0,
       setting: 'train_facebook_supports',
-    }
+    },
+    bits: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_twitch_bits',
+    },
+    stars: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_facebook_stars',
+    },
+    sponsor: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_youtube_sponsors',
+    },
+    superchat: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_youtube_superchats',
+    },
   };
 
   @mutation()
@@ -191,7 +233,7 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
     };
 
     // Because trains are client-side, we can force a fast update
-    if (['train_tips', 'train_twitch_follows', 'train_twitch_subscriptions', 'train_facebook_supports'].includes(statname)) {
+    if (['train_tips', 'train_twitch_follows', 'train_twitch_subscriptions', 'train_facebook_supports', 'train_twitch_bits', 'train_facebook_stars', 'train_youtube_sponsors', 'train_youtube_superchats', 'train_youtube_subscribers', 'train_facebook_follows'].includes(statname)) {
       this.outputAllTrains();
     }
 
@@ -415,28 +457,80 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
 
       this.outputTrainInfo('donation');
     } else if (event.type === 'follow') {
-      this.trains.follow.mostRecentEventAt = Date.now();
-      this.trains.follow.counter += event.message.length;
+      if (event.for === 'twitch_account') {
+        this.trains.follow.mostRecentEventAt = Date.now();
+        this.trains.follow.counter += event.message.length;
 
-      const latest = event.message[event.message.length - 1];
-      this.trains.follow.mostRecentName = latest.name;
+        const latest = event.message[event.message.length - 1];
+        this.trains.follow.mostRecentName = latest.name;
 
-      this.outputTrainInfo('follow');
+        this.outputTrainInfo('follow');
+      } else if (event.for === 'facebook_account') {
+        this.trains.facebook_follow.mostRecentEventAt = Date.now();
+        this.trains.facebook_follow.counter += event.message.length;
+
+        const latest = event.message[event.message.length - 1];
+        this.trains.facebook_follow.mostRecentName = latest.name;
+
+        this.outputTrainInfo('facebook_follow');
+      } else if (event.for === 'youtube_account') {
+        this.trains.youtube_subscriber.mostRecentEventAt = Date.now();
+        this.trains.youtube_subscriber.counter += event.message.length;
+
+        const latest = event.message[event.message.length - 1];
+        this.trains.youtube_subscriber.mostRecentName = latest.name;
+
+        this.outputTrainInfo('youtube_subscriber');
+      }
     } else if (event.type === 'subscription') {
-      this.trains.subscription.mostRecentEventAt = Date.now();
-      this.trains.subscription.counter += event.message.length;
-
-      const latest = event.message[event.message.length - 1];
-      this.trains.subscription.mostRecentName = latest.name;
-
-      this.outputTrainInfo('subscription');
+        if (event.for === 'twitch_account') {
+          this.trains.subscription.mostRecentEventAt = Date.now();
+          this.trains.subscription.counter += event.message.length;
+    
+          const latest = event.message[event.message.length - 1];
+          this.trains.subscription.mostRecentName = latest.name;
+    
+          this.outputTrainInfo('subscription');
+        } else if (event.for === 'youtube_account') {
+          this.trains.sponsor.mostRecentEventAt = Date.now();
+          this.trains.sponsor.counter += event.message.length;
+    
+          const latest = event.message[event.message.length - 1];
+          this.trains.sponsor.mostRecentName = latest.name;
+    
+          this.outputTrainInfo('sponsor');
+        }
     } else if (event.type === 'support') {
-      this.trains.subscription.mostRecentEventAt = Date.now();
-      this.trains.subscription.counter += event.message.length;
+      this.trains.support.mostRecentEventAt = Date.now();
+      this.trains.support.counter += event.message.length;
 
       const latest = event.message[event.message.length - 1];
-      this.trains.subscription.mostRecentName = latest.name;
+      this.trains.support.mostRecentName = latest.name;
       this.outputTrainInfo('support');
+    } else if (event.type === 'bits') {
+      this.trains.bits.mostRecentEventAt = Date.now();
+      this.trains.bits.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.bits.mostRecentName = latest.name;
+
+      this.outputTrainInfo('bits');
+    } else if (event.type === 'superchat') {
+      this.trains.superchat.mostRecentEventAt = Date.now();
+      this.trains.superchat.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.superchat.mostRecentName = latest.name;
+
+      this.outputTrainInfo('superchat');
+    } else if (event.type === 'stars') {
+      this.trains.stars.mostRecentEventAt = Date.now();
+      this.trains.stars.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.stars.mostRecentName = latest.name;
+
+      this.outputTrainInfo('stars');
     }
   }
 

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -75,7 +75,17 @@ export interface IStreamlabelSettingsDefinition {
   settingsWhitelist?: string[];
 }
 
-type TTrainType = 'donation' | 'follow' | 'subscription' | 'support' | 'bits' | 'stars' | 'sponsor' | 'superchat' | 'youtube_subscriber' | 'facebook_follow';
+type TTrainType =
+  | 'donation'
+  | 'follow'
+  | 'subscription'
+  | 'support'
+  | 'bits'
+  | 'stars'
+  | 'sponsor'
+  | 'superchat'
+  | 'youtube_subscriber'
+  | 'facebook_follow';
 
 interface IStreamlabelsServiceState {
   definitions: IStreamlabelSet;
@@ -233,7 +243,20 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
     };
 
     // Because trains are client-side, we can force a fast update
-    if (['train_tips', 'train_twitch_follows', 'train_twitch_subscriptions', 'train_facebook_supports', 'train_twitch_bits', 'train_facebook_stars', 'train_youtube_sponsors', 'train_youtube_superchats', 'train_youtube_subscribers', 'train_facebook_follows'].includes(statname)) {
+    if (
+      [
+        'train_tips',
+        'train_twitch_follows',
+        'train_twitch_subscriptions',
+        'train_facebook_supports',
+        'train_twitch_bits',
+        'train_facebook_stars',
+        'train_youtube_sponsors',
+        'train_youtube_superchats',
+        'train_youtube_subscribers',
+        'train_facebook_follows',
+      ].includes(statname)
+    ) {
       this.outputAllTrains();
     }
 
@@ -483,23 +506,23 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
         this.outputTrainInfo('youtube_subscriber');
       }
     } else if (event.type === 'subscription') {
-        if (event.for === 'twitch_account') {
-          this.trains.subscription.mostRecentEventAt = Date.now();
-          this.trains.subscription.counter += event.message.length;
-    
-          const latest = event.message[event.message.length - 1];
-          this.trains.subscription.mostRecentName = latest.name;
-    
-          this.outputTrainInfo('subscription');
-        } else if (event.for === 'youtube_account') {
-          this.trains.sponsor.mostRecentEventAt = Date.now();
-          this.trains.sponsor.counter += event.message.length;
-    
-          const latest = event.message[event.message.length - 1];
-          this.trains.sponsor.mostRecentName = latest.name;
-    
-          this.outputTrainInfo('sponsor');
-        }
+      if (event.for === 'twitch_account') {
+        this.trains.subscription.mostRecentEventAt = Date.now();
+        this.trains.subscription.counter += event.message.length;
+
+        const latest = event.message[event.message.length - 1];
+        this.trains.subscription.mostRecentName = latest.name;
+
+        this.outputTrainInfo('subscription');
+      } else if (event.for === 'youtube_account') {
+        this.trains.sponsor.mostRecentEventAt = Date.now();
+        this.trains.sponsor.counter += event.message.length;
+
+        const latest = event.message[event.message.length - 1];
+        this.trains.sponsor.mostRecentName = latest.name;
+
+        this.outputTrainInfo('sponsor');
+      }
     } else if (event.type === 'support') {
       this.trains.support.mostRecentEventAt = Date.now();
       this.trains.support.counter += event.message.length;

--- a/app/services/streamlabels/index.ts
+++ b/app/services/streamlabels/index.ts
@@ -42,6 +42,7 @@ interface ITrains {
   donation: IDonationTrainInfo;
   subscription: ITrainInfo;
   follow: ITrainInfo;
+  support: ITrainInfo;
 }
 
 export interface IStreamlabelSet {
@@ -68,7 +69,7 @@ export interface IStreamlabelSettingsDefinition {
   settingsWhitelist?: string[];
 }
 
-type TTrainType = 'donation' | 'follow' | 'subscription';
+type TTrainType = 'donation' | 'follow' | 'subscription' | 'support';
 
 interface IStreamlabelsServiceState {
   definitions: IStreamlabelSet;
@@ -141,6 +142,12 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
       counter: 0,
       setting: 'train_twitch_follows',
     },
+    support: {
+      mostRecentEventAt: null,
+      mostRecentName: null,
+      counter: 0,
+      setting: 'train_facebook_supports',
+    }
   };
 
   @mutation()
@@ -184,7 +191,7 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
     };
 
     // Because trains are client-side, we can force a fast update
-    if (['train_tips', 'train_twitch_follows', 'train_twitch_subscriptions'].includes(statname)) {
+    if (['train_tips', 'train_twitch_follows', 'train_twitch_subscriptions', 'train_facebook_supports'].includes(statname)) {
       this.outputAllTrains();
     }
 
@@ -423,6 +430,13 @@ export class StreamlabelsService extends StatefulService<IStreamlabelsServiceSta
       this.trains.subscription.mostRecentName = latest.name;
 
       this.outputTrainInfo('subscription');
+    } else if (event.type === 'support') {
+      this.trains.subscription.mostRecentEventAt = Date.now();
+      this.trains.subscription.counter += event.message.length;
+
+      const latest = event.message[event.message.length - 1];
+      this.trains.subscription.mostRecentName = latest.name;
+      this.outputTrainInfo('support');
     }
   }
 


### PR DESCRIPTION
Added support for the following train types in Stream Labels: 
- Twitch Bits
- Facebook Supporters
- Facebook Stars
- Facebook Follows
- Youtube Subscribers
- Youtube Sponsors
- Youtube Superchats

FB Follows, YT Subs and YT Sponsors required a minor refactor due to how they're sent via the websocket. 

On hold until Karl ships support on the API side, this was tested against beta.streamlabs.com prior to creating PR. 