### PR TITLE
Fix Search Term Highlighting Style

### DIFF
--- a/app/components/shared/SearchablePages.m.less
+++ b/app/components/shared/SearchablePages.m.less
@@ -9,6 +9,7 @@
   // text
   :global(mark) {
     border-radius: 2px;
+    background: yellow;
   }
 
   :global(.search-highlight) {


### PR DESCRIPTION
The highlight color for search terms in Settings was getting overridden by AntD (pretty sure), this fixes it. 

Before: 
![image](https://user-images.githubusercontent.com/1477223/114627079-a9992680-9c82-11eb-8013-df2e5b86746e.png)

After: 
![image](https://user-images.githubusercontent.com/1477223/114627116-b74eac00-9c82-11eb-8776-d8b1cb31b34e.png)

