### PR TITLE
Memory dump option

### DIFF
--- a/app/components/windows/settings/ExtraSettings.vue
+++ b/app/components/windows/settings/ExtraSettings.vue
@@ -25,6 +25,10 @@
             <i class="fa fa-spinner fa-spin" v-if="cacheUploading" />
           </a>
         </div>
+        <bool-input
+          v-model="enableCrashDumpUpload"
+          :metadata="{ title: $t('Enable reporting additional information on a crash (requires restart)'), name: 'enable_dump_upload'  }"
+        />
       </div>
     </div>
     <div class="section">

--- a/app/components/windows/settings/ExtraSettings.vue.ts
+++ b/app/components/windows/settings/ExtraSettings.vue.ts
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 import { ObsImporterService } from 'services/obs-importer';
 import { StreamSettingsService } from 'services/settings/streaming';
+import rimraf from 'rimraf';
 
 @Component({
   components: { BoolInput },
@@ -148,5 +149,33 @@ export default class ExtraSettings extends Vue {
 
   get disableHAFilePath() {
     return path.join(this.appService.appDataDirectory, 'HADisable');
+  }
+
+  enableCU: boolean = null;
+
+  get enableCrashDumpUpload() {
+    if (this.enableCU == null) {
+      this.enableCU = fs.existsSync(this.enableCUFilePath);
+    }
+
+    return this.enableCU;
+  }
+
+  set enableCrashDumpUpload(val: boolean) {
+    try {
+      if (val) {
+        fs.mkdirSync(this.enableCUFilePath);
+        this.enableCU = true;
+      } else {
+        rimraf.sync(this.enableCUFilePath);
+        this.enableCU = false;
+      }
+    } catch (e) {
+      console.error('Error setting crash upload option', e);
+    }
+  }
+
+  get enableCUFilePath() {
+    return path.join(this.appService.appDataDirectory, 'CrashMemoryDump');
   }
 }

--- a/app/components/windows/settings/ExtraSettings.vue.ts
+++ b/app/components/windows/settings/ExtraSettings.vue.ts
@@ -170,7 +170,7 @@ export default class ExtraSettings extends Vue {
         rimraf.sync(this.enableCUFilePath);
         this.enableCU = false;
       }
-    } catch (e) {
+    } catch (e: unknown) {
       console.error('Error setting crash upload option', e);
     }
   }

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -25,6 +25,7 @@
   "Configure Default Devices": "Configure Default Devices",
   "OBS Import": "OBS Import",
   "Confirm stream title and game before going live": "Confirm stream title and game before going live",
+  "Enable reporting additional information on a crash (requires restart)": "Enable reporting additional information on a crash (requires restart)",
   "WARNING! You will lose all scenes, sources, and settings. This cannot be undone!": "WARNING! You will lose all scenes, sources, and settings. This cannot be undone!",
   "Your cache directory has been successfully uploaded.  The file name %{file} has been copied to your clipboard.": "Your cache directory has been successfully uploaded.  The file name %{file} has been copied to your clipboard.",
   "Stream Labels session has been successfully restarted!": "Stream Labels session has been successfully restarted!",


### PR DESCRIPTION
Option to control memory dump on crash functionality. 
It create and remove folder inside users cache folder. 

This folder be used by this PRs.
https://github.com/stream-labs/crash-handler/pull/61
https://github.com/stream-labs/obs-studio-node/pull/901