### PR TITLE
fb chat fixes and go live window fixes

### DIFF
--- a/app/components-react/windows/go-live/GameSelector.tsx
+++ b/app/components-react/windows/go-live/GameSelector.tsx
@@ -74,6 +74,7 @@ export default function GameSelector(p: TProps) {
       imageSize={TwitchService.gameImageSize}
       loading={isSearching}
       notFoundContent={isSearching ? $t('Searching...') : $t('No matching game(s) found.')}
+      allowClear
     />
   );
 }

--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -77,7 +77,7 @@
         </div>
         <div
           class="live-dock-chat"
-          v-if="!hideStyleBlockers && (isTwitch || (isYoutube && isStreaming) || isFacebook)"
+          v-if="!hideStyleBlockers && (isTwitch || (isYoutube && isStreaming) || isFacebook && isStreaming)"
         >
           <div v-if="hasChatTabs" class="flex">
             <tabs :tabs="chatTabs" v-model="selectedChat" :hideContent="true" />

--- a/app/services/integrations/twitter.ts
+++ b/app/services/integrations/twitter.ts
@@ -40,7 +40,7 @@ export class TwitterService extends PersistentStatefulService<ITwitterServiceSta
     creatorSiteOnboardingComplete: false,
     creatorSiteUrl: '',
     screenName: '',
-    tweetWhenGoingLive: true,
+    tweetWhenGoingLive: false,
   };
 
   init() {

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -524,12 +524,9 @@ export class FacebookService
       this.state.facebookPages.find(p => p.id === this.state.settings.pageId);
 
     // determine the chat url
-    if (page && page.category === 'Gaming Video Creator') {
-      // GVC pages have a specific chat url
+    if (page) {
+      // pages have a specific chat url
       return `https://www.facebook.com/live/producer/dashboard/${this.state.videoId}/COMMENTS/`;
-    } else if (page && this.state.settings.game) {
-      // if it's not a GVC page but the game is selected then use a legacy chatUrl
-      return 'https://www.facebook.com/gaming/streamer/chat/';
     } else {
       // in other cases we can use only read-only chat
       const token = this.views.getDestinationToken(


### PR DESCRIPTION
- added the sleeping kevin offline image to FB chat like we have for YT
- removed GVC restriction from FB chat
- added ability to clear the game selector
- changed default tweet state to true