### PR TITLE
ensure tweet state is false when unlinked or logged out

### DIFF
--- a/app/services/integrations/twitter.ts
+++ b/app/services/integrations/twitter.ts
@@ -73,7 +73,7 @@ export class TwitterService extends PersistentStatefulService<ITwitterServiceSta
     this.state.creatorSiteOnboardingComplete = false;
     this.state.creatorSiteUrl = '';
     this.state.screenName = '';
-    this.state.tweetWhenGoingLive = true;
+    this.state.tweetWhenGoingLive = false;
   }
 
   setTweetPreference(preference: boolean) {
@@ -93,7 +93,7 @@ export class TwitterService extends PersistentStatefulService<ITwitterServiceSta
   }
 
   async unlinkTwitter() {
-    this.SET_TWEET_PREFERENCE(false);
+    this.RESET_TWITTER_STATUS();
     const host = this.hostsService.streamlabs;
     const url = `https://${host}/api/v5/slobs/twitter/unlink`;
     const headers = authorizedHeaders(this.userService.apiToken);


### PR DESCRIPTION
I had only changed the default state in my previous PR, but we were not properly resetting it when unlinking or logging out. 