### PR TITLE
Fix FrankerFaceZ Settings Window

### DIFF
--- a/app/components/windows/FFZSettings.vue
+++ b/app/components/windows/FFZSettings.vue
@@ -5,6 +5,7 @@
         class="ffz-settings-container"
         id="ffz-settings"
         ref="ffzSettings"
+        :partition="partition"
         :src="popoutURL"
       />
     </div>

--- a/app/components/windows/FFZSettings.vue.ts
+++ b/app/components/windows/FFZSettings.vue.ts
@@ -4,6 +4,7 @@ import { Inject } from '../../services/core/injector';
 import ModalLayout from '../ModalLayout.vue';
 import { CustomizationService } from 'services/customization';
 import { WindowsService } from 'services/windows';
+import { UserService } from 'services/user';
 
 @Component({
   components: {
@@ -13,6 +14,7 @@ import { WindowsService } from 'services/windows';
 export default class FFZSettings extends Vue {
   @Inject() customizationService: CustomizationService;
   @Inject() windowsService: WindowsService;
+  @Inject() userService: UserService;
 
   $refs: {
     ffzSettings: Electron.WebviewTag;
@@ -39,6 +41,10 @@ export default class FFZSettings extends Vue {
         true,
       );
     });
+  }
+
+  get partition() {
+    return this.userService.isLoggedIn ? this.userService.views.auth.partition : undefined;
   }
 
   get popoutURL() {


### PR DESCRIPTION
Currently, the FFZ Settings window provided by SLOBS is effectively useless because it runs in a different partition than other embedded Twitch pages.

This PR grabs the authenticated user's partition from `UserService` and adds it to the `<webview />` in the FFZ Settings window. I copied the way the partition is read in `app/components/editor/elements/Browser.tsx` for this purpose.