### PR TITLE
skip setting output res for tiktok users

### DIFF
--- a/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
+++ b/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
@@ -165,14 +165,9 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
       bitrate: currentSettings.streaming.bitrate,
     };
 
-    // change the resolution only if user didn't set a custom one
-    if (!currentSettings.streaming.hasCustomResolution) {
-      // skip this output res step for tiktok since they stream in portrait
-      if (this.userService.platformType === 'tiktok') {
-        return;
-      } else {
-        newStreamingSettings.outputResolution = encoderProfile.resolutionOut;
-      }
+    // change the resolution only if user didn't set a custom one or if not using tiktok
+    if (!currentSettings.streaming.hasCustomResolution && this.userService.platformType !== 'tiktok') {
+      newStreamingSettings.outputResolution = encoderProfile.resolutionOut;
     }
 
     console.log('Apply encoder settings', newStreamingSettings);

--- a/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
+++ b/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
@@ -166,7 +166,10 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
     };
 
     // change the resolution only if user didn't set a custom one or if not using tiktok
-    if (!currentSettings.streaming.hasCustomResolution && this.userService.platformType !== 'tiktok') {
+    if (
+      !currentSettings.streaming.hasCustomResolution &&
+      this.userService.platformType !== 'tiktok'
+    ) {
       newStreamingSettings.outputResolution = encoderProfile.resolutionOut;
     }
 

--- a/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
+++ b/app/services/video-encoding-optimizations/video-encoding-optimizations.ts
@@ -4,6 +4,7 @@ import {
   IStreamingEncoderSettings,
   EEncoderFamily,
 } from 'services/settings';
+import { UserService } from 'services/user';
 import { StreamingService, EStreamingState } from 'services/streaming';
 import { Inject, mutation, PersistentStatefulService } from 'services/core';
 import { IEncoderProfile } from './definitions';
@@ -59,6 +60,7 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
   @Inject() private streamingService: StreamingService;
   @Inject() private outputSettingsService: OutputSettingsService;
   @Inject() private urlService: UrlService;
+  @Inject() userService: UserService;
 
   init() {
     super.init();
@@ -163,9 +165,14 @@ export class VideoEncodingOptimizationService extends PersistentStatefulService<
       bitrate: currentSettings.streaming.bitrate,
     };
 
+    // change the resolution only if user didn't set a custom one
     if (!currentSettings.streaming.hasCustomResolution) {
-      // change the resolution only if user didn't set a custom one
-      newStreamingSettings.outputResolution = encoderProfile.resolutionOut;
+      // skip this output res step for tiktok since they stream in portrait
+      if (this.userService.platformType === 'tiktok') {
+        return;
+      } else {
+        newStreamingSettings.outputResolution = encoderProfile.resolutionOut;
+      }
     }
 
     console.log('Apply encoder settings', newStreamingSettings);


### PR DESCRIPTION
skip setting the output res with encoder optimization for tiktok users, since they stream in portrait