### PR TITLE
fix some minor touchbar rounding issues

### DIFF
--- a/app/services/touch-bar.ts
+++ b/app/services/touch-bar.ts
@@ -257,8 +257,12 @@ export class TouchBarService extends Service {
 
       this.cpuLabel.label = `CPU: ${this.performanceService.state.CPU.toFixed(1)}%`;
       this.fpsLabel.label = `FPS: ${this.performanceService.state.frameRate.toFixed(2)}`;
-      this.dfLabel.label = `Dropped Frames: ${this.performanceService.state.numberDroppedFrames.toFixed(0)}`;
-      this.brLabel.label = `Bitrate: ${this.performanceService.state.streamingBandwidth.toFixed(0)} kbps`;
+      this.dfLabel.label = `Dropped Frames: ${this.performanceService.state.numberDroppedFrames.toFixed(
+        0,
+      )}`;
+      this.brLabel.label = `Bitrate: ${this.performanceService.state.streamingBandwidth.toFixed(
+        0,
+      )} kbps`;
     }, 2000);
   }
 

--- a/app/services/touch-bar.ts
+++ b/app/services/touch-bar.ts
@@ -257,8 +257,8 @@ export class TouchBarService extends Service {
 
       this.cpuLabel.label = `CPU: ${this.performanceService.state.CPU.toFixed(1)}%`;
       this.fpsLabel.label = `FPS: ${this.performanceService.state.frameRate.toFixed(2)}`;
-      this.dfLabel.label = `Dropped Frames: ${this.performanceService.state.numberDroppedFrames}`;
-      this.brLabel.label = `Bitrate: ${this.performanceService.state.streamingBandwidth} kbps`;
+      this.dfLabel.label = `Dropped Frames: ${this.performanceService.state.numberDroppedFrames.toFixed(0)}`;
+      this.brLabel.label = `Bitrate: ${this.performanceService.state.streamingBandwidth.toFixed(0)} kbps`;
     }, 2000);
   }
 


### PR DESCRIPTION
dropped frames and bitrate were not rounded on touchbar display, causing some wild long decimals (has been a thing since Mac release)