### PR TITLE
Downgrade to electron 10.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "css-element-queries": "1.2.3",
     "css-loader": "2.1.1",
     "dotenv": "8.2.0",
-    "electron": "10.4.4",
+    "electron": "10.4.0",
     "electron-builder": "22.7.0",
     "electron-devtools-installer": "3.1.1",
     "electron-notarize": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4697,10 +4697,10 @@ electron-window-state@5.0.3:
     jsonfile "^4.0.0"
     mkdirp "^0.5.1"
 
-electron@10.4.4:
-  version "10.4.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-10.4.4.tgz#88e45557d4fdd8189462a027644aad11b089fe1d"
-  integrity sha512-52yQJTIoj0fYVbPiroc4xBldE8cCEEiHvQpb2iyfScAAuGzCwtp4XifqHh2wvDjo1nBTys32WM9+ccf9SlEqdw==
+electron@10.4.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-10.4.0.tgz#018385914474b56110a5a43087a53c114b67c08d"
+  integrity sha512-qK8OOCWuNvEFWThmjkukkqDwIpBqULlDuMXVC9MC/2P4UaWJEjIYvBmBuTyxtFcKoE3kWvcWyeRDUuvzVxxXjA==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^12.0.12"


### PR DESCRIPTION
Temporarily downgrade to electron 10.4.0, to avoid the bug fixed here: https://github.com/electron/electron/pull/28984

This bugfix was unfortunately not backported to 10.x, so we are downgrading until we get on 11.x or later.