### PR TITLE
YT: fix go live with Low and Ultralow latency

### DIFF
--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -510,7 +510,6 @@ export class YoutubeService
       enableDvr: params.enableDvr,
       enableEmbed: broadcast.contentDetails.enableEmbed,
       projection: isMidStreamMode ? broadcast.contentDetails.projection : params.projection,
-      enableLowLatency: params.latencyPreference === 'low',
       latencyPreference: isMidStreamMode
         ? broadcast.contentDetails.latencyPreference
         : params.latencyPreference,


### PR DESCRIPTION
YT recently made a change in API that prevents users to go live to a scheduled event with UltraLow latency. Also changing latency to Low doesn't work