### PR TITLE
fix showing variation conditions on default alerts

### DIFF
--- a/app/components/widgets/AlertBox.vue
+++ b/app/components/widgets/AlertBox.vue
@@ -329,7 +329,7 @@
         :metadata="metadata.minRecentEvents"
         v-if="['donations', 'hosts'].includes(selectedAlert)"
       />
-      <div v-if="selectedId !== 'default'">
+      <div v-if="!selectedId.includes('default')">
         <v-form-group v-model="selectedVariation.condition" :metadata="metadata.conditions" />
         <v-form-group v-model="selectedVariation.conditionData" :metadata="metadata.variations" />
       </div>


### PR DESCRIPTION
default alerts are not just "default", they are "default-donations" or "default-bits", etc, so we were showing variation conditions on default alerts when we shouldn't be