### PR TITLE
GoLiveWindow: allow to select text in errors

### DIFF
--- a/app/components-react/windows/go-live/GoLiveError.m.less
+++ b/app/components-react/windows/go-live/GoLiveError.m.less
@@ -2,14 +2,11 @@
 
 .container {
   color: var(--paragraph);
-}
 
-.container_error {
-  background-color: var(--warning-bg) !important;
-}
-
-.container_success {
-  background-color: var(--teal-semi) !important;
+  // allow to select errors text
+  * {
+    user-select: text;
+  }
 }
 
 .title {

--- a/app/components-react/windows/go-live/GoLiveError.m.less
+++ b/app/components-react/windows/go-live/GoLiveError.m.less
@@ -1,8 +1,6 @@
 @import "../../../styles/index.less";
 
 .container {
-  color: var(--paragraph);
-
   // allow to select errors text
   * {
     user-select: text;

--- a/app/components-react/windows/go-live/MessageLayout.tsx
+++ b/app/components-react/windows/go-live/MessageLayout.tsx
@@ -25,7 +25,7 @@ export default function MessageLayout(p: IMessageLayoutProps & HTMLAttributes<un
 
   function render() {
     return (
-      <div>
+      <div className={styles.container}>
         <Alert type={type} message={message} showIcon description={renderDescription()} />
       </div>
     );


### PR DESCRIPTION
Fix the regression that don't allow to select text in the error message