### PR TITLE
GoLIveWindow: fix some error messages

### DIFF
--- a/app/components-react/windows/go-live/MessageLayout.tsx
+++ b/app/components-react/windows/go-live/MessageLayout.tsx
@@ -1,6 +1,6 @@
 import styles from './GoLiveError.m.less';
 import React, { useState, HTMLAttributes } from 'react';
-import { IStreamError } from '../../../services/streaming/stream-error';
+import {errorTypes, IStreamError} from '../../../services/streaming/stream-error';
 import { $t } from '../../../services/i18n';
 import { Alert } from 'antd';
 
@@ -19,9 +19,9 @@ interface IMessageLayoutProps {
 export default function MessageLayout(p: IMessageLayoutProps & HTMLAttributes<unknown>) {
   const [isErrorDetailsShown, setDetailsShown] = useState(false);
   const error = p.error;
-  const message = p.message || error?.message;
   const details = error?.details;
   const type = error ? 'error' : p.type;
+  const message = p.message || error?.message || (p.error && errorTypes[p.error.type]?.message);
 
   function render() {
     return (

--- a/app/components-react/windows/go-live/MessageLayout.tsx
+++ b/app/components-react/windows/go-live/MessageLayout.tsx
@@ -1,6 +1,6 @@
 import styles from './GoLiveError.m.less';
 import React, { useState, HTMLAttributes } from 'react';
-import {errorTypes, IStreamError} from '../../../services/streaming/stream-error';
+import { errorTypes, IStreamError } from '../../../services/streaming/stream-error';
 import { $t } from '../../../services/i18n';
 import { Alert } from 'antd';
 

--- a/app/services/streaming/stream-error.ts
+++ b/app/services/streaming/stream-error.ts
@@ -4,7 +4,7 @@ import { $t } from 'services/i18n';
 import { Services } from '../../components-react/service-provider';
 import { platform } from 'os';
 
-const errorTypes = {
+export const errorTypes = {
   PLATFORM_REQUEST_FAILED: {
     get message() {
       return $t('The request to the platform failed');


### PR DESCRIPTION
Some error messages display incorrectly.
How to reproduce:
- Enable TW for streaming
- Type banned words, for example, "kill people"
Result:
You will see an empty error message