### PR TITLE
Add FB Live Producer Link to Live Dock

### DIFF
--- a/app/components/LiveDock.vue
+++ b/app/components/LiveDock.vue
@@ -68,6 +68,13 @@
             >
               <i class="icon-studio" />
             </a>
+            <a
+              @click="openFBStreamDashboardUrl"
+              v-if="isFacebook && isStreaming"
+              v-tooltip="liveProducerTooltip"
+            >
+              <i class="icon-settings" />
+            </a>
           </div>
           <div class="flex">
             <a @click="refreshChat" v-if="isTwitch || (isYoutube && isStreaming) || isFacebook">

--- a/app/components/LiveDock.vue.ts
+++ b/app/components/LiveDock.vue.ts
@@ -69,6 +69,7 @@ export default class LiveDock extends Vue {
   viewStreamTooltip = $t('View your live stream in a web browser');
   editStreamInfoTooltip = $t('Edit your stream title and description');
   controlRoomTooltip = $t('Go to YouTube Live Dashboard');
+  liveProducerTooltip = $t('Go to the Facebook Live Producer Dashboard');
 
   mounted() {
     this.elapsedInterval = window.setInterval(() => {
@@ -156,6 +157,10 @@ export default class LiveDock extends Vue {
 
   openFBStreamUrl() {
     electron.remote.shell.openExternal(this.facebookService.streamPageUrl);
+  }
+
+  openFBStreamDashboardUrl() {
+    electron.remote.shell.openExternal(this.facebookService.streamDashboardUrl);
   }
 
   get isTwitch() {

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -36,6 +36,7 @@
   "View your live stream in a web browser": "View your live stream in a web browser",
   "Edit your stream title and description": "Edit your stream title and description",
   "Go to YouTube Live Dashboard to control your stream": "Go to YouTube Live Dashboard to control your stream",
+  "Go to the Facebook Live Producer Dashboard": "Go to the Facebook Live Producer Dashboard",
   "Are you sure you want to exit while live?": "Are you sure you want to exit while live?",
   "Enable the preview stream": "Enable the preview stream",
   "Disable the preview stream, can help with CPU": "Disable the preview stream, can help with CPU",

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -62,6 +62,7 @@ interface IFacebookServiceState extends IPlatformState {
    */
   videoId: string;
   streamPageUrl: string;
+  streamDashboardUrl: string;
   userAvatar: string;
   outageWarning: string;
 }
@@ -92,6 +93,7 @@ const initialState: IFacebookServiceState = {
   grantedPermissions: [],
   outageWarning: '',
   streamPageUrl: '',
+  streamDashboardUrl: '',
   userAvatar: '',
   videoId: '',
   settings: {
@@ -160,6 +162,11 @@ export class FacebookService
   private SET_STREAM_PAGE_URL(url: string) {
     this.state.streamPageUrl = url;
   }
+  
+  @mutation()
+  private SET_STREAM_DASHBOARD_URL(url: string) {
+    this.state.streamDashboardUrl = url;
+  }
 
   @mutation()
   protected SET_AVATAR(avatar: string) {
@@ -198,6 +205,10 @@ export class FacebookService
     return this.state.streamPageUrl;
   }
 
+  get streamDashboardUrl() : string {
+    return this.state.streamDashboardUrl;
+  }
+
   async beforeGoLive(options: IGoLiveSettings) {
     const fbOptions = options.platforms.facebook;
 
@@ -227,6 +238,7 @@ export class FacebookService
     }
     this.SET_STREAM_KEY(streamKey);
     this.SET_STREAM_PAGE_URL(`https://facebook.com/${liveVideo.permalink_url}`);
+    this.SET_STREAM_DASHBOARD_URL(`https://facebook.com/live/producer/${liveVideo.video.id}`)
     this.UPDATE_STREAM_SETTINGS({ ...fbOptions, liveVideoId: liveVideo.id });
     this.SET_VIDEO_ID(liveVideo.video.id);
 

--- a/app/services/platforms/facebook.ts
+++ b/app/services/platforms/facebook.ts
@@ -162,7 +162,7 @@ export class FacebookService
   private SET_STREAM_PAGE_URL(url: string) {
     this.state.streamPageUrl = url;
   }
-  
+
   @mutation()
   private SET_STREAM_DASHBOARD_URL(url: string) {
     this.state.streamDashboardUrl = url;
@@ -205,7 +205,7 @@ export class FacebookService
     return this.state.streamPageUrl;
   }
 
-  get streamDashboardUrl() : string {
+  get streamDashboardUrl(): string {
     return this.state.streamDashboardUrl;
   }
 
@@ -238,7 +238,7 @@ export class FacebookService
     }
     this.SET_STREAM_KEY(streamKey);
     this.SET_STREAM_PAGE_URL(`https://facebook.com/${liveVideo.permalink_url}`);
-    this.SET_STREAM_DASHBOARD_URL(`https://facebook.com/live/producer/${liveVideo.video.id}`)
+    this.SET_STREAM_DASHBOARD_URL(`https://facebook.com/live/producer/${liveVideo.video.id}`);
     this.UPDATE_STREAM_SETTINGS({ ...fbOptions, liveVideoId: liveVideo.id });
     this.SET_VIDEO_ID(liveVideo.video.id);
 


### PR DESCRIPTION
Hello streamlabs maintainers :)

This PR includes a feature I've wanted for the last couple months. It's fairly simple, and improves the functionality of streaming to Facebook. It adds a link to the live dock that link to the URL of the streaming dashboard on Facebook which is found at the link below.

## Problem Statement:
Every time I stream on Facebook I have to tediously visit the dashboard URL and copy paste in the Facebook video ID in order to make clips, view insights, make polls, and whatever else Facebook streaming supports.

https://www.facebook.com/live/producer/{VIDEO_ID}

## Solution:
I mimicked the YouTube streaming dashboard link in the live dock and made a separate one for Facebook's Live Producer.

![image](https://user-images.githubusercontent.com/24259636/120230112-9e8f5b00-c21c-11eb-92fa-af20b87c13e4.png)

Video Demo:
https://user-images.githubusercontent.com/24259636/120230914-4ce7d000-c21e-11eb-9bdf-87bb9007bcbc.mp4



## What was changed:
1. Edited LiveDock.vue to include the new `<a>` tag.
2. Added tooltip variable to LiveDock.vue.ts.
3. Added method that calls electron to open external link.
4. Added `streamDashboardUrl` state variable to /services/platorms/facebook.ts including the set and get methods.
5. Included tooltip text in en-US i18n dictionary.


