### PR TITLE
Add documentation to external API

### DIFF
--- a/app/services/api/external-api/audio/audio-source.ts
+++ b/app/services/api/external-api/audio/audio-source.ts
@@ -8,12 +8,18 @@ import { SourcesService as InternalSourcesService } from 'services/sources';
 import { Fallback } from 'services/api/external-api';
 import * as obs from '../../../../../obs-api';
 
+/**
+ * Fader variables.
+ */
 export interface IFader {
   db: number;
   deflection: number;
   mul: number;
 }
 
+/**
+ * Serialized representation of an audio source.
+ */
 export interface IAudioSourceModel {
   sourceId: string;
   name: string;
@@ -26,6 +32,10 @@ export interface IAudioSourceModel {
   mixerHidden: boolean;
 }
 
+/**
+ * API for audio source management. Provides operations related to a single
+ * audio source like set deflection and mute / unmute audio source.
+ */
 @ServiceHelper()
 export class AudioSource implements ISerializable {
   @Inject() private audioService: InternalAudioService;
@@ -40,6 +50,9 @@ export class AudioSource implements ISerializable {
     return this.audioSource.isDestroyed();
   }
 
+  /**
+   * @return A serialized representation of this {@link AudioSource}
+   */
   getModel(): IAudioSourceModel {
     const sourceModel = this.sourcesService.views.getSource(this.sourceId).getModel();
     return {
@@ -55,11 +68,22 @@ export class AudioSource implements ISerializable {
     };
   }
 
-  setDeflection(deflection: number) {
+  /**
+   * Sets the audio source's deflection.
+   *
+   * @param deflection the deflection number to set for this audio source
+   */
+  setDeflection(deflection: number): void {
     this.audioSource.setDeflection(deflection);
   }
 
-  setMuted(muted: boolean) {
+  /**
+   * Mutes /unmutes this audio source.
+   *
+   * @param muted Set to `true`if you want to mute the audio source, `false` to
+   * unmute
+   */
+  setMuted(muted: boolean): void {
     this.audioSource.setMuted(muted);
   }
 }

--- a/app/services/api/external-api/audio/audio.ts
+++ b/app/services/api/external-api/audio/audio.ts
@@ -4,7 +4,9 @@ import { AudioSource } from './audio-source';
 import { Inject } from 'services';
 
 /**
- * Provides API for manage audio sources
+ * API for audio sources management. This API provides methods for retrieving
+ * references to audio sources. If you need to execute further actions see
+ * {@link AudioSource}, {@link SceneItem} and {@link SourcesService}.
  */
 @Singleton()
 export class AudioService {
@@ -12,21 +14,41 @@ export class AudioService {
   @Inject()
   protected audioService: InternalAudioService;
 
+  /**
+   * Returns the audio source with the provided id or null if no audio
+   * source was found with that.
+   *
+   * @param sourceId The id of the audio source
+   * @returns The audio source with the provided id or `null if there is no
+   * audio source with this id
+   */
   getSource(sourceId: string): AudioSource {
     const source = this.audioService.views.getSource(sourceId);
     return source ? new AudioSource(sourceId) : null;
   }
 
+  /**
+   * @returns A list of all audio sources
+   */
   getSources(): AudioSource[] {
     return this.audioService.views.getSources().map(source => this.getSource(source.sourceId));
   }
 
+  /**
+   * @returns A list of all audio sources of the currently active scene.
+   */
   getSourcesForCurrentScene(): AudioSource[] {
     return this.audioService.views.sourcesForCurrentScene.map(source =>
       this.getSource(source.sourceId),
     );
   }
 
+  /**
+   * Returns a list of audio sources for a specific scene.
+   *
+   * @param sceneId The id of the scene to get the audio sources from
+   * @returns The list of audio sources of the specific id.
+   */
   getSourcesForScene(sceneId: string): AudioSource[] {
     return this.audioService.views
       .getSourcesForScene(sceneId)

--- a/app/services/api/external-api/notifications/notifications.ts
+++ b/app/services/api/external-api/notifications/notifications.ts
@@ -3,12 +3,18 @@ import { Inject } from 'services/core/injector';
 import { Fallback, Singleton } from 'services/api/external-api';
 import { IJsonRpcRequest } from 'services/api/jsonrpc';
 
+/**
+ * Available types of notifications.
+ */
 enum ENotificationType {
   INFO = 'INFO',
   WARNING = 'WARNING',
   SUCCESS = 'SUCCESS',
 }
 
+/**
+ * Available sub types of notifications.
+ */
 enum ENotificationSubType {
   DEFAULT = 'DEFAULT',
   DISCONNECTED = 'DISCONNECTED',
@@ -17,6 +23,9 @@ enum ENotificationSubType {
   SKIPPED = 'SKIPPED',
 }
 
+/**
+ * Notification options that are available for creating a new notification.
+ */
 interface INotificationOptions {
   message: string;
   code?: string;
@@ -27,11 +36,16 @@ interface INotificationOptions {
   data?: any;
   subType?: ENotificationSubType;
 
-  /** The notification's life time in ms. Use -1 for infinity */
+  /**
+   * The notification's life time in ms. Use -1 for infinity
+   */
   lifeTime?: number;
   showTime?: boolean;
 }
 
+/**
+ * Serialized representation of a notification.
+ */
 export interface INotificationModel extends INotificationOptions {
   id: number;
   type: ENotificationType;
@@ -44,61 +58,125 @@ export interface INotificationModel extends INotificationOptions {
   subType: ENotificationSubType;
 }
 
+/**
+ * The representation of the available notification settings.
+ */
 export interface INotificationsSettings {
   enabled: boolean;
   playSound: boolean;
 }
 
+/**
+ * API for notifications management. Provides operations for creating, reading
+ * and configuring notifications and notification options.
+ */
 @Singleton()
 export class NotificationsService {
   @Fallback()
   @Inject()
   protected notificationsService: InternalNotificationsService;
 
+  /**
+   * Creates a new notification.
+   *
+   * @param notifyInfo The notification information to use
+   * @returns The created notification
+   */
   push(notifyInfo: INotificationOptions): INotificationModel {
     return this.notificationsService.push(notifyInfo);
   }
 
+  /**
+   * Returns a notification with a specific id.
+   *
+   * @param id The id of the notification to get
+   * @returns A serialized representation of the notification
+   */
   getNotification(id: number): INotificationModel {
     return this.notificationsService.views.getNotification(id);
   }
 
-  applyAction(notificationId: number) {
+  /**
+   * Applies the action bounded with the notification.
+   *
+   * @param notificationId The id of the notification to apply its action
+   */
+  applyAction(notificationId: number): void {
     return this.notificationsService.applyAction(notificationId);
   }
 
-  getAll(type: ENotificationType): INotificationModel[] {
+  /**
+   * Returns all notifications of a specific type.
+   *
+   * @param type The type of notifications to retrieve. Set to
+   * `null` or do not provide to retrieve all notifications.
+   */
+  getAll(type?: ENotificationType): INotificationModel[] {
     return this.notificationsService.views.getAll(type);
   }
 
+  /**
+   * Returns all unread notifications of a specific type.
+   *
+   * @param type The type of notifications to retrieve. Set to
+   * `null` or do not provide to retrieve all unread notifications.
+   */
   getUnread(type: ENotificationType): INotificationModel[] {
     return this.notificationsService.views.getUnread(type);
   }
 
+  /**
+   * Returns all read notifications of a specific type.
+   *
+   * @param type The type of notifications to retrieve. Set to
+   * `null` or do not provide to retrieve all read notifications.
+   */
   getRead(type: ENotificationType): INotificationModel[] {
     return this.notificationsService.views.getRead(type);
   }
 
+  /**
+   * Marks a specific notification as read.
+   *
+   * @param id The id of notification to mark as read
+   */
   markAsRead(id: number): void {
     return this.notificationsService.markAsRead(id);
   }
 
+  /**
+   * Marks all (unread) notifications as read.
+   */
   markAllAsRead(): void {
     return this.notificationsService.markAllAsRead();
   }
 
+  /**
+   * @returns The notification settings
+   */
   getSettings(): INotificationsSettings {
     return this.notificationsService.views.getSettings();
   }
 
+  /**
+   * Sets the notification settings.
+   *
+   * @param patch The changes to apply on top of the current settings
+   */
   setSettings(patch: Partial<INotificationsSettings>): void {
     return this.notificationsService.setSettings(patch);
   }
 
+  /**
+   * Restores the default notification settings.
+   */
   restoreDefaultSettings(): void {
     return this.notificationsService.restoreDefaultSettings();
   }
 
+  /**
+   * Opens the notifications dialog.
+   */
   showNotifications(): void {
     return this.notificationsService.showNotifications();
   }

--- a/app/services/api/external-api/performance/performance.ts
+++ b/app/services/api/external-api/performance/performance.ts
@@ -2,6 +2,9 @@ import { Singleton, Fallback } from 'services/api/external-api';
 import { Inject } from 'services/core/injector';
 import { PerformanceService as InternalPerformanceService } from 'services/performance';
 
+/**
+ * Serialized representation of the performance values.
+ */
 interface IPerformanceState {
   CPU: number;
   numberDroppedFrames: number;
@@ -11,7 +14,8 @@ interface IPerformanceState {
 }
 
 /**
- * Api for performance monitoring
+ * API for performance monitoring. Provides basic information about the current
+ * performance sate.
  */
 @Singleton()
 export class PerformanceService {
@@ -19,6 +23,9 @@ export class PerformanceService {
   @Inject()
   private performanceService: InternalPerformanceService;
 
+  /**
+   * @returns A serialized representation of the current performance state
+   */
   getModel(): IPerformanceState {
     return {
       CPU: this.performanceService.state.CPU,

--- a/app/services/api/external-api/scene-collections/scene-collections.ts
+++ b/app/services/api/external-api/scene-collections/scene-collections.ts
@@ -5,15 +5,28 @@ import { Observable } from 'rxjs';
 import { Expensive } from 'services/api/external-api-limits';
 import { createProgram } from '../../../../util/webgl/utils';
 
+/**
+ * Representation of a scene collection.
+ */
 interface ISceneCollectionsManifestEntry {
   id: string;
   name: string;
 }
 
+/**
+ * Available options for creating a new scene collection. The only information
+ * currently required is the scene collection's name.
+ */
 interface ISceneCollectionCreateOptions {
   name?: string;
 }
 
+/**
+ * Detailed representation of a scene collection. Generating this detailed schema
+ * is expensive and should be avoided.
+ *
+ * @see {@link SceneCollectionsService.fetchSceneCollectionsSchema}
+ */
 interface ISceneCollectionSchema {
   name: string;
   id: string;
@@ -32,12 +45,21 @@ interface ISceneCollectionSchema {
   }[];
 }
 
+/**
+ * API for scene collections management. Provides operations for creating,
+ * changing and deleting scene collections. Also provides observables for
+ * listening on scene collection changes and accessors for scene collection
+ * detailed information.
+ */
 @Singleton()
 export class SceneCollectionsService {
   @Fallback()
   @Inject()
   protected sceneCollectionsService: InternalSceneCollectionsService;
 
+  /**
+   * The currently active scene collection.
+   */
   get activeCollection(): ISceneCollectionsManifestEntry {
     const collection = this.sceneCollectionsService.activeCollection;
     return {
@@ -46,52 +68,105 @@ export class SceneCollectionsService {
     };
   }
 
+  /**
+   * Provides the scene collection's schema including all scenes, scene nodes
+   * and sources. This operation is expensive and should be avoided if possible.
+   *
+   * @returns The currently active scene collection's schema
+   */
   @Expensive()
   fetchSceneCollectionsSchema(): Promise<ISceneCollectionSchema[]> {
     return this.sceneCollectionsService.fetchSceneCollectionsSchema();
   }
 
+  /**
+   * Creates a new scene collection with the provided options.
+   *
+   * @param options The options to use for the creation of the new scene
+   * collection
+   * @returns The scene collection's manifest entry of the new scene collection
+   */
   create(options: ISceneCollectionCreateOptions): Promise<ISceneCollectionsManifestEntry> {
     return this.sceneCollectionsService.create(options);
   }
 
+  /**
+   * Switches to the scene collection with the provided id.
+   *
+   * @param id The id of the scene collection to switch to
+   */
   load(id: string): Promise<void> {
     return this.sceneCollectionsService.load(id);
   }
 
+  /**
+   * Renames the scene collection with the provided id.
+   *
+   * @param newName The new name of the scene collection to rename
+   * @param id The id of the scene collection to rename
+   */
   rename(newName: string, id: string): Promise<void> {
     return this.sceneCollectionsService.rename(newName, id);
   }
 
   /**
-   * Deletes a scene collection.  If no id is specified, it
-   * will delete the current collection.
-   * @param id the id of the collection to delete
+   * Deletes a scene collection. If no id is specified, it will delete the
+   * current collection.
+   *
+   * @param id The id of the collection to delete
    */
   async delete(id?: string): Promise<void> {
     return this.sceneCollectionsService.delete(id);
   }
 
+  /**
+   * Observable event that is triggered whenever a new scene collection is added.
+   * The observed value is the newly added scene collection's manifest entry.
+   */
   get collectionAdded(): Observable<ISceneCollectionsManifestEntry> {
     return this.sceneCollectionsService.collectionAdded;
   }
 
+  /**
+   * Observable event that is triggered whenever a scene collection is removed.
+   * The observed value is the removed scene collection's manifest entry.
+   */
   get collectionRemoved(): Observable<ISceneCollectionsManifestEntry> {
     return this.sceneCollectionsService.collectionRemoved;
   }
 
+  /**
+   * Observable event that is triggered whenever a scene collection is about to
+   * switch. If you want to access the currently active scene collection or need
+   * to know to which scene collection will be switched use {@link activeCollection}
+   * and {@link collectionSwitched} accordingly.
+   */
   get collectionWillSwitch(): Observable<void> {
     return this.sceneCollectionsService.collectionWillSwitch;
   }
 
+  /**
+   * Observable event that is triggered after a scene collection has been
+   * switched. The observed value is the new currently active scene collection's
+   * manifest entry.
+   */
   get collectionSwitched(): Observable<ISceneCollectionsManifestEntry> {
     return this.sceneCollectionsService.collectionSwitched;
   }
 
+  /**
+   * Observable event that is triggered whenever a scene collection has been
+   * updated. This can be for example when the scene collection has been
+   * renamed. The observed value is the updated scene collection's manifest
+   * entry.
+   */
   get collectionUpdated(): Observable<ISceneCollectionsManifestEntry> {
     return this.sceneCollectionsService.collectionUpdated;
   }
 
+  /**
+   * @returns The list of manifest entries of all available scene collections.
+   */
   get collections(): ISceneCollectionsManifestEntry[] {
     return this.sceneCollectionsService.collections;
   }

--- a/app/services/api/external-api/scenes/scene-item-folder.ts
+++ b/app/services/api/external-api/scenes/scene-item-folder.ts
@@ -7,12 +7,18 @@ import { Selection } from './selection';
 import Utils from '../../../utils';
 import { ServiceHelper } from '../../../core';
 
+/**
+ * Serialized representation of {@link SceneItemFolder}.
+ */
 export interface ISceneItemFolderModel extends ISceneNodeModel {
   name: string;
 }
 
 /**
- * API for folders
+ * API for scene item folder operations. Allows actions for adding and removing
+ * scene nodes to the current folder and also operations for getting various
+ * other nodes based on this folder. For further scene item folder operations
+ * see {@link SceneNode}, {@link Scene} and {@link SourcesService}.
  */
 @ServiceHelper()
 export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel {
@@ -28,7 +34,7 @@ export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel 
   }
 
   /**
-   * serialize folder
+   * @returns A serialized representation of this {@link SceneItemFolder}
    */
   getModel(): ISceneItemFolderModel {
     return {
@@ -39,8 +45,10 @@ export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel 
   }
 
   /**
-   * Returns all direct children
-   * To get all nested children
+   * Returns all direct children. To get all nested children use
+   * {@link getNestedNodes}.
+   *
+   * @returns All direct {@link SceneNode}s
    * @see getNestedNodes
    */
   getNodes(): SceneNode[] {
@@ -49,14 +57,14 @@ export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel 
   }
 
   /**
-   * Returns all direct children items
+   * @returns All direct children {@link SceneItem}s
    */
   getItems(): SceneItem[] {
     const scene = this.getScene();
     return this.sceneFolder.getItems().map(item => scene.getItem(item.id));
   }
   /**
-   * Returns all direct children folders
+   * @returns All direct children {@link SceneItemFolder}s
    */
   getFolders(): SceneItemFolder[] {
     const scene = this.getScene();
@@ -64,8 +72,10 @@ export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel 
   }
 
   /**
-   * Returns all nested nodes.
-   * To get only direct children nodes
+   * Returns all nested nodes. To get only direct children nodes use
+   * {@link getNodes}.
+   *
+   * @returns All nested {@link SceneNode}s
    * @see getNodes
    */
   getNestedNodes(): SceneNode[] {
@@ -74,31 +84,39 @@ export class SceneItemFolder extends SceneNode implements ISceneItemFolderModel 
   }
 
   /**
-   * Renames the folder
+   * Renames this scene folder.
+   *
+   * @param newName The new name of the folder
    */
   setName(newName: string): void {
     return this.sceneFolder.setName(newName);
   }
 
   /**
-   * Add an item or folder to the current folder
-   * A shortcut for `SceneNode.setParent()`
-   * @see SceneNode.setParent()
+   * Add an item or folder to the this folder. Shortcut for
+   * {@link SceneNode.setParent}
+   *
+   * @param sceneNodeId The scene node to add to this folder
+   * @see SceneNode.setParent
    */
   add(sceneNodeId: string): void {
     return this.sceneFolder.add(sceneNodeId);
   }
 
   /**
-   * Removes folder, but keep the all nested nodes untouched
+   * Removes this folder, but keeps all nested nodes untouched by moving them
+   * to parent.
    */
   ungroup(): void {
     return this.sceneFolder.ungroup();
   }
 
   /**
-   * Returns a Selection object
-   * Helpful for bulk operations
+   * Returns a Selection object. Helpful for bulk operations on the scene nodes
+   * of this folder.
+   *
+   * @returns A new {@link Selection} object with all children of this folder
+   * selected
    */
   getSelection(): Selection {
     // convert InternalSelection to ExternalSelection

--- a/app/services/api/external-api/scenes/scene-item.ts
+++ b/app/services/api/external-api/scenes/scene-item.ts
@@ -10,6 +10,9 @@ import { getExternalNodeModel, ISceneNodeModel, SceneNode } from './scene-node';
 import Utils from '../../../utils';
 import { Inject, ServiceHelper } from '../../../core';
 
+/**
+ * Serialized representation of {@link SceneItem}.
+ */
 export interface ISceneItemModel extends ISceneItemSettings, ISceneNodeModel {
   sceneItemId: string;
   sourceId: string;
@@ -17,6 +20,9 @@ export interface ISceneItemModel extends ISceneItemSettings, ISceneNodeModel {
   resourceId: string;
 }
 
+/**
+ * Available scene item settings.
+ */
 export interface ISceneItemSettings {
   transform: ITransform;
   visible: boolean;
@@ -25,6 +31,9 @@ export interface ISceneItemSettings {
   recordingVisible: boolean;
 }
 
+/**
+ * Available cropping options.
+ */
 interface ICrop {
   top: number;
   bottom: number;
@@ -32,6 +41,9 @@ interface ICrop {
   right: number;
 }
 
+/**
+ * Available transformation settings.
+ */
 export interface ITransform {
   position: IVec2;
   scale: IVec2;
@@ -39,6 +51,11 @@ export interface ITransform {
   rotation: number;
 }
 
+/**
+ * Partial representation for applying new transformations.
+ *
+ * @see ITransform
+ */
 export interface IPartialTransform {
   position?: Partial<IVec2>;
   scale?: Partial<IVec2>;
@@ -46,27 +63,88 @@ export interface IPartialTransform {
   rotation?: number;
 }
 
+/**
+ * List of the available scene item actions.
+ */
 export interface ISceneItemActions {
+  /**
+   * Sets the items settings. Settings can be only partial representation of
+   * {@link ISceneItemSettings}.
+   *
+   * @param settings The settings to set for the this item
+   */
   setSettings(settings: Partial<ISceneItemSettings>): void;
-  setVisibility(visible: boolean): void;
-  setTransform(transform: IPartialTransform): void;
-  resetTransform(): void;
-  flipX(): void;
-  flipY(): void;
-  stretchToScreen(): void;
-  fitToScreen(): void;
-  centerOnScreen(): void;
-  rotate(deg: number): void;
-  remove(): void;
 
   /**
-   * only for scene sources
+   * Sets the item's visibility.
+   *
+   * @param visible the visibility state to set
+   */
+  setVisibility(visible: boolean): void;
+
+  /**
+   * Applies transformation to the current item. {@param transform} can be
+   * partial representation of {@link ITransform}.
+   *
+   * @param transform the transformation to apply to the item
+   */
+  setTransform(transform: IPartialTransform): void;
+
+  /**
+   * Resets the transformations of the current item.
+   */
+  resetTransform(): void;
+
+  /**
+   * Flips the scene item on the X axis.
+   */
+  flipX(): void;
+
+  /**
+   * Flips the scene item on the Y axis.
+   */
+  flipY(): void;
+
+  /**
+   * Stretches the scene item to match screen dimensions.
+   */
+  stretchToScreen(): void;
+
+  /**
+   * Scales the scene item to fit into screen dimensions.
+   */
+  fitToScreen(): void;
+
+  /**
+   * Centers the scene item on the screen.
+   */
+  centerOnScreen(): void;
+
+  /**
+   * Rotates the scene item.
+   *
+   * @param deg The degree to rotate the scene item
+   */
+  rotate(deg: number): void;
+
+  /**
+   * Removes the scene item.
+   */
+  remove(): void;
+
+  // TODO setScale not included, on purpose?
+
+  /**
+   * Sets content crop. Only for scene sources.
    */
   setContentCrop(): void;
 }
 
 /**
- * API for scene-items
+ * API for scene item operations. Provides various scene item modification
+ * options for the current scene item. For more scene related operations see
+ * {@link SceneNode} and {@link Scene}. For source related operations see
+ * {@link SourcesService}.
  */
 @ServiceHelper()
 export class SceneItem extends SceneNode implements ISceneItemActions, ISceneItemModel {
@@ -90,14 +168,14 @@ export class SceneItem extends SceneNode implements ISceneItemActions, ISceneIte
   }
 
   /**
-   * Returns the related source for the current item
+   * @returns The related source for the current item
    */
   getSource(): Source {
     return this.sourcesService.getSource(this.sceneItem.sourceId);
   }
 
   /**
-   * returns serialized representation of scene-item
+   * @returns A serialized representation of this {@link SceneItem}
    */
   getModel(): ISceneItemModel {
     const sourceModel = this.getSource().getModel();
@@ -149,15 +227,16 @@ export class SceneItem extends SceneNode implements ISceneItemActions, ISceneIte
   }
 
   /**
-   * set scale and adjust the item position according to the origin parameter
+   * Sets the scale and adjusts the scene item position according to the origin
+   * parameter.
+   *
+   * @param newScaleModel The new scale values
+   * @param origin The origin to adjust the scene item's position to
    */
-  setScale(newScaleModel: IVec2, origin?: IVec2) {
+  setScale(newScaleModel: IVec2, origin?: IVec2): void {
     return this.sceneItem.setScale(newScaleModel, origin);
   }
 
-  /**
-   * only for scene sources
-   */
   setContentCrop(): void {
     return this.setContentCrop();
   }

--- a/app/services/api/external-api/scenes/scene-node.ts
+++ b/app/services/api/external-api/scenes/scene-node.ts
@@ -12,8 +12,14 @@ import { SceneItemFolder } from './scene-item-folder';
 import { SceneItem } from './scene-item';
 import { ServiceHelper } from 'services';
 
+/**
+ * Available scene node types.
+ */
 export declare type TSceneNodeType = 'folder' | 'item';
 
+/**
+ * Serialized representation of {@link SceneNode}.
+ */
 export interface ISceneNodeModel {
   id: string;
   sceneId: string;
@@ -23,7 +29,8 @@ export interface ISceneNodeModel {
 }
 
 /**
- * A base API for Items and Folders
+ * API for scene node operations. Provides basic actions for modification,
+ * selection and reordering of a specific scene node.
  */
 export abstract class SceneNode {
   @Inject('ScenesService') protected internalScenesService: InternalScenesService;
@@ -45,128 +52,147 @@ export abstract class SceneNode {
   }
 
   /**
-   * returns serialized representation on scene-node
+   * @returns A serialized representation of this {@link SceneNode}
    */
   getModel(): ISceneNodeModel {
     return getExternalNodeModel(this.sceneNode);
   }
 
+  /**
+   * @returns The scene this scene node belongs to.
+   */
   getScene(): Scene {
     return this.scenesService.getScene(this.sceneId);
   }
 
   /**
-   * Returns parent folder
+   * @returns The parent folder
    */
   getParent(): SceneItemFolder {
     return this.getScene().getFolder(this.sceneNode.parentId);
   }
 
   /**
-   * Sets parent folder
+   * Sets parent folder. This moves the current scene node inside the folder.
+   *
+   * @param parentId The id of the parent folder
    */
   setParent(parentId: string): void {
     this.sceneNode.setParent(parentId);
   }
 
   /**
-   * Returns true if the node is inside the folder
+   * @returns `true` if the node is inside a folder, `false` otherwise
    */
   hasParent(): boolean {
     return this.sceneNode.hasParent();
   }
 
   /**
-   * Detaches the node from its parent
-   * After detaching the parent the current node will be a first-level-nesting node
+   * Detaches the scene node from its parent. After detaching the parent the
+   * current node will be a root scene node (first-level-nesting).
    */
   detachParent(): void {
     return this.sceneNode.detachParent();
   }
 
   /**
-   * Place the current node before the provided node
-   * This method can change the parent of current node
+   * Places the current node before the provided node. This method can change
+   * the parent of current node.
+   *
+   * @param nodeId The id of the node to place this scene node before
    */
   placeBefore(nodeId: string): void {
     return this.sceneNode.placeBefore(nodeId);
   }
   /**
-   * Place the current node after the provided node
-   * This method can change the parent of current node
+   * Places the current node after the provided node. This method can change
+   * the parent of current node.
+   *
+   * @param nodeId The id of the node to place this scene node after
    */
   placeAfter(nodeId: string): void {
     return this.sceneNode.placeAfter(nodeId);
   }
 
   /**
-   * Check the node is scene item
+   * Checks if the node is a {@link SceneItem}.
+   *
+   * @returns `true` if it is a {@link SceneItem}, `false` otherwise
    */
   isItem(): this is SceneItem {
     return this.sceneNode.isItem();
   }
 
   /**
-   * Check the node is scene folder
+   * Checks if the node is a {@link SceneItemFolder}.
+   *
+   * @returns `true` if it is a {@link SceneItemFolder}, `false` otherwise
    */
   isFolder(): this is SceneItemFolder {
     return this.sceneNode.isFolder();
   }
 
   /**
-   * Removes the node.
-   * For folders, all nested folders and items also will be removed.
-   * To remove a folder without removing the nested nodes, use the `SceneItemFolder.ungroup()` method
-   * @see SceneItemFolder.ungroup()
+   * Removes this scene node. For folders, all nested scene nodes will also be
+   * removed. To remove it without removing the nested nodes, use
+   * {@link SceneItemFolder.ungroup}.
+   *
+   * @see SceneItemFolder.ungroup
    */
   remove(): void {
     return this.sceneNode.remove();
   }
 
   /**
-   * A shortcut for `SelectionService.isSelected(id)`
+   * A shortcut for {@link SelectionService.isSelected}.
+   *
+   * @returns `true` if this folder is selected, `false` otherwise.
    */
   isSelected(): boolean {
     return this.isSelected();
   }
 
   /**
-   * A shortcut for `SelectionService.select(id)`
+   * Selects this scene node. Shortcut for {@link SelectionService.select}.
+   * This action does deselect previous selected scene nodes.
    */
   select(): void {
     return this.sceneNode.select();
   }
 
   /**
-   * A shortcut for `SelectionService.add(id)`
+   * Adds this scene node to selection. Shortcut for
+   * {@link SelectionService.add}. This action does not deselect previous
+   * selected scene nodes.
    */
   addToSelection(): void {
     return this.sceneNode.addToSelection();
   }
 
   /**
-   * Shortcut for `SelectionService.deselect(id)`
+   * Deselects this scene node. Shortcut for {@link SelectionService.deselect}.
    */
   deselect(): void {
     return this.sceneNode.deselect();
   }
 
   /**
-   * Returns the node index in the list of all nodes
-   * To change node index use `placeBefore` and `placeAfter` methods
+   * Returns the node index in the list of all nodes. To change node index use
+   * {@link placeBefore} and {@link placeAfter} methods.
+   *
+   * @returns The node index of all scene nodes
    */
   getNodeIndex(): number {
     return this.sceneNode.getNodeIndex();
   }
 
   /**
-   * Returns the item index in the list of all nodes.
-   * itemIndex defines the draw order of the node
-   * itemIndex for a SceneFolder is the itemIndex of the previous SceneItem
-   *
-   * To change itemIndex use `placeBefore` and `placeAfter` methods
-   *
-   * <pre>
+   * Returns the item index in the list of all nodes. The item index defines
+   * the draw order of the scene node. The item index for a
+   * {@link SceneItemFolder} is the index of the previous {@link SceneItem}.
+   * Example indexing:
+   * ```
    * nodeInd | itemInd | nodes tree
    *  0      |    0    | Folder1
    *  1      |    0    |   |_Folder2
@@ -176,14 +202,16 @@ export abstract class SceneNode {
    *  5      |    2    | Folder3
    *  6      |    3    |   |_Item4
    *  7      |    4    |   \_Item5
-   *  </pre>
+   *  ```
+   * To change the item index use {@link placeBefore} and {@link placeAfter}
+   * methods.
    */
   getItemIndex(): number {
     return this.getItemIndex();
   }
 
   /**
-   * Returns a node with the previous nodeIndex
+   * @returns The node with the previous node index
    */
   getPrevNode(): SceneNode {
     const node = this.sceneNode.getPrevNode();
@@ -191,7 +219,7 @@ export abstract class SceneNode {
   }
 
   /**
-   * Returns a node with the next nodeIndex
+   * @returns The node with the next node index
    */
   getNextNode(): SceneNode {
     const node = this.sceneNode.getPrevNode();
@@ -199,7 +227,7 @@ export abstract class SceneNode {
   }
 
   /**
-   * Returns the closest next item from the nodes list
+   * @returns The closest next item from the nodes list
    */
   getNextItem(): SceneItem {
     const item = this.sceneNode.getNextItem();
@@ -207,7 +235,7 @@ export abstract class SceneNode {
   }
 
   /**
-   * Returns the closest previous item from the nodes list
+   * @returns The closest previous item from the nodes list
    */
   getPrevItem(): SceneItem {
     const item = this.sceneNode.getPrevItem();
@@ -215,7 +243,8 @@ export abstract class SceneNode {
   }
 
   /**
-   * Returns the node path - the chain of all parent ids for the node
+   * @returns The node path that represents the chain of all parent ids for
+   * this scene node
    */
   getPath(): string[] {
     return this.sceneNode.getPath();

--- a/app/services/api/external-api/scenes/scene.ts
+++ b/app/services/api/external-api/scenes/scene.ts
@@ -10,12 +10,21 @@ import { getExternalSceneItemModel, SceneItem } from './scene-item';
 import { SceneItemFolder } from './scene-item-folder';
 import Utils from '../../../utils';
 
+/**
+ * Serialized representation of a {@link Scene}.
+ */
 export interface ISceneModel {
   id: string;
   name: string;
   nodes: ISceneNodeModel[];
 }
 
+/**
+ * API for scene management. Provides various operations for managing the scene
+ * nodes of this scene, including grouping and ungrouping of scene nodes,
+ * creating, reordering and removing sources from this scene. For more general
+ * scene operations see {@link ScenesService}.
+ */
 @ServiceHelper()
 export class Scene implements ISceneModel {
   @InjectFromExternalApi() private scenesService: ScenesService;
@@ -37,6 +46,9 @@ export class Scene implements ISceneModel {
     return this.scene.isDestroyed();
   }
 
+  /**
+   * @returns A serialized representation of this {@link Scene}
+   */
   getModel(): ISceneModel {
     return {
       id: this.scene.id,
@@ -45,56 +57,95 @@ export class Scene implements ISceneModel {
     };
   }
 
-  getNode(sceneNodeId: string): SceneNode {
+  /**
+   * Returns a specific scene node with id {@param sceneNodeId}.
+   *
+   * @param sceneNodeId The id of the scene node
+   * @returns SceneNode with the provided id or `null` if no scene node found
+   */
+  getNode(sceneNodeId: string): SceneNode | null {
     const node = this.scene.getNode(sceneNodeId);
+    if (!node) return null;
     return node.sceneNodeType === 'folder'
       ? this.getFolder(sceneNodeId)
       : this.getItem(sceneNodeId);
   }
 
-  getNodeByName(name: string): SceneNode {
+  /**
+   * Returns a specific scene node with the provided {@param name}.
+   *
+   * @param name The the name of the scene node
+   * @returns SceneNode with the provided name or `null` if no scene scene node
+   * found
+   */
+  getNodeByName(name: string): SceneNode | null {
     const node = this.scene.getNodeByName(name);
     return node ? this.getNode(node.id) : null;
   }
 
-  getItem(sceneItemId: string): SceneItem {
+  /**
+   * Returns a specific scene item with the provided {@param sceneItemId}.
+   *
+   * @param sceneItemId The id of the scene item
+   * @returns The scene item with the specified id or `null` if not found or
+   * not a {@link SceneItem}
+   */
+  getItem(sceneItemId: string): SceneItem | null {
     const item = this.scene.getItem(sceneItemId);
     if (!item) return null;
     return item ? new SceneItem(item.sceneId, item.id, item.sourceId) : null;
   }
 
-  getFolder(sceneFolderId: string): SceneItemFolder {
+  /**
+   * Returns a specific scene folder with the provided {@param sceneFolderId}.
+   *
+   * @param sceneFolderId The id of the scene folder
+   * @returns The scene folder with the specified id or `null` if not found or
+   * not a {@link SceneItemFolder}
+   */
+  getFolder(sceneFolderId: string): SceneItemFolder | null {
     const folder = this.scene.getFolder(sceneFolderId);
     if (!folder) return null;
     return folder ? new SceneItemFolder(folder.sceneId, folder.id) : null;
   }
 
+  /**
+   * @returns A list of all nodes of this scene
+   */
   getNodes(): SceneNode[] {
     return this.scene.getNodes().map(node => this.getNode(node.id));
   }
 
+  /**
+   * @returns A list of all root nodes of this scene
+   */
   getRootNodes(): SceneNode[] {
     return this.scene.getRootNodes().map(node => this.getNode(node.id));
   }
 
+  /**
+   * @returns A list of all scene items of this scene
+   */
   getItems(): SceneItem[] {
     return this.scene.getItems().map(item => this.getItem(item.id));
   }
 
+  /**
+   * @returns A list of all scene folders of this scene
+   */
   getFolders(): SceneItemFolder[] {
     return this.scene.getFolders().map(folder => this.getFolder(folder.id));
   }
 
   /**
-   * returns scene items of scene + scene items of nested scenes
+   * @returns A list of all scene items of this scene and all nested scenes
    */
   getNestedItems(): SceneItem[] {
     return this.scene.getNestedItems().map(item => this.getItem(item.id));
   }
 
   /**
-   * returns sources of scene + sources of nested scenes
-   * result also includes nested scenes
+   * @returns A list of all sources of this scene and all nested scenes
    */
   getNestedSources(): Source[] {
     return this.scene
@@ -103,36 +154,66 @@ export class Scene implements ISceneModel {
   }
 
   /**
-   * return nested scenes in the safe-to-add order
+   * @returns A list of all nested scenes in the safe-to-add order
    */
   getNestedScenes(): Scene[] {
     return this.scene.getNestedScenes().map(scene => this.scenesService.getScene(scene.id));
   }
 
   /**
-   * returns the source linked to scene
+   * @returns The source linked to this scene
    */
   getSource(): Source {
     return this.sourcesService.getSource(this.scene.id);
   }
 
-  addSource(sourceId: string, options?: ISceneNodeAddOptions): SceneItem {
+  /**
+   * Adds a source with the provided id and options to this scene.
+   *
+   * @param sourceId The id of the source
+   * @param options The options of the source
+   * @returns The created {@link SceneItem} of the source that was added to this
+   * scene or `null` if the source could not be added to the scene
+   */
+  addSource(sourceId: string, options?: ISceneNodeAddOptions): SceneItem | null {
     const newItem = this.scene.addSource(sourceId, options);
     return newItem ? this.getItem(newItem.sceneItemId) : null;
   }
 
-  createAndAddSource(name: string, type: TSourceType, settings?: Dictionary<any>): SceneItem {
+  /**
+   * Creates and adds a source to this scene.
+   *
+   * @param name The name of the source
+   * @param type The type of the source
+   * @param settings The settings of the source
+   * @returns The created {@link SceneItem} of the source that was created and
+   * added to this scene or `null` if the source could not be added to the scene
+   */
+  createAndAddSource(
+    name: string,
+    type: TSourceType,
+    settings?: Dictionary<any>,
+  ): SceneItem | null {
     const newItem = this.scene.createAndAddSource(name, type, settings);
     return newItem ? this.getItem(newItem.sceneItemId) : null;
   }
 
+  /**
+   * Creates a new folder with the provided {@param name}.
+   *
+   * @param name The name of the folder
+   * @returns The created {@link SceneItemFolder} of the newly created folder
+   */
   createFolder(name: string): SceneItemFolder {
     return this.getFolder(this.scene.createFolder(name).id);
   }
 
   /**
-   * creates sources from file system folders and files
-   * source type depends on the file extension
+   * Creates sources from file system folders and files. Source type depends on
+   * the file extensions.
+   *
+   * @param path The path to the files
+   * @param folderId The id of the folder to add the created scene nodes
    */
   addFile(path: string, folderId?: string): SceneNode {
     const newNode = this.scene.addFile(path, folderId);
@@ -140,36 +221,74 @@ export class Scene implements ISceneModel {
   }
 
   /**
-   * removes all nodes from the scene
+   * Removes all nodes from this scene.
    */
   clear(): void {
     return this.scene.clear();
   }
 
+  /**
+   * Removes the folder with the specified {@param folderId}.
+   *
+   * @param folderId The id of the folder to remove
+   */
   removeFolder(folderId: string): void {
     return this.removeFolder(folderId);
   }
 
+  /**
+   * Removes the item with the specified {@param sceneItemId}.
+   *
+   * @param sceneItemId The id of the scene item to remove
+   */
   removeItem(sceneItemId: string): void {
     return this.scene.removeItem(sceneItemId);
   }
 
+  /**
+   * Removes this scene. Shortcut for {@link ScenesService.removeScene}.
+   *
+   * @see ScenesService.removeScene
+   */
   remove(): void {
     this.scene.remove();
   }
 
+  /**
+   * Checks if the source with the specified id can be added to scene.
+   *
+   * @param sourceId The id of the source to check
+   * @returns `true` if the source can be added to this scene, `false` otherwise
+   */
   canAddSource(sourceId: string): boolean {
     return this.scene.canAddSource(sourceId);
   }
 
+  /**
+   * Changes the name of this scene.
+   *
+   * @param newName The new name of the scene
+   */
   setName(newName: string): void {
     return this.scene.setName(newName);
   }
 
+  /**
+   * Switches to this scene. Shortcut for {@link ScenesService.makeSceneActive}.
+   *
+   * @see ScenesService.makeSceneActive
+   */
   makeActive(): void {
     return this.scene.makeActive();
   }
 
+  /**
+   * Creates a {@link Selection} object and selects all nodes with the given
+   * ids (if provided).
+   *
+   * @param ids The ids of the nodes to select
+   * @returns A new {@link Selection} object of all the nodes that were found
+   */
   getSelection(ids?: string[]): Selection {
     return new Selection(this.sceneId, ids);
   }

--- a/app/services/api/external-api/scenes/scenes.ts
+++ b/app/services/api/external-api/scenes/scenes.ts
@@ -16,7 +16,8 @@ import { map } from 'rxjs/operators';
 import { SelectionService } from 'services/selection';
 
 /**
- * Api for scenes management
+ * API for scenes management. Contains operations like scene creation, switching
+ * and deletion and provides observables for scene events registration.
  */
 @Singleton()
 export class ScenesService {
@@ -51,18 +52,51 @@ export class ScenesService {
   }
 
   // convert internal models from events to external models
+  /**
+   * Observable event that is triggered whenever a new scene is added. The
+   * observed value is the newly added scene serialized as {@link ISceneModel}.
+   */
   sceneAdded = this.scenesService.sceneAdded.pipe(map(m => this.convertToExternalSceneModel(m)));
+
+  /**
+   * Observable event that is triggered whenever a scene is removed. The
+   * observed value is the scene that was removed serialized as
+   * {@link ISceneModel}.
+   */
   sceneRemoved = this.scenesService.sceneRemoved.pipe(
     map(m => this.convertToExternalSceneModel(m)),
   );
+
+  /**
+   * Observable event that is triggered whenever the scene is switched. The
+   * observed value is the scene that was switched to serialized as
+   * {@link ISceneModel}.
+   */
   sceneSwitched = this.scenesService.sceneSwitched.pipe(
     map(m => this.convertToExternalSceneModel(m)),
   );
+
+  /**
+   * Observable event that is triggered whenever a scene item is removed. The
+   * observed value is the the removed scene item serialized as
+   * {@link ISceneItemModel}.
+   */
   itemRemoved = this.scenesService.itemRemoved.pipe(
     map(m => this.convertToExternalSceneItemModel(m)),
   );
+
+  /**
+   * Observable event that is triggered whenever a new scene item is added. The
+   * observed value is the newly added scene item serialized as
+   * {@link ISceneItemModel}.
+   */
   itemAdded = this.scenesService.itemAdded.pipe(map(m => this.convertToExternalSceneItemModel(m)));
 
+  /**
+   * Observable event that is triggered whenever a scene item is updated. The
+   * observed value is the updated scene item serialized as
+   * {@link ISceneItemModel}.
+   */
   itemUpdated = (() => {
     const itemUpdated = new Subject<ISceneItemModel>();
 
@@ -82,6 +116,12 @@ export class ScenesService {
     return itemUpdated;
   })();
 
+  /**
+   * Returns the scene with the {@param id} provided.
+   *
+   * @param id The id of the scene to return
+   * @returns the scene with the {@param id}
+   */
   getScene(id: string): Scene {
     if (!this.scenesService.state.scenes[id]) return null;
     return new Scene(id);
@@ -95,29 +135,56 @@ export class ScenesService {
     return this.scenesService.views.scenes.map(scene => this.getScene(scene.id));
   }
 
-  getSceneNames() {
+  /**
+   * @returns A list with names of the available scenes.
+   */
+  getSceneNames(): string[] {
     return this.scenesService.views.scenes.map(scene => scene.name);
   }
 
+  /**
+   * Creates a new scene.
+   *
+   * @param name The name of the new scene
+   * @returns The newly created scene
+   */
   createScene(name: string): Scene {
     const scene = this.scenesService.createScene(name);
     return this.getScene(scene.id);
   }
 
+  /**
+   * Removes the scene with the {@param id}.
+   *
+   * @param id The id of the scene to remove
+   * @returns The scene that was removed
+   */
   removeScene(id: string): ISceneModel {
     const model = this.getScene(id).getModel();
     this.scenesService.removeScene(id);
     return model;
   }
 
+  /**
+   * Switches to the scene with the passed {@param id}.
+   *
+   * @param id The id of the scene to make active
+   * @returns `true` if successfully switched to the scene, `false` otherwise.
+   */
   makeSceneActive(id: string): boolean {
     return this.scenesService.makeSceneActive(id);
   }
 
+  /**
+   * Accessor for the currently active scene.
+   */
   get activeScene(): Scene {
     return this.getScene(this.activeSceneId);
   }
 
+  /**
+   * Accessor for the id of the currently active scene.
+   */
   get activeSceneId(): string {
     return this.scenesService.views.activeSceneId;
   }

--- a/app/services/api/external-api/scenes/selection.ts
+++ b/app/services/api/external-api/scenes/selection.ts
@@ -13,16 +13,19 @@ import { SceneItem } from './scene-item';
 import { SceneItemFolder } from './scene-item-folder';
 import { SceneNode } from './scene-node';
 
+/**
+ * Serialized representation of a {@link Selection}.
+ */
 export interface ISelectionModel {
   selectedIds: string[];
   lastSelectedId: string;
 }
 
 /**
- * Allows call bulk actions with scene items and folders.
- * Selection can contain items only for one scene.
- * @see Scene.getSelection() to fetch a new selection object
- * @see SelectionService to make items active
+ * API for selection operations. Allows bulk actions on scene nodes (scene items
+ * and folders). Selection can contain items only for one scene.
+ *
+ * Use {@link Scene.getSelection} to fetch a new {@link Selection} object.
  */
 @ServiceHelper()
 export class Selection implements ISceneItemActions {
@@ -38,7 +41,10 @@ export class Selection implements ISceneItemActions {
     return this.internalSelection.isDestroyed();
   }
 
-  get sceneId() {
+  /**
+   * @returns The id of the scene the selection is applied to
+   */
+  get sceneId(): string {
     return this.internalSelection.sceneId;
   }
 
@@ -47,7 +53,7 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * returns serializable representation of selection
+   * @returns A serializable representation of this {@link Selection}
    */
   getModel(): ISelectionModel {
     return {
@@ -56,49 +62,72 @@ export class Selection implements ISceneItemActions {
     };
   }
 
+  /**
+   * @returns The scene the selection applies to
+   */
   getScene(): Scene {
     return this.scenesService.getScene(this.sceneId);
   }
 
   /**
-   * Add items to current selection
+   * Adds items to current {@link Selection}.
+   *
+   * @param ids The ids of the items to add.
+   * @returns This selection
    */
   add(ids: string[]): Selection {
     this.selection.add(ids);
     return this;
   }
+
   /**
-   * Select items. Previous selected items will be unselected
+   * Selects items. Previous selected items will be unselected.
+   *
+   * @param ids ids of the items to select
+   * @returns This selection
    */
   select(ids: string[]): Selection {
     this.selection.select(ids);
     return this;
   }
+
   /**
-   * Deselect items
+   * Deselects items.
+   *
+   * @param ids ids of the items to deselect
+   * @returns This selection
    */
   deselect(ids: string[]): Selection {
     this.selection.deselect(ids);
     return this;
   }
+
   /**
-   * Reset current selection
+   * Resets current selection.
+   *
+   * @returns This selection
    */
   reset(): Selection {
     this.selection.reset();
     return this;
   }
+
   /**
-   * Invert current selection.
-   * If you need to get an inverted selection without changing the current object use `.getInverted()`
-   * @see ISelection.getInverted()
+   * Inverts current selection. If you need to get an inverted selection without
+   * changing the current object use {@link getInverted}.
+   *
+   * @returns This selection
+   * @see getInverted
    */
   invert(): Selection {
     this.selection.invert();
     return this;
   }
+
   /**
-   * Select the all items from the scene
+   * Selects all items from the scene.
+   *
+   * @returns This selection
    */
   selectAll(): Selection {
     this.selection.selectAll();
@@ -106,20 +135,25 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * Returns duplicated Selection
+   * Returns a duplication of this {@link Selection}.
+   *
+   * @returns A new instance of {@link Selection} containing all items of
+   * {@link getIds}.
    */
   clone(): Selection {
     return this.scenesService.getScene(this.sceneId).getSelection(this.getIds());
   }
+
   /**
-   * Returns all selected scene items
+   * @returns All selected {@link SceneItem}s
    */
   getItems(): SceneItem[] {
     const scene = this.scenesService.getScene(this.sceneId);
     return this.selection.getItems().map(item => scene.getItem(item.id));
   }
+
   /**
-   * Returns all selected scene folders
+   * @returns All selected {@link SceneItemFolder}s
    */
   getFolders(): SceneItemFolder[] {
     const scene = this.scenesService.getScene(this.sceneId);
@@ -127,7 +161,9 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * A visual item is visible in the editor and not locked
+   * Note: A visual item is visible in the editor and not locked.
+   *
+   * @returns All visual {@link SceneItem}s
    */
   getVisualItems(): SceneItem[] {
     const scene = this.scenesService.getScene(this.sceneId);
@@ -135,21 +171,26 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * Returns the list of selected folders and items ids
+   * @returns The list of selected folders and items ids
    */
   getIds(): string[] {
     return this.selection.getIds();
   }
+
   /**
-   * Returns the inverted list of selected folders and items ids
+   * @returns The inverted list of selected folders and items ids
    */
   getInvertedIds(): string[] {
     return this.selection.getInvertedIds();
   }
+
   /**
-   * Returns the inverted selection. The current object will not be changed.
-   * To change the current object use `.invert()`
-   * @see ISelection.invert()
+   * Returns the nodes of the scene this selection applies that are not
+   * selected. The current selection will not be changed. To change it use
+   * {@link invert}.
+   *
+   * @returns The {@link SceneNode}s of the selection's inversion
+   * @see invert
    */
   getInverted(): SceneNode[] {
     const scene = this.getScene();
@@ -157,91 +198,115 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * Returns a minimal bounding rectangle for selected items.
+   * @returns A minimal bounding rectangle for the selected items
    */
   getBoundingRect(): IRectangle {
     return this.selection.getBoundingRect();
   }
 
   /**
-   * Returns the last item or folder added to selection
+   * @returns The last item or folder added to selection
    */
   getLastSelected(): SceneNode {
     return this.getScene().getNode(this.getLastSelectedId());
   }
+
   /**
-   * Returns the id of the last item or folder added to selection
+   * @returns The id of the last item or folder added to selection
    */
   getLastSelectedId(): string {
     return this.selection.getLastSelectedId();
   }
 
   /**
-   * Returns the selection size
+   * @returns The selection size
    */
   getSize(): number {
     return this.selection.getSize();
   }
+
   /**
-   * Check the node is selected
+   * Checks if the node with the provided id is selected.
+   *
+   * @param nodeId The id of the node
+   * @returns `true` of the node is selected
    */
   isSelected(nodeId: string): boolean {
     return this.selection.isSelected(nodeId);
   }
 
   /**
-   * Copy selected item and folders to specific scene or folder
-   * For sources duplication use `.copyTo()` method.
-   * @see ISelection.copyTo()
+   * Copies selected items and folders to specific scene or folder.
+   *
+   * @param sceneId The id of the scene to copy the files into
+   * @param folderId The id of a folder inside the scene
+   * @param duplicateSources set to true of the sources should be duplicated
+   * @see moveTo
    */
   copyTo(sceneId: string, folderId?: string, duplicateSources?: boolean): void {
     this.selection.copyTo(sceneId, folderId, duplicateSources);
   }
 
   /**
-   * Do the same as `.copyTo()` and remove copied items
+   * Moves selected items and folders to specific scene or folder.
+   *
+   * @see copyTo
    */
   moveTo(sceneId: string, folderId?: string): void {
     this.selection.moveTo(sceneId, folderId);
   }
 
   /**
-   * Bulk version of `SceneNodeApi.placeAfter()`
-   * @see `SceneNodeApi.placeAfter()`
+   * Places selected items and folders after the node provided. This is a bulk
+   * version of {@link SceneNode.placeAfter}.
+   *
+   * @param sceneNodeId the id of the {@link SceneNode} the items and folders
+   * should be placed after it
+   * @see SceneNode.placeAfter
    */
   placeAfter(sceneNodeId: string): void {
     this.selection.placeAfter(sceneNodeId);
   }
 
   /**
-   * Bulk version of `SceneNodeApi.placeBefore()`
-   * @see `SceneNodeApi.placeBefore()`
+   * Places selected items and folders before the node provided. This is a bulk
+   * version of {@link SceneNode.placeBefore}.
+   *
+   * @param sceneNodeId the id of the {@link SceneNode} the items and folders
+   * should be placed before it
+   * @see SceneNode.placeBefore
    */
   placeBefore(sceneNodeId: string): void {
     this.selection.placeBefore(sceneNodeId);
   }
 
   /**
-   * Bulk version of `SceneNodeApi.setParent()`
-   * @see `SceneNodeApi.setParent()`
+   * Sets selected items and folders parent (folder) id. This moves all nodes
+   * into the provided folder. This is a bulk version of
+   * {@link SceneNode.setParent}.
+   *
+   * @param folderId The id of the folder to set as parent
+   * @see SceneNode.setParent
    */
   setParent(folderId: string): void {
     this.selection.setParent(folderId);
   }
 
   /**
-   * Returns a minimal representation of selection
-   * for selection list like this:
-   *
+   * Returns a minimal representation of the selection's root nodes. For
+   * selection list like this:
+   * ```
    * Folder1      <- selected
    *  |_ Item1    <- selected
    *  \_ Folder2  <- selected
    * Item3        <- selected
    * Folder3
-   *  |_ Item3
-   *  \_ Item4    <- selected
+   *  |_ Item4
+   *  \_ Item5    <- selected
+   * ```
+   * the return array would be [Folder1, Item3, Item5].
    *
-   *  returns Folder1, Item3, Item4
+   * @returns An array with all root nodes
    */
   getRootNodes(): SceneNode[] {
     const scene = this.getScene();
@@ -249,7 +314,7 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * Returns the linked to selection sources
+   * @returns The linked to selection sources
    */
   getSources(): Source[] {
     return this.selection
@@ -310,29 +375,29 @@ export class Selection implements ISceneItemActions {
   }
 
   /**
-   * only for scene sources
+   * Sets the content crop. Applicable only for scene sources.
    */
   setContentCrop(): void {
     return this.selection.setContentCrop();
   }
 
-  scale(scale: IVec2, origin?: IVec2) {
+  scale(scale: IVec2, origin?: IVec2): void {
     return this.selection.scale(scale, origin);
   }
 
-  scaleWithOffset(scale: IVec2, offset: IVec2) {
+  scaleWithOffset(scale: IVec2, offset: IVec2): void {
     return this.selection.scale(scale, offset);
   }
 
   /**
-   * returns true if selection contains only one SceneFolder
+   * @returns `true` if selection contains only one {@link SceneItemFolder}
    */
   isSceneFolder(): boolean {
     return this.selection.isSceneFolder();
   }
 
   /**
-   * returns true if selection contains only one SceneItem
+   * @returns `true` if selection contains only one {@link SceneItem}
    */
   isSceneItem(): boolean {
     return this.selection.isSceneFolder();

--- a/app/services/api/external-api/selection/selection.ts
+++ b/app/services/api/external-api/selection/selection.ts
@@ -17,7 +17,7 @@ export class SelectionService extends Selection {
     return this.selection.sceneId;
   }
 
-  protected get selection(): Selection {
+  protected get selection() {
     return this.internalSelectionService.views.globalSelection;
   }
 }

--- a/app/services/api/external-api/selection/selection.ts
+++ b/app/services/api/external-api/selection/selection.ts
@@ -4,8 +4,8 @@ import { Selection } from 'services/api/external-api/scenes/selection';
 import { Inject } from 'services';
 
 /**
- * Allows select/deselect items and call bulk actions on Scene Items.
- * Works only with the currently active scene.
+ * API for selection management. Allows selecting/deselecting items and bulk
+ * action calls on scene nodes. Works only with the currently active scene.
  */
 @Singleton()
 export class SelectionService extends Selection {
@@ -13,11 +13,11 @@ export class SelectionService extends Selection {
   @Inject('SelectionService')
   private internalSelectionService: InternalSelectionService;
 
-  get sceneId() {
+  get sceneId(): string {
     return this.selection.sceneId;
   }
 
-  protected get selection() {
+  protected get selection(): Selection {
     return this.internalSelectionService.views.globalSelection;
   }
 }

--- a/app/services/api/external-api/sources/source.ts
+++ b/app/services/api/external-api/sources/source.ts
@@ -10,6 +10,9 @@ import { Fallback, InjectFromExternalApi } from '../../external-api';
 import { SourcesService } from './sources';
 import Utils from '../../../utils';
 
+/**
+ * Serialized representation of a {@link Source}.
+ */
 export interface ISourceModel {
   sourceId: string;
   id: string; // Streamdeck uses id field
@@ -27,6 +30,11 @@ export interface ISourceModel {
   configurable: boolean;
 }
 
+/**
+ * API for single source management. Provides basic source operations like
+ * renaming the source or updating settings and properties form data. For more
+ * scene related operations see {@link SceneNode} and {@link Scene}.
+ */
 @ServiceHelper()
 export class Source implements ISourceModel, ISerializable {
   @Inject('SourcesService') private internalSourcesService: InternalSourcesService;
@@ -55,38 +63,75 @@ export class Source implements ISourceModel, ISerializable {
     return this.source.isDestroyed();
   }
 
+  /**
+   * @returns The serialized representation of this {@link Source}.
+   */
   getModel(): ISourceModel {
     return this.sourcesService.convertInternalModelToExternal(this.source.getModel());
   }
 
+  /**
+   * Updates the source's settings.
+   *
+   * @param settings The settings to update. Can be a partial representation.
+   */
   updateSettings(settings: Dictionary<any>): void {
     this.source.updateSettings(settings);
   }
 
+  /**
+   * @returns The source's settings
+   */
   getSettings(): Dictionary<any> {
     return this.source.getSettings();
   }
 
+  /**
+   * @returns The form data of the source's properties
+   */
   getPropertiesFormData(): TObsFormData {
     return this.source.getPropertiesFormData();
   }
 
+  /**
+   * Sets the source's properties form data.
+   *
+   * @param properties The properties form data to set
+   */
   setPropertiesFormData(properties: TObsFormData): void {
     return this.source.setPropertiesFormData(properties);
   }
 
+  /**
+   * Whether or not this source has properties.
+   *
+   * @returns `true` if this source has properties, `false` otherwise.
+   */
   hasProps(): boolean {
     return this.source.hasProps();
   }
 
+  /**
+   * Renames this source.
+   *
+   * @param newName The new name to set for this source
+   */
   setName(newName: string): void {
     return this.source.setName(newName);
   }
 
+  /**
+   * Refreshes the page of a browsers source. Only available for browser sources.
+   */
   refresh(): void {
     this.source.refresh();
   }
 
+  /**
+   * Duplicates this source.
+   *
+   * @returns A duplication of this source
+   */
   duplicate(): Source {
     return this.sourcesService.getSource(this.source.duplicate().sourceId);
   }

--- a/app/services/api/external-api/sources/sources.ts
+++ b/app/services/api/external-api/sources/sources.ts
@@ -10,11 +10,19 @@ import { Inject } from 'services/core/injector';
 import { Fallback, Singleton } from 'services/api/external-api';
 import { ISourceModel, Source } from './source';
 
+/**
+ * Available source add options.
+ */
 export interface ISourceAddOptions {
   channel?: number;
   isTemporary?: boolean;
 }
 
+/**
+ * API for sources management. Contains operations like source creation,
+ * switching and deletion and provides observables for source events
+ * registration.
+ */
 @Singleton()
 export class SourcesService {
   @Fallback()
@@ -31,23 +39,48 @@ export class SourcesService {
     return this.getSource(source.sourceId);
   }
 
-  getSource(sourceId: string): Source {
+  /**
+   * Returns the source with the provided id.
+   *
+   * @param sourceId The id of the source to get
+   */
+  getSource(sourceId: string): Source | null {
     const source = this.sourcesService.views.getSource(sourceId);
     return source ? new Source(sourceId) : null;
   }
 
+  /**
+   * @returns The list of all created sources.
+   */
   getSources(): Source[] {
     return this.sourcesService.views.getSources().map(source => this.getSource(source.sourceId));
   }
 
+  /**
+   * Removes a source by id.
+   *
+   * @param id The id of the source to remove
+   */
   removeSource(id: string): void {
     this.sourcesService.removeSource(id);
   }
 
+  /**
+   * Provides a list of all available source types.
+   *
+   * @returns A list with the available source types.
+   * @see TSourceType
+   */
   getAvailableSourcesTypesList(): IObsListOption<TSourceType>[] {
     return this.sourcesService.getAvailableSourcesTypesList();
   }
 
+  /**
+   * Returns a list of sources found by a specific name.
+   *
+   * @param name The name of the sources to get
+   * @returns A list of sources with matching name
+   */
   getSourcesByName(name: string): Source[] {
     return this.sourcesService.views
       .getSourcesByName(name)
@@ -55,39 +88,68 @@ export class SourcesService {
   }
 
   /**
-   * creates a source from a file
-   * source type depends on the file extension
+   * Creates a source from a file. The source type depends on the file
+   * extension.
+   *
+   * @param path The path to the file
+   * @returns The source created from the file
    */
-  addFile(path: string): Source {
+  addFile(path: string): Source | null {
     return this.getSource(this.sourcesService.addFile(path).sourceId);
   }
 
+  /**
+   * Opens the source's properties.
+   *
+   * @param sourceId
+   */
   showSourceProperties(sourceId: string): void {
     return this.sourcesService.showSourceProperties(sourceId);
   }
 
+  /**
+   * Opens the sources showcase (dialog for creating new sources).
+   */
   showShowcase(): void {
     return this.sourcesService.showShowcase();
   }
 
+  /**
+   * opens the sources showcase with preselected source type.
+   *
+   * @param sourceType The source type to use a preselection
+   * @see showShowcase
+   */
   showAddSource(sourceType: TSourceType): void {
     return this.sourcesService.showAddSource(sourceType);
   }
 
+  /**
+   * Observable event that is triggered whenever a new source is added. The
+   * observed value is the newly added source serialized as {@link ISourceModel}.
+   */
   get sourceAdded(): Observable<ISourceModel> {
     return this.exposeSourceEvent(this.sourcesService.sourceAdded);
   }
 
+  /**
+   * Observable event that is triggered whenever a source is updated. The
+   * observed value is the updated source serialized as {@link ISourceModel}.
+   */
   get sourceUpdated(): Observable<ISourceModel> {
     return this.exposeSourceEvent(this.sourcesService.sourceUpdated);
   }
 
+  /**
+   * Observable event that is triggered whenever a source is removed. The
+   * observed value is the removed source serialized as {@link ISourceModel}.
+   */
   get sourceRemoved(): Observable<ISourceModel> {
     return this.exposeSourceEvent(this.sourcesService.sourceRemoved);
   }
 
   /**
-   * converts an InternalApi event to ExternalApi event
+   * Converts an InternalApi event to ExternalApi event.
    */
   private exposeSourceEvent(
     observable: Observable<IInternalSourceModel>,
@@ -97,6 +159,12 @@ export class SourcesService {
     );
   }
 
+  /**
+   * Convertes an internal source model to an external / serialized source model.
+   *
+   * @param internalModel The internal source model to serialized
+   * @returns The internal model serialized as external model
+   */
   convertInternalModelToExternal(internalModel: IInternalSourceModel): ISourceModel {
     return {
       sourceId: internalModel.sourceId,

--- a/app/services/api/external-api/streaming/streaming.ts
+++ b/app/services/api/external-api/streaming/streaming.ts
@@ -4,6 +4,9 @@ import { Fallback, Singleton } from 'services/api/external-api';
 import { Observable } from 'rxjs';
 import { ISerializable } from 'services/api/rpc-api';
 
+/**
+ * Possible streaming states.
+ */
 enum EStreamingState {
   Offline = 'offline',
   Starting = 'starting',
@@ -12,6 +15,9 @@ enum EStreamingState {
   Reconnecting = 'reconnecting',
 }
 
+/**
+ * Possible recording states.
+ */
 enum ERecordingState {
   Offline = 'offline',
   Starting = 'starting',
@@ -19,6 +25,9 @@ enum ERecordingState {
   Stopping = 'stopping',
 }
 
+/**
+ * Possible replay buffer states.
+ */
 enum EReplayBufferState {
   Running = 'running',
   Stopping = 'stopping',
@@ -26,6 +35,10 @@ enum EReplayBufferState {
   Saving = 'saving',
 }
 
+/**
+ * Serialized representation of {@link StreamingService}. Includes
+ * streaming, recording and replay buffer state representation.
+ */
 interface IStreamingState {
   streamingStatus: EStreamingState;
   streamingStatusTime: string;
@@ -36,8 +49,9 @@ interface IStreamingState {
 }
 
 /**
- * Provides API to start/stop streaming and recording.
- * Allows watching for streaming status.
+ * API for streaming, recording and replay buffer management. Provides
+ * operations like starting and stopping streaming and recording and allows
+ * watching for streaming status.
  */
 @Singleton()
 export class StreamingService implements ISerializable {
@@ -45,41 +59,80 @@ export class StreamingService implements ISerializable {
   @Inject()
   protected streamingService: InternalStreamingService;
 
+  /**
+   * Observable event that is triggered whenever the the streaming state changes.
+   * The observed value determines the current streaming state and is represented
+   * by {@link EStreamingState}.
+   *
+   * @see EStreamingState
+   */
   get streamingStatusChange(): Observable<EStreamingState> {
     return this.streamingService.streamingStatusChange;
   }
 
+  /**
+   * Observable event that is triggered whenever the the recording state changes.
+   * The observed value determines the current recording state and is represented
+   * by {@link ERecordingState}.
+   *
+   * @see ERecordingState
+   */
   get recordingStatusChange(): Observable<ERecordingState> {
     return this.streamingService.recordingStatusChange;
   }
 
+  /**
+   * Observable event that is triggered whenever the the replay buffer state
+   * changes. The observed value determines the current replay buffer state and
+   * is represented by {@link EReplayBufferState}.
+   *
+   * @see EReplayBufferState
+   */
   get replayBufferStatusChange(): Observable<EReplayBufferState> {
     return this.streamingService.replayBufferStatusChange;
   }
 
   /**
-   * returns current streaming/recording status
+   * Returns The current streaming, recording and replay buffer state
+   * represented.
+   *
+   * @returns A serialized representation of {@link StreamingService}
    */
   getModel(): IStreamingState {
     return this.streamingService.getModel();
   }
 
+  /**
+   * Toggles recording.
+   */
   toggleRecording(): void {
     return this.streamingService.toggleRecording();
   }
 
+  /**
+   * Toggles streaming.
+   */
   toggleStreaming(): Promise<never> | Promise<void> {
     return this.streamingService.toggleStreaming();
   }
 
+  /**
+   * Starts replay buffer.
+   */
   startReplayBuffer(): void {
     return this.streamingService.startReplayBuffer();
   }
 
+  /**
+   * Stops replay buffer.
+   */
   stopReplayBuffer(): void {
     return this.streamingService.stopReplayBuffer();
   }
 
+  /**
+   * Saves replay.
+   */
   saveReplay(): void {
     return this.streamingService.saveReplay();
   }

--- a/app/services/api/external-api/transitions/transitions.ts
+++ b/app/services/api/external-api/transitions/transitions.ts
@@ -4,12 +4,17 @@ import { Fallback, Singleton } from 'services/api/external-api';
 import { Observable } from 'rxjs';
 import { ISerializable } from 'services/api/rpc-api';
 
+/**
+ * Serialized representation of {@link TransitionsService}.
+ */
 export interface ITransitionsServiceState {
   studioMode: boolean;
 }
 
 /**
- * Manage the studio mode transitions
+ * API for studio mode state and transitions management. Contains operations for
+ * toggling studio mode and provides observables for studio mode events
+ * registration.
  */
 @Singleton()
 export class TransitionsService implements ISerializable {
@@ -17,28 +22,41 @@ export class TransitionsService implements ISerializable {
   @Inject()
   protected transitionsService: InternalTransitionsService;
 
+  /**
+   * Observable event that is triggered whenever the studio mode is changed. The
+   * observed value determines if the studio mode is active or not.
+   */
   get studioModeChanged(): Observable<boolean> {
     return this.transitionsService.studioModeChanged;
   }
 
+  /**
+   * @returns A serialized representation of the studio mode state.
+   */
   getModel(): ITransitionsServiceState {
     return {
       studioMode: this.transitionsService.state.studioMode,
     };
   }
 
-  enableStudioMode() {
+  /**
+   * Enables the studio mode.
+   */
+  enableStudioMode(): void {
     this.transitionsService.enableStudioMode();
   }
 
-  disableStudioMode() {
+  /**
+   * Disables the studio mode.
+   */
+  disableStudioMode(): void {
     this.transitionsService.disableStudioMode();
   }
 
   /**
-   * While in studio mode, will execute a studio mode transition
+   * While in studio mode, will execute a studio mode transition.
    */
-  executeStudioModeTransition() {
+  executeStudioModeTransition(): void {
     this.transitionsService.executeStudioModeTransition();
   }
 }


### PR DESCRIPTION
Adds documentation to external API (untested).

I couldn't find a way to test the documentation web rendering like in https://stream-labs.github.io/streamlabs-obs-api-docs/docs/index.html, so the changes couldn't be tested yet properly.

I also found various bugs and issues while creating this documentation and I will contribute some bug fixes in different PRs, so stay tuned. :)

I also found out that the page https://stream-labs.github.io/streamlabs-obs-api-docs/docs/index.html is different from https://stream-labs.github.io/streamlabs-obs-api-docs/docs/. What exactly happens there? Are both related to this project or to https://github.com/stream-labs/streamlabs-obs-api-docs?

I have some wishes for the future too:
- Please provide information on how to contribute to this project properly, e.g. where to do the merge requests, what information you need in PRs, what to avoid
- Please provide information on how the documentation is rendered in https://stream-labs.github.io/streamlabs-obs-api-docs/docs/index.html
- Fix the https://tracker.streamlabs.com link or even better
- Enable GitHub issues
- Provide contact options for questions, discussions and issues related to the development