### PR TITLE
Fix method infinite recursion bugs in external API

### DIFF
--- a/app/services/api/external-api/scenes/scene-item.ts
+++ b/app/services/api/external-api/scenes/scene-item.ts
@@ -159,7 +159,7 @@ export class SceneItem extends SceneNode implements ISceneItemActions, ISceneIte
    * only for scene sources
    */
   setContentCrop(): void {
-    return this.setContentCrop();
+    return this.sceneItem.setContentCrop();
   }
 }
 

--- a/app/services/api/external-api/scenes/scene-node.ts
+++ b/app/services/api/external-api/scenes/scene-node.ts
@@ -127,7 +127,7 @@ export abstract class SceneNode {
    * A shortcut for `SelectionService.isSelected(id)`
    */
   isSelected(): boolean {
-    return this.isSelected();
+    return this.sceneNode.isSelected();
   }
 
   /**
@@ -179,7 +179,7 @@ export abstract class SceneNode {
    *  </pre>
    */
   getItemIndex(): number {
-    return this.getItemIndex();
+    return this.sceneNode.getNodeIndex();
   }
 
   /**

--- a/app/services/api/external-api/scenes/scene.ts
+++ b/app/services/api/external-api/scenes/scene.ts
@@ -147,7 +147,7 @@ export class Scene implements ISceneModel {
   }
 
   removeFolder(folderId: string): void {
-    return this.removeFolder(folderId);
+    return this.scene.removeFolder(folderId);
   }
 
   removeItem(sceneItemId: string): void {


### PR DESCRIPTION
Fixes 4 infinite recursions that exist in external API calls `SceneNode.isSelected`, `SceneNode.getItemIndex`, `SceneItem.setContentCrop` and `Scene.removeFolder`.

Question before merge:
Should the method `SceneNode.getItemIndex` be renamed to `SceneNode.getNodeIndex`? Will be an API change.