### PR TITLE
Fix NameFolder Submit

### DIFF
--- a/app/components-react/windows/NameFolder.tsx
+++ b/app/components-react/windows/NameFolder.tsx
@@ -78,9 +78,10 @@ export default function NameFolder() {
         <TextInput
           name="name"
           value={name}
-          onChange={v => setName(v)}
+          onInput={v => setName(v)}
           label={$t('Please enter the name of the folder')}
           required={true}
+          uncontrolled={false}
         />
       </Form>
     </ModalLayout>


### PR DESCRIPTION
It appears that onChange whilst focusing on an input swallows the initial MouseEvent that should be hitting the submit button