### PR TITLE
Mark serializable classes as such

### DIFF
--- a/app/services/api/external-api/performance/performance.ts
+++ b/app/services/api/external-api/performance/performance.ts
@@ -1,6 +1,7 @@
 import { Singleton, Fallback } from 'services/api/external-api';
 import { Inject } from 'services/core/injector';
 import { PerformanceService as InternalPerformanceService } from 'services/performance';
+import { ISerializable } from '../../rpc-api';
 
 interface IPerformanceState {
   CPU: number;
@@ -14,7 +15,7 @@ interface IPerformanceState {
  * Api for performance monitoring
  */
 @Singleton()
-export class PerformanceService {
+export class PerformanceService implements ISerializable {
   @Fallback()
   @Inject()
   private performanceService: InternalPerformanceService;

--- a/app/services/api/external-api/scenes/scene-node.ts
+++ b/app/services/api/external-api/scenes/scene-node.ts
@@ -11,6 +11,7 @@ import { Scene } from './scene';
 import { SceneItemFolder } from './scene-item-folder';
 import { SceneItem } from './scene-item';
 import { ServiceHelper } from 'services';
+import { ISerializable } from '../../rpc-api';
 
 export declare type TSceneNodeType = 'folder' | 'item';
 
@@ -25,7 +26,7 @@ export interface ISceneNodeModel {
 /**
  * A base API for Items and Folders
  */
-export abstract class SceneNode {
+export abstract class SceneNode implements ISerializable {
   @Inject('ScenesService') protected internalScenesService: InternalScenesService;
   @InjectFromExternalApi() protected scenesService: ScenesService;
   @Fallback() protected sceneNode: InternalSceneNode;

--- a/app/services/api/external-api/scenes/scene.ts
+++ b/app/services/api/external-api/scenes/scene.ts
@@ -9,6 +9,7 @@ import { ISceneNodeModel, SceneNode } from './scene-node';
 import { getExternalSceneItemModel, SceneItem } from './scene-item';
 import { SceneItemFolder } from './scene-item-folder';
 import Utils from '../../../utils';
+import { ISerializable } from '../../rpc-api';
 
 export interface ISceneModel {
   id: string;
@@ -17,7 +18,7 @@ export interface ISceneModel {
 }
 
 @ServiceHelper()
-export class Scene implements ISceneModel {
+export class Scene implements ISceneModel, ISerializable {
   @InjectFromExternalApi() private scenesService: ScenesService;
   @InjectFromExternalApi() private sourcesService: SourcesService;
   @Inject('ScenesService')

--- a/app/services/api/external-api/scenes/selection.ts
+++ b/app/services/api/external-api/scenes/selection.ts
@@ -12,6 +12,7 @@ import { Scene } from './scene';
 import { SceneItem } from './scene-item';
 import { SceneItemFolder } from './scene-item-folder';
 import { SceneNode } from './scene-node';
+import { ISerializable } from '../../rpc-api';
 
 export interface ISelectionModel {
   selectedIds: string[];
@@ -25,7 +26,7 @@ export interface ISelectionModel {
  * @see SelectionService to make items active
  */
 @ServiceHelper()
-export class Selection implements ISceneItemActions {
+export class Selection implements ISceneItemActions, ISerializable {
   @InjectFromExternalApi() private sourcesService: SourcesService;
   @InjectFromExternalApi() private scenesService: ScenesService;
   @Fallback() private internalSelection: InternalSelection;


### PR DESCRIPTION
Add `implements Serializable` to classes from external API that implement the `getModel()` method but not marked as serializable classes.

Main purpose for proper hierarchy generation in documentation.