### PR TITLE
Improve JSON-RPC implementation

### DIFF
--- a/app/services/api/external-api.ts
+++ b/app/services/api/external-api.ts
@@ -168,12 +168,15 @@ export class ExternalApiService extends RpcApi {
 
     // return error if there are not enough points
     if (this.points < costPerSecond) {
-      return this.jsonrpc.createError(request, {
-        code: E_JSON_RPC_ERROR.INVALID_REQUEST,
-        message: `Reached the limit of calls for "${resourceName}.${methodName}"${
-          comment ? ' ' + comment : ''
-        }`,
-      });
+      return this.jsonrpc.createError(
+        {
+          code: E_JSON_RPC_ERROR.INVALID_REQUEST,
+          message: `Reached the limit of calls for "${resourceName}.${methodName}"${
+            comment ? ' ' + comment : ''
+          }`,
+        },
+        request,
+      );
     }
 
     // extract points and call the base method

--- a/app/services/api/jsonrpc/jsonrpc-api.ts
+++ b/app/services/api/jsonrpc/jsonrpc-api.ts
@@ -12,7 +12,7 @@ export enum E_JSON_RPC_ERROR {
 
 export interface IJsonRpcRequest {
   jsonrpc: '2.0';
-  id: string;
+  id?: string | number | null;
   method: string;
   params: {
     resource: string;
@@ -26,7 +26,7 @@ export interface IJsonRpcRequest {
 
 export interface IJsonRpcResponse<TResponse> {
   jsonrpc: '2.0';
-  id?: string | number;
+  id: string | number | null;
   result?: TResponse;
   error?: {
     code: number;

--- a/app/services/api/jsonrpc/jsonrpc.ts
+++ b/app/services/api/jsonrpc/jsonrpc.ts
@@ -107,6 +107,6 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
     data: any;
     isRejected?: boolean;
   }): IJsonRpcResponse<IJsonRpcEvent> {
-    return JsonrpcService.createResponse.apply(this, options);
+    return JsonrpcService.createEvent.apply(this, options);
   }
 }

--- a/app/services/api/jsonrpc/jsonrpc.ts
+++ b/app/services/api/jsonrpc/jsonrpc.ts
@@ -10,22 +10,14 @@ import uuid from 'uuid/v4';
 
 export class JsonrpcService extends Service implements IJsonrpcServiceApi {
   static createError(
-    requestOrRequestId: string | IJsonRpcRequest,
     options: { code: E_JSON_RPC_ERROR; message?: string },
+    request?: IJsonRpcRequest,
   ): IJsonRpcResponse<any> {
-    /* eslint-disable */
-    const id =
-      arguments[0] && typeof arguments[0] === 'object'
-        ? (arguments[0] as IJsonRpcRequest).id
-        : arguments[0];
-
-    /* eslint-enable */
     return {
-      id,
+      id: request?.id || null,
       jsonrpc: '2.0',
       error: {
         code: options.code,
-        // tslint:disable-next-line:prefer-template
         message: E_JSON_RPC_ERROR[options.code] + (options.message ? ' ' + options.message : ''),
       },
     };
@@ -60,16 +52,14 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
   }
 
   static createResponse<TResult>(
-    requestOrRequestId: string | IJsonRpcRequest,
+    request?: IJsonRpcRequest,
     result: TResult = null,
   ): IJsonRpcResponse<TResult> {
-    /* eslint-disable */
-    const id =
-      arguments[0] && typeof arguments[0] === 'object'
-        ? (arguments[0] as IJsonRpcRequest).id
-        : arguments[0];
-    /* eslint-enable */
-    return { id, result, jsonrpc: '2.0' } as IJsonRpcResponse<TResult>;
+    return {
+      jsonrpc: '2.0',
+      id: request?.id || null,
+      result,
+    } as IJsonRpcResponse<TResult>;
   }
 
   static createEvent(options: {
@@ -78,23 +68,21 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
     data: any;
     isRejected?: boolean;
   }): IJsonRpcResponse<IJsonRpcEvent> {
-    return this.createResponse<IJsonRpcEvent>(null, {
+    return this.createResponse<IJsonRpcEvent>(undefined, {
       _type: 'EVENT',
       ...options,
     });
   }
 
   createError(
-    requestOrRequestId: string | IJsonRpcRequest,
     options: { code: E_JSON_RPC_ERROR; message?: string },
+    request?: IJsonRpcRequest,
   ): IJsonRpcResponse<any> {
-    // eslint-disable-next-line
-    return JsonrpcService.createError.apply(this, arguments);
+    return JsonrpcService.createError.apply(this, [options, request]);
   }
 
   createRequest(resourceId: string, method: string, ...args: any[]): IJsonRpcRequest {
-    // eslint-disable-next-line
-    return JsonrpcService.createRequest.apply(this, arguments);
+    return JsonrpcService.createRequest.apply(this, [resourceId, method, args]);
   }
 
   createRequestWithOptions(
@@ -103,16 +91,14 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
     options: { compactMode: boolean; fetchMutations: boolean },
     ...args: any[]
   ): IJsonRpcRequest {
-    // eslint-disable-next-line
-    return JsonrpcService.createRequestWithOptions.apply(this, arguments);
+    return JsonrpcService.createRequestWithOptions.apply(this, [resourceId, method, options, args]);
   }
 
   createResponse<TResult>(
-    requestOrRequestId: string | IJsonRpcRequest,
-    result: TResult,
+    request?: IJsonRpcRequest,
+    result: TResult = null,
   ): IJsonRpcResponse<TResult> {
-    // eslint-disable-next-line
-    return JsonrpcService.createResponse.apply(this, arguments);
+    return JsonrpcService.createResponse.apply(this, [result, request]);
   }
 
   createEvent(options: {
@@ -121,7 +107,6 @@ export class JsonrpcService extends Service implements IJsonrpcServiceApi {
     data: any;
     isRejected?: boolean;
   }): IJsonRpcResponse<IJsonRpcEvent> {
-    // eslint-disable-next-line
-    return JsonrpcService.createResponse.apply(this, arguments);
+    return JsonrpcService.createResponse.apply(this, options);
   }
 }

--- a/app/services/api/tcp-server/tcp-server.ts
+++ b/app/services/api/tcp-server/tcp-server.ts
@@ -354,7 +354,7 @@ export class TcpServerService
     if (this.isRequestsHandlingStopped && !this.forceRequests) {
       this.sendResponse(
         client,
-        this.jsonrpcService.createError(null, {
+        this.jsonrpcService.createError({
           code: E_JSON_RPC_ERROR.INTERNAL_JSON_RPC_ERROR,
           message: 'API server is busy. Try again later',
         }),
@@ -373,10 +373,13 @@ export class TcpServerService
         const errorMessage = this.validateRequest(request);
 
         if (errorMessage) {
-          const errorResponse = this.jsonrpcService.createError(request, {
-            code: E_JSON_RPC_ERROR.INVALID_PARAMS,
-            message: errorMessage,
-          });
+          const errorResponse = this.jsonrpcService.createError(
+            {
+              code: E_JSON_RPC_ERROR.INVALID_PARAMS,
+              message: errorMessage,
+            },
+            request,
+          );
           this.sendResponse(client, errorResponse);
           return;
         }
@@ -398,7 +401,7 @@ export class TcpServerService
       } catch (e: unknown) {
         this.sendResponse(
           client,
-          this.jsonrpcService.createError(null, {
+          this.jsonrpcService.createError({
             code: E_JSON_RPC_ERROR.INVALID_REQUEST,
             message:
               'Make sure that the request is valid json. ' +
@@ -454,10 +457,13 @@ export class TcpServerService
       } else {
         this.sendResponse(
           client,
-          this.jsonrpcService.createError(request, {
-            code: E_JSON_RPC_ERROR.INTERNAL_JSON_RPC_ERROR,
-            message: 'Invalid token',
-          }),
+          this.jsonrpcService.createError(
+            {
+              code: E_JSON_RPC_ERROR.INTERNAL_JSON_RPC_ERROR,
+              message: 'Invalid token',
+            },
+            request,
+          ),
         );
       }
 
@@ -467,10 +473,13 @@ export class TcpServerService
     if (!client.isAuthorized) {
       this.sendResponse(
         client,
-        this.jsonrpcService.createError(request, {
-          code: E_JSON_RPC_ERROR.INTERNAL_JSON_RPC_ERROR,
-          message: 'Authorization required. Use TcpServerService.auth(token) method',
-        }),
+        this.jsonrpcService.createError(
+          {
+            code: E_JSON_RPC_ERROR.INTERNAL_JSON_RPC_ERROR,
+            message: 'Authorization required. Use TcpServerService.auth(token) method',
+          },
+          request,
+        ),
       );
       return true;
     }


### PR DESCRIPTION
_This PR is an OPTIONAL improvement._

What does it change:
- Reduces the type and argument checks made for request, event, error and response creation in the `JsonrpcService`
- Resolves the eslint-disable-rules
- Marks optional arguments as such (this caused further ordering changes)
- Fixes a wrong function call in `JsonrpcService.createEvent`

For further details see commit messages.

Note: Since there is no information for executing tests, multiple tests executed with `npm run test` fail

_Feel free to squash commits, cherry-pick only the bug fix or reject the whole PR_ :)