### PR TITLE
Highlighter Improvements

### DIFF
--- a/app/components-react/highlighter/BlankSlate.tsx
+++ b/app/components-react/highlighter/BlankSlate.tsx
@@ -25,7 +25,7 @@ export default function BlankSlate() {
     SettingsService.actions.setSettingsPatch({
       General: {
         ReplayBufferWhileStreaming: true,
-        KeepRecordingWhenStreamStops: false,
+        KeepReplayBufferStreamStops: false,
       },
       Output: {
         RecRB: true,

--- a/app/components-react/highlighter/ClipPreview.tsx
+++ b/app/components-react/highlighter/ClipPreview.tsx
@@ -11,6 +11,8 @@ export default function ClipPreview(props: { clip: IClip; onClick: () => void })
   const filename = useMemo(() => {
     return path.basename(props.clip.path);
   }, [props.clip.path]);
+  // Deleted clips always show as disabled
+  const enabled = props.clip.deleted ? false : props.clip.enabled;
 
   function mouseMove(e: React.MouseEvent) {
     const frameIdx = Math.floor((e.nativeEvent.offsetX / SCRUB_WIDTH) * SCRUB_FRAMES);
@@ -67,7 +69,9 @@ export default function ClipPreview(props: { clip: IClip; onClick: () => void })
       )}
       <span style={{ position: 'absolute', top: '10px', left: '10px' }}>
         <BoolButtonInput
-          value={props.clip.deleted ? false : props.clip.enabled}
+          tooltip={enabled ? 'Disable Clip' : 'Enable Clip'}
+          tooltipPlacement="right"
+          value={enabled}
           onChange={setEnabled}
           checkboxStyles={{
             width: '24px',

--- a/app/components-react/highlighter/ClipPreview.tsx
+++ b/app/components-react/highlighter/ClipPreview.tsx
@@ -26,22 +26,48 @@ export default function ClipPreview(props: { clip: IClip; onClick: () => void })
 
   return (
     <div style={{ height: `${SCRUB_HEIGHT}px`, position: 'relative' }}>
-      <img
-        src={props.clip.scrubSprite}
-        style={{
-          width: `${SCRUB_WIDTH}px`,
-          height: `${SCRUB_HEIGHT}px`,
-          objectFit: 'none',
-          objectPosition: `-${scrubFrame * SCRUB_WIDTH}px`,
-          borderRadius: '10px',
-          opacity: props.clip.enabled ? 1.0 : 0.3,
-        }}
-        onMouseMove={mouseMove}
-        onClick={props.onClick}
-      ></img>
+      {!props.clip.deleted && (
+        <img
+          src={props.clip.scrubSprite}
+          style={{
+            width: `${SCRUB_WIDTH}px`,
+            height: `${SCRUB_HEIGHT}px`,
+            objectFit: 'none',
+            objectPosition: `-${scrubFrame * SCRUB_WIDTH}px`,
+            borderRadius: '10px',
+            opacity: props.clip.enabled ? 1.0 : 0.3,
+          }}
+          onMouseMove={mouseMove}
+          onClick={props.onClick}
+        ></img>
+      )}
+      {props.clip.deleted && (
+        <div
+          style={{
+            width: `${SCRUB_WIDTH}px`,
+            height: `${SCRUB_HEIGHT}px`,
+            borderRadius: '10px',
+            background: 'black',
+            verticalAlign: 'middle',
+            display: 'inline-block',
+            position: 'relative',
+          }}
+        >
+          <i
+            className="icon-trash"
+            style={{
+              position: 'absolute',
+              textAlign: 'center',
+              width: '100%',
+              fontSize: 72,
+              top: '27%',
+            }}
+          />
+        </div>
+      )}
       <span style={{ position: 'absolute', top: '10px', left: '10px' }}>
         <BoolButtonInput
-          value={props.clip.enabled}
+          value={props.clip.deleted ? false : props.clip.enabled}
           onChange={setEnabled}
           checkboxStyles={{
             width: '16px',
@@ -63,7 +89,7 @@ export default function ClipPreview(props: { clip: IClip; onClick: () => void })
           borderRadius: '0 0 10px 10px',
         }}
       >
-        {filename}
+        {`${props.clip.deleted ? '[DELETED] ' : ''}${filename}`}
       </div>
     </div>
   );

--- a/app/components-react/highlighter/ClipPreview.tsx
+++ b/app/components-react/highlighter/ClipPreview.tsx
@@ -70,9 +70,9 @@ export default function ClipPreview(props: { clip: IClip; onClick: () => void })
           value={props.clip.deleted ? false : props.clip.enabled}
           onChange={setEnabled}
           checkboxStyles={{
-            width: '16px',
-            height: '16px',
-            fontSize: '10px',
+            width: '24px',
+            height: '24px',
+            fontSize: '14px',
             background: 'white',
             borderColor: '#333',
           }}

--- a/app/components-react/highlighter/ExportModal.tsx
+++ b/app/components-react/highlighter/ExportModal.tsx
@@ -1,217 +1,23 @@
-import React, { useState } from 'react';
-import styles from '../pages/Highlighter.m.less';
+import React, { useState, useEffect } from 'react';
 import { EExportStep } from 'services/highlighter';
 import { Services } from 'components-react/service-provider';
 import { useVuex } from 'components-react/hooks';
-import { FileInput, TextInput, TextAreaInput } from 'components-react/shared/inputs';
+import { FileInput, TextInput } from 'components-react/shared/inputs';
 import Form from 'components-react/shared/inputs/Form';
 import path from 'path';
-import { Button, Progress, Tooltip } from 'antd';
-import { RadioInput } from 'components-react/shared/inputs/RadioInput';
-import { TPrivacyStatus } from 'services/platforms/youtube/uploader';
-import electron from 'electron';
-
-// Source: https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
-function humanFileSize(bytes: number, si: boolean) {
-  const thresh = si ? 1000 : 1024;
-  if (Math.abs(bytes) < thresh) {
-    return bytes + ' B';
-  }
-  const units = si
-    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
-  let u = -1;
-  do {
-    bytes /= thresh;
-    ++u;
-  } while (Math.abs(bytes) >= thresh && u < units.length - 1);
-  return bytes.toFixed(1) + ' ' + units[u];
-}
-
-function YoutubeUpload(props: { defaultTitle: string; close: () => void }) {
-  const [title, setTitle] = useState(props.defaultTitle);
-  const [description, setDescription] = useState('');
-  const [privacy, setPrivacy] = useState('private');
-  const [urlCopied, setUrlCopied] = useState(false);
-  const { UserService, HighlighterService } = Services;
-  const v = useVuex(() => ({
-    youtubeLinked: !!UserService.state.auth?.platforms.youtube,
-    uploadInfo: HighlighterService.views.uploadInfo,
-    exportInfo: HighlighterService.views.exportInfo,
-  }));
-  const filename = path.parse(v.exportInfo.file).base;
-
-  function getYoutubeForm() {
-    return (
-      <div>
-        <div style={{ display: 'flex', flexDirection: 'row' }}>
-          {v.youtubeLinked && (
-            <div style={{ flexGrow: 1 }}>
-              <Form layout="vertical">
-                <TextInput label="Title" value={title} onChange={setTitle} />
-                <TextAreaInput label="Description" value={description} onChange={setDescription} />
-                <RadioInput
-                  label="Privacy Status"
-                  options={[
-                    {
-                      label: 'Private',
-                      value: 'private',
-                      description: 'Only you and people you choose can watch your video',
-                    },
-                    {
-                      label: 'Unlisted',
-                      value: 'unlisted',
-                      description: 'Anyone with the video link can watch your video',
-                    },
-                    {
-                      label: 'Public',
-                      value: 'public',
-                      description: 'Everyone can watch your video',
-                    },
-                  ]}
-                  value={privacy}
-                  onChange={setPrivacy}
-                />
-              </Form>
-            </div>
-          )}
-          {!v.youtubeLinked && (
-            <div style={{ flexGrow: 1 }}>
-              Please connect your YouTube account to upload your video to YouTube.
-            </div>
-          )}
-          <div
-            style={{
-              width: 300,
-              marginLeft: 24,
-              marginBottom: 24,
-              display: 'flex',
-              flexDirection: 'column',
-            }}
-          >
-            <video
-              src={HighlighterService.views.getCacheBustingUrl(v.exportInfo.file)}
-              controls
-              style={{
-                width: '100%',
-                borderTopRightRadius: 8,
-                borderTopLeftRadius: 8,
-                outline: 'none',
-              }}
-            />
-            <div
-              style={{
-                borderBottomLeftRadius: 8,
-                borderBottomRightRadius: 8,
-                background: 'var(--section)',
-                fontWeight: 800,
-                padding: 12,
-              }}
-            >
-              {filename}
-              <br />
-              <a
-                onClick={() => {
-                  electron.remote.shell.showItemInFolder(v.exportInfo.file);
-                }}
-              >
-                Open file location
-              </a>
-            </div>
-          </div>
-        </div>
-        <div style={{ textAlign: 'right' }}>
-          <Button style={{ marginRight: 8 }} onClick={props.close}>
-            Close
-          </Button>
-          {v.youtubeLinked && (
-            <Button
-              type="primary"
-              onClick={() => {
-                HighlighterService.actions.upload({
-                  title,
-                  description,
-                  privacyStatus: privacy as TPrivacyStatus,
-                });
-              }}
-            >
-              Publish
-            </Button>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  function getUploadProgress() {
-    return (
-      <div>
-        <h2>Upload Progress</h2>
-        <Progress
-          percent={Math.round((v.uploadInfo.uploadedBytes / v.uploadInfo.totalBytes) * 100)}
-          trailColor="var(--section)"
-          status={v.uploadInfo.cancelRequested ? 'exception' : 'normal'}
-        />
-        {!v.uploadInfo.cancelRequested && (
-          <div>
-            Uploading: {humanFileSize(v.uploadInfo.uploadedBytes, false)}/
-            {humanFileSize(v.uploadInfo.totalBytes, false)}
-          </div>
-        )}
-        {v.uploadInfo.cancelRequested && <span>Canceling...</span>}
-        <br />
-        <button
-          className="button button--soft-warning"
-          onClick={() => HighlighterService.actions.cancelUpload()}
-          style={{ marginTop: '16px' }}
-          disabled={v.uploadInfo.cancelRequested}
-        >
-          Cancel
-        </button>
-      </div>
-    );
-  }
-
-  function getUploadDone() {
-    const url = `https://youtube.com/watch?v=${v.uploadInfo.videoId}`;
-
-    return (
-      <div>
-        <p>
-          Your video was successfully uploaded! Click the link below to access your video. Please
-          note that YouTube will take some time to process your video.
-        </p>
-        <br />
-        <a onClick={() => electron.remote.shell.openExternal(url)}>{url}</a>
-        <Tooltip placement="right" title={urlCopied ? 'Copied!' : 'Copy URL'}>
-          <i
-            className="icon-copy link"
-            style={{ marginLeft: 8, display: 'inline', cursor: 'pointer' }}
-            onClick={() => {
-              setUrlCopied(true);
-              electron.clipboard.writeText(url);
-            }}
-          />
-        </Tooltip>
-      </div>
-    );
-  }
-
-  return (
-    <div>
-      <h2>Upload to YouTube</h2>
-      {!v.uploadInfo.uploading && !v.uploadInfo.videoId && getYoutubeForm()}
-      {v.youtubeLinked && v.uploadInfo.uploading && getUploadProgress()}
-      {v.youtubeLinked && v.uploadInfo.videoId && getUploadDone()}
-    </div>
-  );
-}
+import { Button, Progress, Alert } from 'antd';
+import YoutubeUpload from './YoutubeUpload';
 
 export default function ExportModal(p: { close: () => void }) {
   const { HighlighterService } = Services;
   const v = useVuex(() => ({
     exportInfo: HighlighterService.views.exportInfo,
   }));
+
+  // Clear all errors when this component unmounts
+  useEffect(() => {
+    return () => HighlighterService.actions.dismissError();
+  }, []);
 
   function getExportFileFromVideoName(videoName: string) {
     const parsed = path.parse(v.exportInfo.file);
@@ -253,6 +59,16 @@ export default function ExportModal(p: { close: () => void }) {
               setVideoName(getVideoNameFromExportFile(file));
             }}
           />
+          {v.exportInfo.error && (
+            <Alert
+              style={{ marginBottom: 24 }}
+              message={v.exportInfo.error}
+              type="error"
+              closable
+              showIcon
+              afterClose={() => HighlighterService.actions.dismissError()}
+            />
+          )}
           <div style={{ textAlign: 'right' }}>
             <Button style={{ marginRight: 8 }} onClick={p.close}>
               Close

--- a/app/components-react/highlighter/PreviewModal.tsx
+++ b/app/components-react/highlighter/PreviewModal.tsx
@@ -72,7 +72,7 @@ export default function PreviewModal(p: { close: () => void }) {
             controls
             autoPlay
           />
-      )}
+        )}
     </div>
   );
 }

--- a/app/components-react/highlighter/PreviewModal.tsx
+++ b/app/components-react/highlighter/PreviewModal.tsx
@@ -1,8 +1,7 @@
 import { useVuex } from 'components-react/hooks';
 import React, { useEffect, useRef } from 'react';
 import { Services } from 'components-react/service-provider';
-import { Progress } from 'antd';
-import url from 'url';
+import { Progress, Alert } from 'antd';
 
 export default function PreviewModal(p: { close: () => void }) {
   const { HighlighterService } = Services;
@@ -13,7 +12,12 @@ export default function PreviewModal(p: { close: () => void }) {
   useEffect(() => {
     HighlighterService.actions.export(true);
 
-    return () => HighlighterService.cancelExport();
+    return () => HighlighterService.actions.cancelExport();
+  }, []);
+
+  // Clear all errors when this component unmounts
+  useEffect(() => {
+    return () => HighlighterService.actions.dismissError();
   }, []);
 
   // Kind of hacky but used to know if we ever were exporting at any point
@@ -55,13 +59,19 @@ export default function PreviewModal(p: { close: () => void }) {
           Cancel
         </button>
       )}
-      {!v.exportInfo.exporting && !v.exportInfo.cancelRequested && didStartExport.current && (
-        <video
-          style={{ outline: 'none', width: '100%' }}
-          src={HighlighterService.views.getCacheBustingUrl(v.exportInfo.previewFile)}
-          controls
-          autoPlay
-        />
+      {!v.exportInfo.exporting && v.exportInfo.error && (
+        <Alert style={{ marginBottom: 24 }} message={v.exportInfo.error} type="error" showIcon />
+      )}
+      {!v.exportInfo.exporting &&
+        !v.exportInfo.cancelRequested &&
+        !v.exportInfo.error &&
+        didStartExport.current && (
+          <video
+            style={{ outline: 'none', width: '100%' }}
+            src={HighlighterService.views.getCacheBustingUrl(v.exportInfo.previewFile)}
+            controls
+            autoPlay
+          />
       )}
     </div>
   );

--- a/app/components-react/highlighter/YoutubeUpload.tsx
+++ b/app/components-react/highlighter/YoutubeUpload.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from 'react';
+import { Services } from 'components-react/service-provider';
+import { useVuex } from 'components-react/hooks';
+import { TextInput, TextAreaInput } from 'components-react/shared/inputs';
+import Form from 'components-react/shared/inputs/Form';
+import path from 'path';
+import { Button, Progress, Tooltip } from 'antd';
+import { RadioInput } from 'components-react/shared/inputs/RadioInput';
+import { TPrivacyStatus } from 'services/platforms/youtube/uploader';
+import electron from 'electron';
+
+// Source: https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable-string/10420404
+function humanFileSize(bytes: number, si: boolean) {
+  const thresh = si ? 1000 : 1024;
+  if (Math.abs(bytes) < thresh) {
+    return bytes + ' B';
+  }
+  const units = si
+    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+  let u = -1;
+  do {
+    bytes /= thresh;
+    ++u;
+  } while (Math.abs(bytes) >= thresh && u < units.length - 1);
+  return bytes.toFixed(1) + ' ' + units[u];
+}
+
+export default function YoutubeUpload(props: { defaultTitle: string; close: () => void }) {
+  const [title, setTitle] = useState(props.defaultTitle);
+  const [description, setDescription] = useState('');
+  const [privacy, setPrivacy] = useState('private');
+  const [urlCopied, setUrlCopied] = useState(false);
+  const { UserService, HighlighterService } = Services;
+  const v = useVuex(() => ({
+    youtubeLinked: !!UserService.state.auth?.platforms.youtube,
+    uploadInfo: HighlighterService.views.uploadInfo,
+    exportInfo: HighlighterService.views.exportInfo,
+  }));
+  const filename = path.parse(v.exportInfo.file).base;
+
+  function getYoutubeForm() {
+    return (
+      <div>
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          {v.youtubeLinked && (
+            <div style={{ flexGrow: 1 }}>
+              <Form layout="vertical">
+                <TextInput label="Title" value={title} onChange={setTitle} />
+                <TextAreaInput label="Description" value={description} onChange={setDescription} />
+                <RadioInput
+                  label="Privacy Status"
+                  options={[
+                    {
+                      label: 'Private',
+                      value: 'private',
+                      description: 'Only you and people you choose can watch your video',
+                    },
+                    {
+                      label: 'Unlisted',
+                      value: 'unlisted',
+                      description: 'Anyone with the video link can watch your video',
+                    },
+                    {
+                      label: 'Public',
+                      value: 'public',
+                      description: 'Everyone can watch your video',
+                    },
+                  ]}
+                  value={privacy}
+                  onChange={setPrivacy}
+                />
+              </Form>
+            </div>
+          )}
+          {!v.youtubeLinked && (
+            <div style={{ flexGrow: 1 }}>
+              Please connect your YouTube account to upload your video to YouTube.
+            </div>
+          )}
+          <div
+            style={{
+              width: 300,
+              marginLeft: 24,
+              marginBottom: 24,
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <video
+              src={HighlighterService.views.getCacheBustingUrl(v.exportInfo.file)}
+              controls
+              style={{
+                width: '100%',
+                borderTopRightRadius: 8,
+                borderTopLeftRadius: 8,
+                outline: 'none',
+              }}
+            />
+            <div
+              style={{
+                borderBottomLeftRadius: 8,
+                borderBottomRightRadius: 8,
+                background: 'var(--section)',
+                fontWeight: 800,
+                padding: 12,
+              }}
+            >
+              {filename}
+              <br />
+              <a
+                onClick={() => {
+                  electron.remote.shell.showItemInFolder(v.exportInfo.file);
+                }}
+              >
+                Open file location
+              </a>
+            </div>
+          </div>
+        </div>
+        <div style={{ textAlign: 'right' }}>
+          <Button style={{ marginRight: 8 }} onClick={props.close}>
+            Close
+          </Button>
+          {v.youtubeLinked && (
+            <Button
+              type="primary"
+              onClick={() => {
+                HighlighterService.actions.upload({
+                  title,
+                  description,
+                  privacyStatus: privacy as TPrivacyStatus,
+                });
+              }}
+            >
+              Publish
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  function getUploadProgress() {
+    return (
+      <div>
+        <h2>Upload Progress</h2>
+        <Progress
+          percent={Math.round((v.uploadInfo.uploadedBytes / v.uploadInfo.totalBytes) * 100)}
+          trailColor="var(--section)"
+          status={v.uploadInfo.cancelRequested ? 'exception' : 'normal'}
+        />
+        {!v.uploadInfo.cancelRequested && (
+          <div>
+            Uploading: {humanFileSize(v.uploadInfo.uploadedBytes, false)}/
+            {humanFileSize(v.uploadInfo.totalBytes, false)}
+          </div>
+        )}
+        {v.uploadInfo.cancelRequested && <span>Canceling...</span>}
+        <br />
+        <button
+          className="button button--soft-warning"
+          onClick={() => HighlighterService.actions.cancelUpload()}
+          style={{ marginTop: '16px' }}
+          disabled={v.uploadInfo.cancelRequested}
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+
+  function getUploadDone() {
+    const url = `https://youtube.com/watch?v=${v.uploadInfo.videoId}`;
+
+    return (
+      <div>
+        <p>
+          Your video was successfully uploaded! Click the link below to access your video. Please
+          note that YouTube will take some time to process your video.
+        </p>
+        <br />
+        <a onClick={() => electron.remote.shell.openExternal(url)}>{url}</a>
+        <Tooltip placement="right" title={urlCopied ? 'Copied!' : 'Copy URL'}>
+          <i
+            className="icon-copy link"
+            style={{ marginLeft: 8, display: 'inline', cursor: 'pointer' }}
+            onClick={() => {
+              setUrlCopied(true);
+              electron.clipboard.writeText(url);
+            }}
+          />
+        </Tooltip>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h2>Upload to YouTube</h2>
+      {!v.uploadInfo.uploading && !v.uploadInfo.videoId && getYoutubeForm()}
+      {v.youtubeLinked && v.uploadInfo.uploading && getUploadProgress()}
+      {v.youtubeLinked && v.uploadInfo.videoId && getUploadDone()}
+    </div>
+  );
+}

--- a/app/components-react/highlighter/YoutubeUpload.tsx
+++ b/app/components-react/highlighter/YoutubeUpload.tsx
@@ -1,10 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Services } from 'components-react/service-provider';
 import { useVuex } from 'components-react/hooks';
 import { TextInput, TextAreaInput } from 'components-react/shared/inputs';
 import Form from 'components-react/shared/inputs/Form';
 import path from 'path';
-import { Button, Progress, Tooltip } from 'antd';
+import { Button, Progress, Tooltip, Alert } from 'antd';
 import { RadioInput } from 'components-react/shared/inputs/RadioInput';
 import { TPrivacyStatus } from 'services/platforms/youtube/uploader';
 import electron from 'electron';
@@ -38,6 +38,11 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
     exportInfo: HighlighterService.views.exportInfo,
   }));
   const filename = path.parse(v.exportInfo.file).base;
+
+  // Clear all errors when this component unmounts
+  useEffect(() => {
+    return () => HighlighterService.actions.dismissError();
+  }, []);
 
   function getYoutubeForm() {
     return (
@@ -118,6 +123,16 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
             </div>
           </div>
         </div>
+        {v.uploadInfo.error && (
+          <Alert
+            style={{ marginBottom: 24 }}
+            message="An error occurred while uploading to YouTube"
+            type="error"
+            closable
+            showIcon
+            afterClose={() => HighlighterService.actions.dismissError()}
+          />
+        )}
         <div style={{ textAlign: 'right' }}>
           <Button style={{ marginRight: 8 }} onClick={props.close}>
             Close

--- a/app/components-react/pages/Highlighter.m.less
+++ b/app/components-react/pages/Highlighter.m.less
@@ -13,3 +13,20 @@
     position: absolute;
   }
 }
+
+.add-clip {
+  display: inline-block;
+  vertical-align: middle;
+  border-width: 2px;
+  border-color: var(--teal);
+  border-style: dashed;
+  border-radius: 10px;
+  background-color: var(--teal-semi);
+  color: var(--teal);
+  opacity: 0.8;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 1.0;
+  }
+}

--- a/app/components-react/shared/inputs/BoolButtonInput.tsx
+++ b/app/components-react/shared/inputs/BoolButtonInput.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import cx from 'classnames';
 import { InputComponent, TSlobsInputProps, useInput } from './inputs';
 import styles from 'components/shared/inputs/BoolButtonInput.m.less';
+import { Tooltip } from 'antd';
+import { TooltipPlacement } from 'antd/lib/tooltip';
 
 interface IBoolButtonInputCustomProps {
   checkboxStyles: React.CSSProperties;
   checkboxActiveStyles: React.CSSProperties;
+  tooltip: string;
+  tooltipPlacement: TooltipPlacement;
 }
 
 export type TBoolButtonInputProps = TSlobsInputProps<IBoolButtonInputCustomProps, boolean>;
@@ -26,20 +30,22 @@ export const BoolButtonInput = InputComponent((p: TBoolButtonInputProps) => {
   }
 
   return (
-    <div
-      className={cx('input-wrapper', { disabled: p.disabled })}
-      data-role="input"
-      data-type="toggle"
-      data-value={!!p.value}
-      data-name={p.name}
-    >
+    <Tooltip title={p.tooltip} placement={p.tooltipPlacement}>
       <div
-        className={cx(styles.boolButton, { [styles.active]: !!p.value })}
-        style={customStyles}
-        onClick={handleClick}
+        className={cx('input-wrapper', { disabled: p.disabled })}
+        data-role="input"
+        data-type="toggle"
+        data-value={!!p.value}
+        data-name={p.name}
       >
-        {p.value && <i className="fa fa-check"></i>}
+        <div
+          className={cx(styles.boolButton, { [styles.active]: !!p.value })}
+          style={customStyles}
+          onClick={handleClick}
+        >
+          {p.value && <i className="fa fa-check"></i>}
+        </div>
       </div>
-    </div>
+    </Tooltip>
   );
 });

--- a/app/services/highlighter/audio-crossfader.ts
+++ b/app/services/highlighter/audio-crossfader.ts
@@ -2,6 +2,7 @@ import execa from 'execa';
 import fs from 'fs';
 import { FFMPEG_EXE } from './constants';
 import { Clip } from './clip';
+import { AudioMixError } from './errors';
 
 export class AudioCrossfader {
   constructor(
@@ -25,7 +26,12 @@ export class AudioCrossfader {
 
     args.push('-c:a', 'flac', '-y', this.outputPath);
 
-    await execa(FFMPEG_EXE, args);
+    try {
+      await execa(FFMPEG_EXE, args);
+    } catch (e: unknown) {
+      console.error('Highlighter audio crossfade error', e);
+      throw new AudioMixError();
+    }
   }
 
   getFilterGraph() {
@@ -55,11 +61,11 @@ export class AudioCrossfader {
   }
 
   async cleanup() {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>(resolve => {
       fs.unlink(this.outputPath, e => {
         if (e) {
           console.log(e);
-          reject();
+          resolve();
           return;
         }
 

--- a/app/services/highlighter/audio-source.ts
+++ b/app/services/highlighter/audio-source.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import execa from 'execa';
 import { FFMPEG_EXE } from './constants';
+import { AudioReadError } from './errors';
 
 /**
  * Extracts an audio file from a video file
@@ -34,15 +35,20 @@ export class AudioSource {
     ];
     /* eslint-enable */
 
-    await execa(FFMPEG_EXE, args);
+    try {
+      await execa(FFMPEG_EXE, args);
+    } catch (e: unknown) {
+      console.error('Highlighter audio export error', e);
+      throw new AudioReadError(this.sourcePath);
+    }
   }
 
   async cleanup() {
-    return new Promise<void>((resolve, reject) => {
+    return new Promise<void>(resolve => {
       fs.unlink(this.outPath, e => {
         if (e) {
           console.log(e);
-          reject();
+          resolve();
           return;
         }
 

--- a/app/services/highlighter/constants.ts
+++ b/app/services/highlighter/constants.ts
@@ -16,7 +16,7 @@ export const CLIP_DIR = path.resolve('C:/', 'Users', 'acree', 'Videos');
  * Enable to use predefined clips instead of pulling from
  * the replay buffer.
  */
-export const TEST_MODE = true;
+export const TEST_MODE = false;
 
 export const WIDTH = 1280;
 export const HEIGHT = 720;

--- a/app/services/highlighter/constants.ts
+++ b/app/services/highlighter/constants.ts
@@ -16,7 +16,7 @@ export const CLIP_DIR = path.resolve('C:/', 'Users', 'acree', 'Videos');
  * Enable to use predefined clips instead of pulling from
  * the replay buffer.
  */
-export const TEST_MODE = false;
+export const TEST_MODE = true;
 
 export const WIDTH = 1280;
 export const HEIGHT = 720;

--- a/app/services/highlighter/errors.ts
+++ b/app/services/highlighter/errors.ts
@@ -1,0 +1,35 @@
+export abstract class HighlighterError extends Error {
+  abstract get userMessage(): string;
+}
+
+export class FrameWriteError extends HighlighterError {
+  get userMessage() {
+    return 'An error occurred while writing the video file';
+  }
+}
+
+export class FrameReadError extends HighlighterError {
+  constructor(private file: string) {
+    super();
+  }
+
+  get userMessage() {
+    return `An error occurred while reading ${this.file}`;
+  }
+}
+
+export class AudioReadError extends HighlighterError {
+  constructor(private file: string) {
+    super();
+  }
+
+  get userMessage() {
+    return `An error occurred while reading audio from ${this.file}`;
+  }
+}
+
+export class AudioMixError extends HighlighterError {
+  get userMessage() {
+    return 'An error occurred while mixing audio';
+  }
+}

--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -64,6 +64,7 @@ export interface IUploadInfo {
   totalBytes: number;
   cancelRequested: boolean;
   videoId: string | null;
+  error: boolean;
 }
 
 export interface ITransitionInfo {
@@ -163,6 +164,7 @@ export class HighlighterService extends StatefulService<IHighligherState> {
       totalBytes: 0,
       cancelRequested: false,
       videoId: null,
+      error: false,
     },
   } as IHighligherState;
 
@@ -331,7 +333,8 @@ export class HighlighterService extends StatefulService<IHighligherState> {
   }
 
   dismissError() {
-    this.SET_EXPORT_INFO({ error: null });
+    if (this.state.export.error) this.SET_EXPORT_INFO({ error: null });
+    if (this.state.upload.error) this.SET_UPLOAD_INFO({ error: false });
   }
 
   async loadClips() {
@@ -544,7 +547,7 @@ export class HighlighterService extends StatefulService<IHighligherState> {
       throw new Error('Cannot start a new upload when uploading is in progress');
     }
 
-    this.SET_UPLOAD_INFO({ uploading: true, cancelRequested: false });
+    this.SET_UPLOAD_INFO({ uploading: true, cancelRequested: false, error: false });
 
     const yt = getPlatformService('youtube') as YoutubeService;
 
@@ -569,6 +572,7 @@ export class HighlighterService extends StatefulService<IHighligherState> {
         console.log('The upload was canceled');
       } else {
         console.error('Got error uploading YT video', e);
+        this.SET_UPLOAD_INFO({ error: true });
       }
     }
 

--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -277,6 +277,22 @@ export class HighlighterService extends StatefulService<IHighligherState> {
     }
   }
 
+  addClips(paths: string[]) {
+    paths.forEach(path => {
+      // Don't allow adding the same clip twice
+      if (this.state.clips[path]) return;
+
+      this.ADD_CLIP({
+        path,
+        loaded: false,
+        enabled: true,
+        startTrim: 0,
+        endTrim: 0,
+        deleted: false,
+      });
+    });
+  }
+
   enableClip(path: string, enabled: boolean) {
     this.UPDATE_CLIP({
       path,


### PR DESCRIPTION
- Fixed a bug with where configure wouldn't work if "Keep replay buffer going after ending stream" option was enabled
- Now properly handles clips that were deleted on disk and doesn't break export
- Increased size of clip enable checkboxes
- Added tooltips to clip enable/disable
- Added the ability to import arbitrary clips via file browser and drag/drop
- Added proper error handling so issues during export/upload no longer lock up the UI and will instead surface a nice error message