### PR TITLE
Highlighter: Last round of v1 changes

### DIFF
--- a/app/components-react/highlighter/BlankSlate.tsx
+++ b/app/components-react/highlighter/BlankSlate.tsx
@@ -90,7 +90,12 @@ export default function BlankSlate(p: { close: () => void }) {
   return (
     <Scrollable style={{ padding: 24, width: '100%' }}>
       <div style={{ width: 700 }}>
-        <h1>Highlighter</h1>
+        <h1>
+          Highlighter{' '}
+          <span style={{ fontSize: 12, verticalAlign: 'top', color: 'var(--beta-text)' }}>
+            Beta
+          </span>
+        </h1>
         <p>
           The highlighter allows you to edit together replays you capture during your stream and
           upload them to YouTube.

--- a/app/components-react/highlighter/ClipPreview.tsx
+++ b/app/components-react/highlighter/ClipPreview.tsx
@@ -99,6 +99,7 @@ export default function ClipPreview(props: {
           padding: '2px 8px 0',
           borderRadius: '5px',
           background: 'rgba(0,0,0,0.5)',
+          color: 'var(--highlighter-icon)',
         }}
       >
         {/* TODO: Let's not use the same icon as studio mode */}
@@ -121,6 +122,7 @@ export default function ClipPreview(props: {
           width: '100%',
           padding: '0 10px',
           borderRadius: '0 0 10px 10px',
+          color: 'var(--highlighter-icon)',
         }}
       >
         {`${props.clip.deleted ? '[DELETED] ' : ''}${filename}`}

--- a/app/components-react/highlighter/ClipTrimmer.m.less
+++ b/app/components-react/highlighter/ClipTrimmer.m.less
@@ -30,7 +30,7 @@
   position: absolute;
   width: 3px;
   height: 100px;
-  background-color: white;
+  background-color: var(--title);
   z-index: 200;
   transition: transform 250ms;
 

--- a/app/components-react/highlighter/ExportModal.tsx
+++ b/app/components-react/highlighter/ExportModal.tsx
@@ -11,7 +11,7 @@ import { RadioInput } from 'components-react/shared/inputs/RadioInput';
 import { confirm } from 'components-react/modals';
 
 export default function ExportModal(p: { close: () => void }) {
-  const { HighlighterService } = Services;
+  const { HighlighterService, UsageStatisticsService } = Services;
   const v = useVuex(() => ({
     exportInfo: HighlighterService.views.exportInfo,
   }));
@@ -128,6 +128,8 @@ export default function ExportModal(p: { close: () => void }) {
                     return;
                   }
                 }
+
+                UsageStatisticsService.actions.recordFeatureUsage('HighlighterExport');
 
                 HighlighterService.actions.setExportFile(exportFile);
                 HighlighterService.actions.export();

--- a/app/components-react/highlighter/ExportModal.tsx
+++ b/app/components-react/highlighter/ExportModal.tsx
@@ -22,7 +22,7 @@ export default function ExportModal(p: { close: () => void }) {
 
   function getExportFileFromVideoName(videoName: string) {
     const parsed = path.parse(v.exportInfo.file);
-    return path.join(parsed.dir, `${videoName}${parsed.ext}`);
+    return path.join(parsed.dir, `${path.basename(videoName)}${parsed.ext}`);
   }
 
   function getVideoNameFromExportFile(exportFile: string) {

--- a/app/components-react/highlighter/ExportModal.tsx
+++ b/app/components-react/highlighter/ExportModal.tsx
@@ -8,6 +8,7 @@ import path from 'path';
 import { Button, Progress, Alert } from 'antd';
 import YoutubeUpload from './YoutubeUpload';
 import { RadioInput } from 'components-react/shared/inputs/RadioInput';
+import { confirm } from 'components-react/modals';
 
 export default function ExportModal(p: { close: () => void }) {
   const { HighlighterService } = Services;
@@ -113,7 +114,21 @@ export default function ExportModal(p: { close: () => void }) {
             </Button>
             <Button
               type="primary"
-              onClick={() => {
+              onClick={async () => {
+                if (await HighlighterService.actions.return.fileExists(exportFile)) {
+                  if (
+                    !(await confirm({
+                      title: 'Overwite File?',
+                      content: `${path.basename(
+                        exportFile,
+                      )} already exists. Would you like to overwrite it?`,
+                      okText: 'Overwrite',
+                    }))
+                  ) {
+                    return;
+                  }
+                }
+
                 HighlighterService.actions.setExportFile(exportFile);
                 HighlighterService.actions.export();
               }}

--- a/app/components-react/highlighter/YoutubeUpload.tsx
+++ b/app/components-react/highlighter/YoutubeUpload.tsx
@@ -31,7 +31,7 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
   const [description, setDescription] = useState('');
   const [privacy, setPrivacy] = useState('private');
   const [urlCopied, setUrlCopied] = useState(false);
-  const { UserService, HighlighterService } = Services;
+  const { UserService, HighlighterService, NavigationService } = Services;
   const v = useVuex(() => ({
     youtubeLinked: !!UserService.state.auth?.platforms.youtube,
     uploadInfo: HighlighterService.views.uploadInfo,
@@ -80,7 +80,19 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
           )}
           {!v.youtubeLinked && (
             <div style={{ flexGrow: 1 }}>
-              Please connect your YouTube account to upload your video to YouTube.
+              <div>Please connect your YouTube account to upload your video to YouTube.</div>
+              <button
+                style={{ marginTop: 8 }}
+                className="button button--youtube"
+                onClick={() =>
+                  NavigationService.actions.navigate('PlatformMerge', {
+                    platform: 'youtube',
+                    highlighter: true,
+                  })
+                }
+              >
+                Connect
+              </button>
             </div>
           )}
           <div

--- a/app/components-react/highlighter/YoutubeUpload.tsx
+++ b/app/components-react/highlighter/YoutubeUpload.tsx
@@ -31,7 +31,7 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
   const [description, setDescription] = useState('');
   const [privacy, setPrivacy] = useState('private');
   const [urlCopied, setUrlCopied] = useState(false);
-  const { UserService, HighlighterService, NavigationService } = Services;
+  const { UserService, HighlighterService, NavigationService, UsageStatisticsService } = Services;
   const v = useVuex(() => ({
     youtubeLinked: !!UserService.state.auth?.platforms.youtube,
     uploadInfo: HighlighterService.views.uploadInfo,
@@ -153,6 +153,7 @@ export default function YoutubeUpload(props: { defaultTitle: string; close: () =
             <Button
               type="primary"
               onClick={() => {
+                UsageStatisticsService.actions.recordFeatureUsage('HighlighterUpload');
                 HighlighterService.actions.upload({
                   title,
                   description,

--- a/app/components-react/pages/Highlighter.tsx
+++ b/app/components-react/pages/Highlighter.tsx
@@ -237,7 +237,12 @@ export default function Highlighter() {
         <Scrollable style={{ flexGrow: 1, padding: '20px 0 20px 20px' }}>
           <div style={{ display: 'flex', paddingRight: 20 }}>
             <div style={{ flexGrow: 1 }}>
-              <h1>Highlighter</h1>
+              <h1>
+                Highlighter{' '}
+                <span style={{ fontSize: 12, verticalAlign: 'top', color: 'var(--beta-text)' }}>
+                  Beta
+                </span>
+              </h1>
               <p>{'Drag & drop to reorder clips.'}</p>
             </div>
             <div>

--- a/app/components-react/pages/Highlighter.tsx
+++ b/app/components-react/pages/Highlighter.tsx
@@ -301,6 +301,7 @@ export default function Highlighter() {
           closable={false}
           visible={!!showModal || !!v.error}
           destroyOnClose={true}
+          keyboard={false}
         >
           {!!v.error && <Alert message={v.error} type="error" showIcon />}
           {inspectedClip && showModal === 'trim' && <ClipTrimmer clip={inspectedClip} />}

--- a/app/components-react/pages/Highlighter.tsx
+++ b/app/components-react/pages/Highlighter.tsx
@@ -25,7 +25,7 @@ import TransitionSelector from 'components-react/highlighter/TransitionSelector'
 type TModal = 'trim' | 'export' | 'preview' | 'remove';
 
 export default function Highlighter() {
-  const { HighlighterService, HotkeysService } = Services;
+  const { HighlighterService, HotkeysService, UsageStatisticsService } = Services;
   const v = useVuex(() => ({
     clips: HighlighterService.views.clips as IClip[],
     exportInfo: HighlighterService.views.exportInfo,
@@ -55,6 +55,8 @@ export default function Highlighter() {
       if (hotkey) setHotkey(hotkey);
     });
   }, []);
+
+  useEffect(() => UsageStatisticsService.actions.recordFeatureUsage('Highlighter'), []);
 
   // This is kind of weird, but ensures that modals stay the right
   // size while the closing animation is played. This is why modal

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -127,7 +127,6 @@ export default class SideNav extends Vue {
         icon: 'icon-graph',
         title: $t('Grow'),
         trackingTarget: 'grow-tab',
-        newBadge: true,
       });
     }
 
@@ -143,6 +142,7 @@ export default class SideNav extends Vue {
         icon: 'fab fa-youtube',
         title: 'Highlighter',
         trackingTarget: 'highlighter',
+        newBadge: true,
       });
     }
 

--- a/app/components/SideNav.tsx
+++ b/app/components/SideNav.tsx
@@ -133,9 +133,7 @@ export default class SideNav extends Vue {
     if (
       getOS() === OS.Windows &&
       this.userService.isLoggedIn &&
-      this.incrementalRolloutService.views.featureIsEnabled(EAvailableFeatures.highlighter) &&
-      // TODO: Remove via bundle when v1 is complete and ready to start rolling out
-      (Utils.isPreview() || Utils.isDevMode())
+      this.incrementalRolloutService.views.featureIsEnabled(EAvailableFeatures.highlighter)
     ) {
       pageData.push({
         target: 'Highlighter',

--- a/app/components/pages/PlatformMerge.tsx
+++ b/app/components/pages/PlatformMerge.tsx
@@ -14,6 +14,7 @@ class PlatformMergeProps {
     platform?: TPlatform;
     overlayUrl?: string;
     overlayName?: string;
+    highlighter?: boolean;
   } = {};
 }
 
@@ -46,6 +47,12 @@ export default class PlatformMerge extends TsxComponent<PlatformMergeProps> {
   private async mergePlatform(platform: TPlatform) {
     const mode = platform === 'youtube' ? 'external' : 'internal';
     await this.userService.startAuth(platform, mode, true);
+
+    if (this.props.params.highlighter) {
+      this.navigationService.navigate('Highlighter');
+      return;
+    }
+
     this.streamSettingsService.setSettings({ protectedModeEnabled: true });
 
     if (this.props.params.overlayUrl) {

--- a/app/services/highlighter/constants.ts
+++ b/app/services/highlighter/constants.ts
@@ -16,7 +16,7 @@ export const CLIP_DIR = path.resolve('C:/', 'Users', 'acree', 'Videos');
  * Enable to use predefined clips instead of pulling from
  * the replay buffer.
  */
-export const TEST_MODE = true;
+export const TEST_MODE = false;
 
 export const SCRUB_WIDTH = 320;
 export const SCRUB_HEIGHT = 180;

--- a/app/services/highlighter/constants.ts
+++ b/app/services/highlighter/constants.ts
@@ -16,7 +16,7 @@ export const CLIP_DIR = path.resolve('C:/', 'Users', 'acree', 'Videos');
  * Enable to use predefined clips instead of pulling from
  * the replay buffer.
  */
-export const TEST_MODE = false;
+export const TEST_MODE = true;
 
 export const SCRUB_WIDTH = 320;
 export const SCRUB_HEIGHT = 180;

--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -23,6 +23,7 @@ import { throttle } from 'lodash-decorators';
 import sample from 'lodash/sample';
 import { HighlighterError } from './errors';
 import { AudioMixer } from './audio-mixer';
+import { UsageStatisticsService } from 'services/usage-statistics';
 
 export interface IClip {
   path: string;
@@ -299,6 +300,7 @@ export class HighlighterService extends StatefulService<IHighligherState> {
 
   @Inject() streamingService: StreamingService;
   @Inject() userService: UserService;
+  @Inject() usageStatisticsService: UsageStatisticsService;
 
   /**
    * A dictionary of actual clip classes.
@@ -789,15 +791,36 @@ export class HighlighterService extends StatefulService<IHighligherState> {
           console.debug(
             `Export complete - Expected Frames: ${this.views.exportInfo.totalFrames} Actual Frames: ${currentFrame}`,
           );
+
+          if (!preview) {
+            this.usageStatisticsService.recordAnalyticsEvent('Highlighter', {
+              type: 'ExportComplete',
+              numClips: clips.length,
+              transition: this.views.transition.type,
+              transitionDuration: this.views.transition.duration,
+              resolution: this.views.exportInfo.resolution,
+              fps: this.views.exportInfo.fps,
+              preset: this.views.exportInfo.preset,
+              duration: totalFramesAfterTransitions / exportOptions.fps,
+            });
+          }
           break;
         }
       }
     } catch (e: unknown) {
       if (e instanceof HighlighterError) {
         this.SET_EXPORT_INFO({ error: e.userMessage });
+        this.usageStatisticsService.recordAnalyticsEvent('Highlighter', {
+          type: 'ExportError',
+          error: e.constructor.name,
+        });
       } else {
         console.error('Highlighter export error', e);
         this.SET_EXPORT_INFO({ error: 'An error occurred while exporting the video' });
+        this.usageStatisticsService.recordAnalyticsEvent('Highlighter', {
+          type: 'ExportError',
+          error: 'Unknown',
+        });
       }
     }
 
@@ -866,6 +889,21 @@ export class HighlighterService extends StatefulService<IHighligherState> {
       cancelRequested: false,
       videoId: result ? result.id : null,
     });
+
+    if (result) {
+      this.usageStatisticsService.recordAnalyticsEvent('Highlighter', {
+        type: 'UploadSuccess',
+        privacy: options.privacyStatus,
+        videoLink:
+          options.privacyStatus === 'public'
+            ? `https://youtube.com/watch?v=${result.id}`
+            : undefined,
+      });
+    } else {
+      this.usageStatisticsService.recordAnalyticsEvent('Highlighter', {
+        type: 'UploadError',
+      });
+    }
   }
 
   /**

--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -557,18 +557,22 @@ export class HighlighterService extends StatefulService<IHighligherState> {
       this.clips[c.path] = this.clips[c.path] ?? new Clip(c.path);
     });
 
-    await pmap(this.views.clips, c => this.clips[c.path].init(), {
-      concurrency: 5, // TODO
-      onProgress: completed => {
-        this.UPDATE_CLIP({
-          path: completed.path,
-          loaded: true,
-          scrubSprite: this.clips[completed.path].frameSource?.scrubJpg,
-          duration: this.clips[completed.path].duration,
-          deleted: this.clips[completed.path].deleted,
-        });
+    await pmap(
+      this.views.clips.filter(c => !c.loaded),
+      c => this.clips[c.path].init(),
+      {
+        concurrency: 5, // TODO
+        onProgress: completed => {
+          this.UPDATE_CLIP({
+            path: completed.path,
+            loaded: true,
+            scrubSprite: this.clips[completed.path].frameSource?.scrubJpg,
+            duration: this.clips[completed.path].duration,
+            deleted: this.clips[completed.path].deleted,
+          });
+        },
       },
-    });
+    );
   }
 
   private async ensureScrubDirectory() {

--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -537,6 +537,10 @@ export class HighlighterService extends StatefulService<IHighligherState> {
     this.DISMISS_TUTORIAL();
   }
 
+  fileExists(file: string) {
+    return fs.existsSync(file);
+  }
+
   async loadClips() {
     await this.ensureScrubDirectory();
 

--- a/app/services/navigation.ts
+++ b/app/services/navigation.ts
@@ -17,7 +17,7 @@ export type TAppPage =
 
 interface INavigationState {
   currentPage: TAppPage;
-  params: Dictionary<string>;
+  params: Dictionary<string | boolean>;
 }
 
 export class NavigationService extends StatefulService<INavigationState> {
@@ -28,13 +28,13 @@ export class NavigationService extends StatefulService<INavigationState> {
 
   navigated = new Subject<INavigationState>();
 
-  navigate(page: TAppPage, params: Dictionary<string> = {}) {
+  navigate(page: TAppPage, params: Dictionary<string | boolean> = {}) {
     this.NAVIGATE(page, params);
     this.navigated.next(this.state);
   }
 
   @mutation()
-  private NAVIGATE(page: TAppPage, params: Dictionary<string>) {
+  private NAVIGATE(page: TAppPage, params: Dictionary<string | boolean>) {
     this.state.currentPage = page;
     this.state.params = params;
   }

--- a/app/services/platform-apps/api/modules/app.ts
+++ b/app/services/platform-apps/api/modules/app.ts
@@ -29,12 +29,12 @@ export class AppModule extends Module {
     super();
     this.navigationService.navigated.subscribe(nav => {
       if (nav.currentPage === 'PlatformAppMainPage') {
-        if (this.callbacks[nav.params.appId]) {
+        if (this.callbacks[nav.params.appId as string]) {
           const data: INavigation = {};
 
-          if (nav.params.sourceId) data.sourceId = nav.params.sourceId;
+          if (nav.params.sourceId) data.sourceId = nav.params.sourceId as string;
 
-          this.callbacks[nav.params.appId](data);
+          this.callbacks[nav.params.appId as string](data);
         }
       }
     });

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -33,7 +33,8 @@ type TAnalyticsEvent =
   | 'Click'
   | 'Session'
   | 'Shown'
-  | 'AppStart';
+  | 'AppStart'
+  | 'Highlighter';
 
 interface IAnalyticsEvent {
   product: string;

--- a/app/themes.g.less
+++ b/app/themes.g.less
@@ -28,6 +28,7 @@
   --prime-hover: darken(@prime-light, 8%);
   --new-badge: fade(@purple-light, 15%);
   --new-badge-text: @purple-light;
+  --beta-text: @purple-light;
 
   --background: @light-2;
   --section: @light-3;
@@ -93,6 +94,7 @@
   --prime-hover: lighten(@prime-dark, 8%);
   --new-badge: fade(@purple-dark, 15%);
   --new-badge-text: @purple-dark;
+  --beta-text: @purple-dark;
 
   --background: @dark-3;
   --section: @dark-2;
@@ -147,6 +149,7 @@
   --prime-hover: lighten(@prime-dark, 8%);
   --new-badge: @prime-dark;
   --new-badge-text: @primelight-1;
+  --beta-text: @prime-dark;
 
   --background: @primedark-3;
   --section: @primedark-2;
@@ -201,6 +204,7 @@
   --prime-hover: darken(@prime-light, 8%);
   --new-badge: @prime-light;
   --new-badge-text: @primelight-1;
+  --beta-text: @prime-light;
 
   --background: @primelight-1;
   --section: @primelight-2;

--- a/app/themes.g.less
+++ b/app/themes.g.less
@@ -29,6 +29,7 @@
   --new-badge: fade(@purple-light, 15%);
   --new-badge-text: @purple-light;
   --beta-text: @purple-light;
+  --highlighter-icon: @light-4;
 
   --background: @light-2;
   --section: @light-3;


### PR DESCRIPTION
- Won't break when video name with file separators is used
- Confirm when overwriting files
- Add YT account merge flow
- Fix having to re-export video when navigating away from the tab
- Move new badge from grow tab to highlighter
- Add a beta tag to the header
- Added analytics
- Fixed clip icons and name colors in day themes
- Disable escape to dismiss modal (was conflicting with escape to unfullscreen video)
- Remove prod gate