### PR TITLE
Fix wraps in ListInput with images

### DIFF
--- a/app/components-react/shared/inputs/ListInput.tsx
+++ b/app/components-react/shared/inputs/ListInput.tsx
@@ -129,7 +129,7 @@ function renderOptionWithImage<T>(opt: IListOption<T>, inputProps: ICustomListPr
     height: `${height}px`,
   };
   return (
-    <Row gutter={8} align="middle">
+    <Row gutter={8} align="middle" wrap={false}>
       <Col>
         {src && <img src={src} alt="" style={imageStyle} />}
         {!src && <div style={imageStyle} />}


### PR DESCRIPTION
Fixes junk in the Facebook page selector
![image](https://user-images.githubusercontent.com/3768346/124840658-56acd380-df40-11eb-9733-58dd7defad36.png)
