### PR TITLE
Update osn to v0.16.17

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,10 +4,9 @@
             "name": "obs-studio-node",
             "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
             "archive": "osn-[VERSION]-release-[OS].tar.gz",
-            "version": "0.16.15",
+            "version": "0.16.17",
             "win64": true,
-            "osx": true,
-            "mac_version": "0.16.16"
+            "osx": true
         },
         {
             "name": "node-libuiohook",


### PR DESCRIPTION
dependabot[bot]	Bump path-parse from 1.0.6 to 1.0.7 (#980)
dependabot[bot]	Bump normalize-url from 4.5.0 to 4.5.1 (#949)
dependabot[bot]	Bump glob-parent from 5.1.1 to 5.1.2 (#948)
dependabot[bot]	Bump lodash from 4.17.19 to 4.17.21 (#931)
dependabot[bot]	Bump underscore from 1.12.0 to 1.13.1 (#923)
dependabot[bot]	Bump handlebars from 4.7.6 to 4.7.7 (#922)
EddyGharbi	Update libobs to v27.1.4 (#978)
Vladimir	Log backtrace (#979)
Vladimir	save stack trace to log instead of sentry report (#977)