### PR TITLE
fix scene-in-scene and game capture theme imports

### DIFF
--- a/app/services/scene-collections/nodes/overlays/scene.ts
+++ b/app/services/scene-collections/nodes/overlays/scene.ts
@@ -1,8 +1,12 @@
 import { Node } from '../node';
 import { SceneItem } from 'services/scenes';
+import { Inject } from 'services/core';
+import { VideoService } from 'services/video';
 
 interface ISceneNodeSchema {
   sceneId: string;
+  width: number; // Exported base resolution width
+  height: number; // Exported base resolution height
 }
 
 interface IContext {
@@ -11,14 +15,28 @@ interface IContext {
 }
 
 export class SceneSourceNode extends Node<ISceneNodeSchema, IContext> {
-  schemaVersion = 1;
+  schemaVersion = 2;
+
+  @Inject() videoService: VideoService;
 
   async save(context: IContext) {
-    this.data = { sceneId: context.sceneItem.sourceId };
+    this.data = {
+      sceneId: context.sceneItem.sourceId,
+      width: this.videoService.baseWidth,
+      height: this.videoService.baseHeight,
+    };
   }
 
   async load(context: IContext) {
     const settings = { ...context.sceneItem.getObsInput().settings };
     context.sceneItem.getObsInput().update(settings);
+  }
+
+  migrate(version: number) {
+    if (version === 1) {
+      // Assume 1080p as that will almost always be right
+      this.data.width = 1920;
+      this.data.height = 1080;
+    }
   }
 }

--- a/app/services/scene-collections/nodes/overlays/slots.ts
+++ b/app/services/scene-collections/nodes/overlays/slots.ts
@@ -254,6 +254,11 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
           {},
           { id, select: false },
         );
+
+        // Adjust scales by the ratio of the exported base resolution to
+        // the users current base resolution
+        obj.scaleX *= obj.content.data.width / this.videoService.baseWidth;
+        obj.scaleY *= obj.content.data.height / this.videoService.baseHeight;
       } else {
         // We will not load this source at all on mac
         return;
@@ -312,6 +317,11 @@ export class SlotsNode extends ArrayNode<TSlotSchema, IContext, TSceneNode> {
     } else if (obj.content instanceof SceneSourceNode) {
       const sceneId = obj.content.data.sceneId;
       sceneItem = context.scene.addSource(sceneId, { select: false });
+
+      // Adjust scales by the ratio of the exported base resolution to
+      // the users current base resolution
+      obj.scaleX *= obj.content.data.width / this.videoService.baseWidth;
+      obj.scaleY *= obj.content.data.height / this.videoService.baseHeight;
     }
 
     this.adjustTransform(sceneItem, obj);


### PR DESCRIPTION
Auto Game Capture and Scene-as-source are both systems that automatically take the width and height of the base resolution.  As such, for both of these sources we need to know the original base resolution they were exported with to be able to position them correctly when importing.