### PR TITLE
perceived perf: light up side nav hover states immediately

### DIFF
--- a/app/components/SideNav.m.less
+++ b/app/components/SideNav.m.less
@@ -37,7 +37,7 @@
     cursor: pointer;
 
     i, svg {
-      transition: all 0.2s;
+      transition: transform 0.2s;
       color: var(--title);
       fill: var(--title);
       transform: scale(1.2, 1.2);


### PR DESCRIPTION
Subtle perceived performance thing: we should light up the hover state immediately instead of on transition.  This makes the UI feel more responsive.  The hover "grow" effect is still on the transition as that makes sense to naturally have a transition.