### PR TITLE
Bugfix for Scene.getNestedItems()

### DIFF
--- a/app/services/api/external-api/scenes/scene.ts
+++ b/app/services/api/external-api/scenes/scene.ts
@@ -142,7 +142,9 @@ export class Scene implements ISceneModel, ISerializable {
    * @returns A list of all scene items of this scene and all nested scenes
    */
   getNestedItems(): SceneItem[] {
-    return this.scene.getNestedItems().map(item => this.getItem(item.id));
+    return this.scene
+      .getNestedItems()
+      .map(item => this.scenesService.getScene(item.sceneId).getItem(item.id));
   }
 
   /**

--- a/test/regular/api/scenes.ts
+++ b/test/regular/api/scenes.ts
@@ -251,3 +251,24 @@ test('Try to make a not existing scene active', async t => {
   const sceneHasBeenSwitched = scenesService.makeSceneActive('This id does not exist');
   t.false(sceneHasBeenSwitched);
 });
+
+test('Scene.getNestedItems()', async t => {
+  const client = await getApiClient();
+  const scenesService = client.getResource<ScenesService>('ScenesService');
+  const scene1 = scenesService.createScene('Scene1');
+  const scene2 = scenesService.createScene('Scene2');
+
+  const scene1Item1 = scene1.createAndAddSource('Item1', 'color_source');
+  const scene1Item2 = scene1.addSource(scene2.getSource().id);
+  const scene2Item1 = scene2.createAndAddSource('Item1', 'color_source');
+
+  const nestedItems = scene1.getNestedItems();
+  const nestedItemIds = nestedItems.map(item => item.id).sort();
+  const expectedItemIds = [scene1Item1, scene1Item2, scene2Item1].map(item => item.id).sort();
+
+  scene1.remove();
+  scene2.remove();
+
+  t.is(nestedItems.length, 3);
+  t.deepEqual(nestedItemIds, expectedItemIds);
+});


### PR DESCRIPTION
Scene.getNestedItems uses the current scene instance to look up items that are returned by a helper method. The helper method may return scene items that belong to nested scenes. When it uses the current scene instance to look up the scene items that belong to nested scenes, a null value is returned.

This pull request is to fix this so the expected scene items are always returned.