### PR TITLE
Support compilation on case-sensitive filesystems

### DIFF
--- a/app/components-react/index.ts
+++ b/app/components-react/index.ts
@@ -9,7 +9,7 @@ import Display from './shared/Display';
 import TitleBar from './shared/TitleBar';
 import Chat from './root/Chat';
 import Highlighter from './pages/Highlighter';
-import Grow from './pages/Grow/Grow';
+import Grow from './pages/grow/Grow';
 import Loader from './pages/Loader';
 import NavTools from './sidebar/NavTools';
 import PlatformLogo from './shared/PlatformLogo';

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -75,7 +75,7 @@ import { byOS, OS } from 'util/operating-systems';
 import { UsageStatisticsService } from './usage-statistics';
 import { Inject } from 'services/core';
 import MessageBoxModal from 'components/shared/modals/MessageBoxModal';
-import Modal from 'components/shared/modals/modal';
+import Modal from 'components/shared/modals/Modal';
 
 const { ipcRenderer, remote } = electron;
 const BrowserWindow = remote.BrowserWindow;


### PR DESCRIPTION
For case sensitive file system there are two folders named differently (case wise) than there reference in the indexes.
Fix indexes to reference folders by their real names, to make compilation on the case sensitive system possible.