### PR TITLE
attempt window rendering issue workaround

### DIFF
--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -422,6 +422,7 @@ export class WindowsService extends StatefulService<IWindowsState> {
       height: 400,
       title: 'New Window',
       backgroundColor: '#17242D',
+      show: false,
       webPreferences: {
         nodeIntegration: true,
         webviewTag: true,
@@ -447,6 +448,8 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     const indexUrl = remote.getGlobal('indexUrl');
     newWindow.loadURL(`${indexUrl}?windowId=${windowId}`);
+
+    newWindow.show();
 
     return windowId;
   }


### PR DESCRIPTION
Attempts to workaround a browser window paint issue related to the electron upgrade.  Appears to be this issue: https://github.com/electron/electron/issues/28929

Issue appears does not appear to affect windows created with `show: false`.