### PR TITLE
Update osn to v0.19.0

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -36,7 +36,7 @@
             "name": "crash-handler",
             "url": "https://slobs-crash-handler.s3-us-west-2.amazonaws.com/",
             "archive": "crash-handler-[VERSION]-[OS].tar.gz",
-            "version": "1.1.21",
+            "version": "1.2.0",
             "win64": true,
             "osx": true
         },


### PR DESCRIPTION
EddyGharbi	Update libobs to v27.3.1 (#1022)
Vladimir	Log long ipc (#1013)
Vladimir	use fixed version of nlohmann lib. as newer versions required std::filesystem which is not available on mac before 10.15 (#1021)
Vladimir	update tests (#1017)
Steven	Tag sentry report with name .dmp in s3 (#1016)