### PR TITLE
Add an error message for widgets

### DIFF
--- a/app/components-react/widgets/common/useWidget.tsx
+++ b/app/components-react/widgets/common/useWidget.tsx
@@ -233,7 +233,7 @@ export class WidgetModule<TWidgetState extends IWidgetState = IWidgetState> {
       });
     } catch (e: unknown) {
       await alertAsync({
-        title: $t('Something went wrong with applying new settings'),
+        title: $t('Something went wrong while applying settings'),
         style: { marginTop: '300px' },
         okText: $t('Reload'),
       });

--- a/app/i18n/en-US/widgets.json
+++ b/app/i18n/en-US/widgets.json
@@ -182,5 +182,6 @@
   "Pick Screen Color": "Pick Screen Color",
   "Play Alert": "Play Alert",
   "Browser Settings": "Browser Settings",
-  "Custom Code": "Custom Code"
+  "Custom Code": "Custom Code",
+  "Something went wrong while applying settings": "Something went wrong while applying settings"
 }

--- a/app/i18n/es-ES/widgets.json
+++ b/app/i18n/es-ES/widgets.json
@@ -179,6 +179,5 @@
   "Slide Out Left": "Salir deslizando izquierda",
   "Slide Out Right": "Salir deslizando derecha",
   "Slide Out Up": "Salir deslizando arriba",
-  "Pick Screen Color": "Seleccionar color de pantalla",
-  "Something went wrong with applying new settings": "Something went wrong with applying new settings"
+  "Pick Screen Color": "Seleccionar color de pantalla"
 }


### PR DESCRIPTION
Show a message with a "Reload" button if settings have failed to save. That prevents widgets from stucking in an invalid state

![reload_alertbox](https://user-images.githubusercontent.com/3768346/139011318-e062146e-bf1b-4dfa-96f4-f5aa7f9c89a3.PNG)
 