### PR TITLE
Fix copy/paste hotkeys for different keyboard layouts

### DIFF
--- a/app/services/shortcuts.ts
+++ b/app/services/shortcuts.ts
@@ -58,7 +58,8 @@ export class ShortcutsService extends Service {
     if (event.ctrlKey) keys.push('Ctrl');
     if (event.shiftKey) keys.push('Shift');
     if (event.altKey) keys.push('Alt');
-    keys.push(event.key);
+    const keyCode = event.code.replace('Key', '');
+    keys.push(keyCode);
     return keys.join('+').toUpperCase();
   }
 }


### PR DESCRIPTION
Shortcuts Ctr+C and Ctrl+V didn't work I keyboard layout is different from English