### PR TITLE
Add readonly TextInput

### DIFF
--- a/app/components-react/shared/inputs/inputs.ts
+++ b/app/components-react/shared/inputs/inputs.ts
@@ -45,6 +45,7 @@ export interface IInputCommonProps<TValue> {
   max?: number;
   placeholder?: string;
   disabled?: boolean;
+  readOnly?: boolean;
   debounce?: number;
   /**
    * true if the input is in the uncontrolled mode
@@ -220,6 +221,7 @@ export function useInput<
       'labelCol',
       'wrapperCol',
       'disabled',
+      'readOnly',
       'nowrap',
       'layout',
       'rules',
@@ -237,7 +239,7 @@ export function useInput<
 
   // pick props for the input element
   const inputAttrs = {
-    ...(pick(inputProps, 'disabled', 'placeholder', 'size', antFeatures || []) as {}),
+    ...(pick(inputProps, 'disabled', 'readOnly', 'placeholder', 'size', antFeatures || []) as {}),
     ...dataAttrs,
     'data-role': 'input',
     name: inputId,

--- a/app/components-react/windows/sharedComponentsLibrary/SharedComponentsLibrary.tsx
+++ b/app/components-react/windows/sharedComponentsLibrary/SharedComponentsLibrary.tsx
@@ -121,6 +121,7 @@ function Examples() {
           {...bind.textVal}
         />
         <TextInput label="Debounced" debounce={500} {...globalProps} {...bind.textVal} />
+        <TextInput label="Read Only" readOnly {...globalProps} {...bind.textVal} />
         <TextInput label="Password" isPassword {...globalProps} {...bind.textVal} />
         <TextInput
           label="With addons"


### PR DESCRIPTION
We need `readOnly` TexInputs for our future React migrations