### PR TITLE
support non-worker window refresh in dev mode

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -276,7 +276,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
   I18nService.setVuei18nInstance(i18n);
 
-  if (!Utils.isOneOffWindow()) {
+  // We don't register main/child windows in dev mode to allow refreshing
+  if (!Utils.isOneOffWindow() && !Utils.isDevMode()) {
     ipcRenderer.send('register-in-crash-handler', { pid: process.pid, critical: false });
   }
 

--- a/app/components-react/root/Chat.tsx
+++ b/app/components-react/root/Chat.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useRef } from 'react';
 import { Services } from '../service-provider';
 import styles from './Chat.m.less';
 import { OS, getOS } from '../../util/operating-systems';
+import { onUnload } from 'util/unload';
 
 export default function Chat(props: { restream: boolean }) {
   const { ChatService, RestreamService } = Services;
@@ -47,9 +48,11 @@ export default function Chat(props: { restream: boolean }) {
   // Mount/switch chat
   useEffect(() => {
     setupChat();
+    const cancelUnload = onUnload(() => service.actions.unmountChat(remote.getCurrentWindow().id));
 
     return () => {
       service.actions.unmountChat(remote.getCurrentWindow().id);
+      cancelUnload();
     };
   }, [props.restream]);
 

--- a/app/components-react/shared/BrowserView.tsx
+++ b/app/components-react/shared/BrowserView.tsx
@@ -7,6 +7,7 @@ import Utils from 'services/utils';
 import Spinner from 'components-react/shared/Spinner';
 import { Services } from 'components-react/service-provider';
 import { useVuex } from 'components-react/hooks';
+import { onUnload } from 'util/unload';
 
 interface BrowserViewProps {
   src: string;
@@ -61,7 +62,10 @@ export default function BrowserView(p: BrowserViewProps) {
 
     const shutdownSubscription = AppService.shutdownStarted.subscribe(destroyBrowserView);
 
+    const cancelUnload = onUnload(() => destroyBrowserView());
+
     return () => {
+      cancelUnload();
       destroyBrowserView();
       shutdownSubscription.unsubscribe();
     };

--- a/app/components-react/shared/TitleBar.tsx
+++ b/app/components-react/shared/TitleBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
 import { useVuex } from '../hooks';
 import { Services } from '../service-provider';
@@ -21,6 +21,8 @@ export default function TitleBar(props: { windowId: string }) {
     }),
     false,
   );
+
+  const isDev = useMemo(() => Utils.isDevMode(), []);
 
   const primeTheme = /prime/.test(v.theme);
   const [errorState, setErrorState] = useState(false);
@@ -71,6 +73,12 @@ export default function TitleBar(props: { windowId: string }) {
       </div>
       {!isMac && (
         <div className={styles.titlebarActions}>
+          {isDev && (
+            <i
+              className={cx('fas fa-sync', styles.titlebarAction)}
+              onClick={() => window.location.reload()}
+            />
+          )}
           <i className={cx('icon-subtract', styles.titlebarAction)} onClick={minimize} />
           {isMaximizable && (
             <i className={cx('icon-expand-1', styles.titlebarAction)} onClick={maximize} />

--- a/app/components-react/widgets/common/useWidget.tsx
+++ b/app/components-react/widgets/common/useWidget.tsx
@@ -11,6 +11,7 @@ import { $t } from '../../../services/i18n';
 import Utils from '../../../services/utils';
 import { TAlertType } from '../../../services/widgets/alerts-config';
 import { alertAsync } from '../../modals';
+import { onUnload } from 'util/unload';
 
 /**
  * Common state for all widgets
@@ -60,6 +61,8 @@ export class WidgetModule<TWidgetState extends IWidgetState = IWidgetState> {
   public widgetsConfig = this.widgetsService.widgetsConfig;
   public eventsConfig = this.widgetsService.alertsConfig;
 
+  cancelUnload: () => void;
+
   // init module
   async init(params: {
     sourceId: string;
@@ -85,6 +88,8 @@ export class WidgetModule<TWidgetState extends IWidgetState = IWidgetState> {
       this.state.previewSourceId = previewSource.sourceId;
     }
 
+    this.cancelUnload = onUnload(() => this.widget.destroyPreviewSource());
+
     // load settings from the server to the store
     this.state.type = WidgetType[widget.type] as TWidgetType;
     const data = await this.fetchData();
@@ -96,6 +101,7 @@ export class WidgetModule<TWidgetState extends IWidgetState = IWidgetState> {
   // de-init module
   destroy() {
     if (this.state.previewSourceId) this.widget.destroyPreviewSource();
+    this.cancelUnload();
   }
 
   async reload() {

--- a/app/components/windows/WidgetEditor.vue.ts
+++ b/app/components/windows/WidgetEditor.vue.ts
@@ -22,6 +22,7 @@ import Scrollable from 'components/shared/Scrollable';
 import { CustomizationService } from '../../services/customization';
 import { SourcesService } from '../../services/sources';
 import { EAvailableFeatures, IncrementalRolloutService } from '../../services/incremental-rollout';
+import { onUnload } from 'util/unload';
 
 class WidgetEditorProps {
   isAlertBox?: boolean = false;
@@ -121,6 +122,8 @@ export default class WidgetEditor extends TsxComponent<WidgetEditorProps> {
     return this.settingsState.pendingRequests > 0;
   }
 
+  cancelUnload: () => void;
+
   mounted() {
     const source = this.widget.getSource();
     this.currentSetting = this.props.navItems[0].value;
@@ -128,6 +131,8 @@ export default class WidgetEditor extends TsxComponent<WidgetEditorProps> {
 
     // create a temporary previewSource while current window is shown
     this.widget.createPreviewSource();
+
+    this.cancelUnload = onUnload(() => this.widget.destroyPreviewSource());
 
     // some widgets have CustomFieldsEditor
     if (this.apiSettings.customFieldsAllowed) {
@@ -137,6 +142,7 @@ export default class WidgetEditor extends TsxComponent<WidgetEditorProps> {
 
   destroyed() {
     this.widget.destroyPreviewSource();
+    this.cancelUnload();
   }
 
   get windowTitle() {

--- a/app/services/video.ts
+++ b/app/services/video.ts
@@ -9,6 +9,7 @@ import { ScalableRectangle } from '../util/ScalableRectangle';
 import { Subscription } from 'rxjs';
 import { SelectionService } from 'services/selection';
 import { byOS, OS, getOS } from 'util/operating-systems';
+import { onUnload } from 'util/unload';
 
 // TODO: There are no typings for nwr
 let nwr: any;
@@ -67,6 +68,8 @@ export class Display {
   movedListener: () => void;
   movedTimeout: number;
 
+  cancelUnload: () => void;
+
   constructor(public name: string, options: IDisplayOptions = {}) {
     this.sourceId = options.sourceId;
     this.electronWindowId = options.electronWindowId || remote.getCurrentWindow().id;
@@ -119,6 +122,8 @@ export class Display {
     this.boundClose = this.remoteClose.bind(this);
 
     electronWindow.on('close', this.boundClose);
+
+    this.cancelUnload = onUnload(() => this.boundClose());
   }
 
   trackingFun: () => void;
@@ -241,6 +246,8 @@ export class Display {
     if (win) {
       win.removeListener('close', this.boundClose);
     }
+    window.removeEventListener('beforeunload', this.boundClose);
+    this.cancelUnload();
     this.remoteClose();
   }
 

--- a/app/util/unload.ts
+++ b/app/util/unload.ts
@@ -1,0 +1,14 @@
+import Utils from 'services/utils';
+
+/**
+ * Helper for registering an action that needs to be performed on window refresh
+ * Does nothing in production for now
+ * @returns a function to cancel the unload operation
+ */
+export function onUnload(fun: () => void) {
+  if (!Utils.isDevMode()) return () => {};
+
+  window.addEventListener('beforeunload', fun);
+
+  return () => window.removeEventListener('beforeunload', fun);
+}


### PR DESCRIPTION
Adds the ability to refresh visible window pages (i.e. main, child, one-off) for easier/faster development.  The worker window cannot be refreshed.