### PR TITLE
fix(youtube): category set as default when scheduling event

### DIFF
--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -282,6 +282,14 @@ export class YoutubeService
     } else {
       assertIsDefined(ytSettings.broadcastId);
       await this.updateBroadcast(ytSettings.broadcastId, ytSettings);
+
+      /*
+       * set the category, `createBroadcast` does it automatically now,
+       * we've moved this here until we can refactor `#updateBroadcast`
+       * to avoid duplicate requests
+       */
+      await this.updateCategory(broadcast.id, ytSettings.categoryId!);
+
       broadcast = await this.fetchBroadcast(ytSettings.broadcastId);
     }
 
@@ -293,9 +301,6 @@ export class YoutubeService
     } else {
       stream = await this.fetchLiveStream(broadcast.contentDetails.boundStreamId);
     }
-
-    // set the category
-    await this.updateCategory(broadcast.id, ytSettings.categoryId!);
 
     // setup key and platform type in the OBS settings
     const streamKey = stream.cdn.ingestionInfo.streamName;
@@ -512,6 +517,10 @@ export class YoutubeService
       method: 'POST',
       url: `${this.apiBase}/${endpoint}`,
     });
+
+    if (params.categoryId) {
+      await this.updateCategory(broadcast.id, params.categoryId);
+    }
 
     // upload thumbnail
     if (params.thumbnail && params.thumbnail !== 'default') {


### PR DESCRIPTION
Category for events was being set to the default of "Entertainment"
since it was only updated by the "before go-live" logic.

This moves the update to `createBroadcast` and re-orders some
logic to avoid duplicate requests.

Ideally, we would refactor `updateBroadcast` to behave in the
same way with some diffing and remove all `updateCategory` calls
from the codebase.

ref: https://app.asana.com/0/911512908891105/1202062997993099