### PR TITLE
feat: primary chat switcher without restream

### DIFF
--- a/app/components-react/windows/go-live/EditStreamWindow.tsx
+++ b/app/components-react/windows/go-live/EditStreamWindow.tsx
@@ -31,7 +31,6 @@ export default function EditStreamWindow() {
     form,
     enabledPlatforms,
     hasMultiplePlatforms,
-    isRestreamEnabled,
     primaryChat,
     setPrimaryChat,
   } = useGoLiveSettingsRoot({ isUpdateMode: true });
@@ -89,7 +88,7 @@ export default function EditStreamWindow() {
     );
   }
 
-  const shouldShowPrimaryChatSwitcher = isRestreamEnabled && hasMultiplePlatforms;
+  const shouldShowPrimaryChatSwitcher = hasMultiplePlatforms;
 
   return (
     <ModalLayout footer={renderFooter()}>

--- a/app/components-react/windows/go-live/GoLiveSettings.tsx
+++ b/app/components-react/windows/go-live/GoLiveSettings.tsx
@@ -37,7 +37,6 @@ export default function DualOutputGoLiveSettings() {
     isLoading,
     isPrime,
     isDualOutputMode,
-    isRestreamEnabled,
     canAddDestinations,
     canUseOptimizedProfile,
     showSelector,
@@ -89,9 +88,8 @@ export default function DualOutputGoLiveSettings() {
   const shouldShowLeftCol = isDualOutputMode ? true : protectedModeEnabled;
   const shouldShowAddDestButton = canAddDestinations && isPrime;
 
-  const shouldShowPrimaryChatSwitcher = isDualOutputMode
-    ? isRestreamEnabled && hasMultiplePlatforms
-    : hasMultiplePlatforms;
+  const shouldShowPrimaryChatSwitcher = hasMultiplePlatforms;
+
   // TODO: make sure this doesn't jank the UI
   const leftPaneHeight = shouldShowPrimaryChatSwitcher ? '81%' : '100%';
 


### PR DESCRIPTION
Show primary chat switcher on dual output for all users. Remove check that ensured multistream was enabled when in dual output mode, as long as the user has two supported platforms enabled they should be able to switch chats.