### PR TITLE
Check for invalid encoder on Mac

### DIFF
--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -662,8 +662,6 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
   }
 
   private ensureValidEncoder() {
-    if (getOS() === OS.Mac) return;
-
     const encoderSetting: IObsListInput<string> =
       this.findSetting(this.state.Output.formData, 'Streaming', 'Encoder') ??
       this.findSetting(this.state.Output.formData, 'Streaming', 'StreamEncoder');


### PR DESCRIPTION
# Description

In a recent backend PR, I removed a [non-functional encoder](https://github.com/streamlabs/obs-studio-node/pull/1540) on Mac.

# Motivation
This is a bug fix. Mac, unlike Windows-desktop.app, did not notify the user their encoder was deprecated.

Now the dialog below is displayed for the user.

<img width="257" height="254" alt="image" src="https://github.com/user-attachments/assets/3a31d791-eac0-4723-8b2c-3d3664ff4480" />
