### PR TITLE
check audioSource if it is valid

### DIFF
--- a/app/services/scene-collections/nodes/sources.ts
+++ b/app/services/scene-collections/nodes/sources.ts
@@ -361,8 +361,8 @@ export class SourcesNode extends Node<ISchema, {}> {
             audioMixers: defaultTo(sourceInfo.audioMixers, 255),
             monitoringType: defaultTo(sourceInfo.monitoringType, defaultMonitoring),
           });
+          audioSource.setHidden(!!sourceInfo.mixerHidden);
         }
-        audioSource.setHidden(!!sourceInfo.mixerHidden);
       }
 
       if (sourceInfo.hotkeys) {


### PR DESCRIPTION
* Repro- in 1.17.2, select "macOS Screen Capture". Next, switch to 1.19.2 (current mac release) and you'll hit this error when scene is loaded (since `mac_screen_capture` source currently doesnt exist in OSN ver `0.25.47`)