### PR TITLE
Make sure show/hide hotkeys handle both horizontal and vertical outputs

### DIFF
--- a/app/services/hotkeys.ts
+++ b/app/services/hotkeys.ts
@@ -322,12 +322,12 @@ const SCENE_ITEM_ACTIONS: HotkeyGroup = {
     },
     shouldApply: sceneItemId => !!getScenesService().views.getSceneItem(sceneItemId)?.video,
     isActive: sceneItemId => !!getScenesService().views.getSceneItem(sceneItemId)?.visible,
-    down: sceneItemId => {      
+    down: sceneItemId => {
       getScenesService().views.getSceneItem(sceneItemId)?.setVisibility(true);
       const dualOutputNodeId = getDualOutputService().views.getDualOutputNodeId(sceneItemId);
       if (dualOutputNodeId) {
         getScenesService().views.getSceneItem(dualOutputNodeId)?.setVisibility(true);
-      }      
+      }
     },
   },
   TOGGLE_SOURCE_VISIBILITY_HIDE: {


### PR DESCRIPTION
Asana ticket: https://app.asana.com/1/1083097041131/project/1207748235152481/task/1210347711770503?focus=true

Using the eye icon to show/hide a browser source with a video handles both horizontal and vertical outputs, but manually setting up a hotkey only handles the active output. The simplest fix was to copy the logic in SourceSelector.tsx::toggleBothVisibility into hotkey.ts handlers for TOGGLE_SOURCE_VISIBILITY_SHOW and TOGGLE_SOURCE_VISIBILITY_HIDE. If the selected scene item has a corresponding dual output scene item, set the visibility for both. This also fixes the issue of the video restarting when unhidden. 