### PR TITLE
encoder settings: set MacOS default encoder

### DIFF
--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -291,5 +291,5 @@
   "%{videoCodec} codec is not supported for Stream Shift. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Stream Shift. Would you like to proceed with the H.264 codec or select another codec?",
   "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?",
   "Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.": "Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.",
-  "Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting." : "Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting."
+  "Your stream encoder has been reset to Software (x264). This can be caused by an invalid encoder setting." : "Your stream encoder has been reset to Software (x264). This can be caused by an invalid encoder setting."
 }

--- a/app/i18n/en-US/settings.json
+++ b/app/i18n/en-US/settings.json
@@ -289,5 +289,7 @@
   "Select Codec": "Select Codec",
   "%{videoCodec} codec is not supported for Multistream. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Multistream. Would you like to proceed with the H.264 codec or select another codec?",
   "%{videoCodec} codec is not supported for Stream Shift. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Stream Shift. Would you like to proceed with the H.264 codec or select another codec?",
-  "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?"
+  "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?": "%{videoCodec} codec is not supported for Dual Output. Would you like to proceed with the H.264 codec or select another codec?",
+  "Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.": "Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.",
+  "Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting." : "Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting."
 }

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -743,18 +743,32 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
     if (encoderSetting.value === 'obs_x264') return;
 
     if (!encoderIsValid) {
+      console.warn(
+        `The selected encoder ${encoderSetting.value} is not valid for the current configuration. Resetting to a valid encoder.`,
+      );
       const mode: string = this.findSettingValue(this.state.Output.formData, 'Untitled', 'Mode');
 
+      const encoderMessage =
+        getOS() === OS.Windows
+          ? $t(
+              'Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.',
+            )
+          : $t(
+              'Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting.',
+            );
       if (mode === 'Advanced') {
         this.setSettingValue('Output', 'Encoder', 'obs_x264');
       } else {
-        this.setSettingValue('Output', 'StreamEncoder', 'x264');
+        if (getOS() === OS.Mac) {
+          this.setSettingValue('Output', 'StreamEncoder', 'obs_x264'); // obs_x264 is the default encoder for MacOS in simple mode
+        } else {
+          this.setSettingValue('Output', 'StreamEncoder', 'x264');
+        }
       }
 
       remote.dialog.showMessageBox(this.windowsService.windows.main, {
         type: 'error',
-        message:
-          'Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.',
+        message: encoderMessage,
       });
     }
   }
@@ -800,7 +814,7 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
     if (mode === 'Advanced') {
       this.setSettingValue('Output', 'Encoder', 'obs_x264');
     } else {
-      this.setSettingValue('Output', 'StreamEncoder', 'x264');
+      this.setSettingValue('Output', 'StreamEncoder', getOS() === OS.Windows ? 'x264' : 'obs_x264');
     }
   }
 

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -754,7 +754,7 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
               'Your stream encoder has been reset to Software (x264). This can be caused by out of date graphics drivers. Please update your graphics drivers to continue using hardware encoding.',
             )
           : $t(
-              'Your stream encoder has been reset to Software (obs_x264). This can be caused by an invalid encoder setting.',
+              'Your stream encoder has been reset to Software (x264). This can be caused by an invalid encoder setting.',
             );
       if (mode === 'Advanced') {
         this.setSettingValue('Output', 'Encoder', 'obs_x264');


### PR DESCRIPTION
* Update MacOS default encoder
* Update MacOS error message
* Add this error message to localization properly

Repro-
Had to manually edit the "StreamEncoder" setting in basic.ini file and set it to invalid encoder. I'm not actually sure how a user could possibly land inside of here otherwise unless we were to deprecate an encoder they are using?

Below is the updated error message shown on MacOS:
<img width="524" height="452" alt="image" src="https://github.com/user-attachments/assets/ab7ef792-c40b-408d-8dc5-8bf20eddd139" />
