### PR TITLE
make app sessions persistent

### DIFF
--- a/app/services/platform-apps/container-manager.ts
+++ b/app/services/platform-apps/container-manager.ts
@@ -313,7 +313,7 @@ export class PlatformContainerManager {
    */
   private getAppPartition(app: ILoadedApp) {
     const userId = this.userService.platformId;
-    const partition = `platformApp-${app.id}-${userId}-${app.unpacked}`;
+    const partition = `persist:platformApp-${app.id}-${userId}-${app.unpacked}`;
 
     if (!this.sessionsInitialized[partition]) {
       const session = remote.session.fromPartition(partition);


### PR DESCRIPTION
This makes app sessions persistent, allowing apps to remember localStorage and cookies between restarting SLD.  Note that in theory an app could read another app's localStorage if its `id` somehow became the same as another app, but this seems like an impossible situation that isn't worth guarding against in code.