### PR TITLE
Fixed browser sources settings URL for OBS 31

### DIFF
--- a/app/services/platform-apps/api/modules/sources.ts
+++ b/app/services/platform-apps/api/modules/sources.ts
@@ -10,6 +10,7 @@ import {
 import { Inject } from 'services/core/injector';
 import { Subject } from 'rxjs';
 import { PlatformAppsService } from 'services/platform-apps';
+import { stringifyAppSourceSettings } from 'services/platform-apps/source-url';
 import { ScenesService } from 'services/scenes';
 import { AudioService } from 'services/audio';
 import { SourceFiltersService } from 'app-services';
@@ -107,7 +108,7 @@ export class SourcesModule extends Module {
   getAppSourceSettings(ctx: IApiContext, sourceId: string) {
     const source = this.getAppSourceForApp(sourceId, ctx.app.id);
 
-    return source.getPropertiesManagerSettings().appSettings;
+    return stringifyAppSourceSettings(source.getPropertiesManagerSettings().appSettings);
   }
 
   @apiMethod()
@@ -115,7 +116,7 @@ export class SourcesModule extends Module {
     const source = this.getAppSourceForApp(sourceId, ctx.app.id);
 
     source.setPropertiesManagerSettings({
-      appSettings: settings,
+      appSettings: stringifyAppSourceSettings(settings),
     });
   }
 
@@ -153,7 +154,7 @@ export class SourcesModule extends Module {
       propertiesManagerSettings: {
         appSourceId,
         appId: ctx.app.id,
-        appSettings: {},
+        appSettings: '',
       },
     });
 

--- a/app/services/platform-apps/index.ts
+++ b/app/services/platform-apps/index.ts
@@ -14,6 +14,7 @@ import { UserService } from 'services/user';
 import trim from 'lodash/trim';
 import without from 'lodash/without';
 import { PlatformContainerManager, getPageUrl, getAssetUrl } from './container-manager';
+import { stringifyAppSourceSettings } from './source-url';
 import { NavigationService } from 'services/navigation';
 import { InitAfter } from '../core';
 import * as remote from '@electron/remote';
@@ -571,7 +572,7 @@ export class PlatformAppsService extends StatefulService<IPlatformAppServiceStat
     });
   }
 
-  getPageUrlForSource(appId: string, appSourceId: string, settings = '') {
+  getPageUrlForSource(appId: string, appSourceId: string, settings: unknown = '') {
     const app = this.views.getApp(appId);
 
     if (!app) return null;
@@ -583,8 +584,10 @@ export class PlatformAppsService extends StatefulService<IPlatformAppServiceStat
 
     let url = getPageUrl(app, source.file);
 
-    if (settings) {
-      url = `${url}&settings=${encodeURIComponent(settings)}`;
+    const normalizedSettings = stringifyAppSourceSettings(settings);
+
+    if (normalizedSettings) {
+      url = `${url}&settings=${encodeURIComponent(normalizedSettings)}`;
     }
 
     url = `${url}&source=true`;

--- a/app/services/platform-apps/source-url.ts
+++ b/app/services/platform-apps/source-url.ts
@@ -1,0 +1,16 @@
+export function stringifyAppSourceSettings(settings: unknown): string {
+  if (settings == null || settings === '') {
+    return '';
+  }
+
+  if (typeof settings === 'string') {
+    return settings;
+  }
+
+  try {
+    const serialized = JSON.stringify(settings);
+    return serialized == null ? '' : serialized;
+  } catch {
+    return '';
+  }
+}

--- a/app/services/sources/properties-managers/platform-app-manager.ts
+++ b/app/services/sources/properties-managers/platform-app-manager.ts
@@ -3,6 +3,7 @@ import { PropertiesManager } from './properties-manager';
 import { Inject } from 'services/core/injector';
 import * as obs from '../../../../obs-api';
 import { PlatformAppsService } from 'services/platform-apps';
+import { stringifyAppSourceSettings } from 'services/platform-apps/source-url';
 import { TransitionsService } from 'services/transitions';
 
 export interface IPlatformAppManagerSettings {
@@ -63,7 +64,10 @@ export class PlatformAppManager extends PropertiesManager {
   }
 
   applySettings(settings: Dictionary<any>) {
-    super.applySettings(settings);
+    super.applySettings({
+      ...settings,
+      appSettings: stringifyAppSourceSettings(settings.appSettings ?? this.settings.appSettings),
+    });
     this.updateUrl();
   }
 

--- a/test/regular/platform-apps-source-url.ts
+++ b/test/regular/platform-apps-source-url.ts
@@ -1,0 +1,33 @@
+import test from 'ava';
+import { stringifyAppSourceSettings } from '../../app/services/platform-apps/source-url';
+
+test('stringifyAppSourceSettings serializes object settings as JSON', t => {
+  const settings = {
+    LONG_ACCESSTOKEN: 'token',
+    intervals: '15',
+  };
+
+  t.is(
+    stringifyAppSourceSettings(settings),
+    '{"LONG_ACCESSTOKEN":"token","intervals":"15"}',
+  );
+});
+
+test('stringifyAppSourceSettings preserves string settings', t => {
+  const settings = '{"LONG_ACCESSTOKEN":"token","intervals":"15"}';
+
+  t.is(stringifyAppSourceSettings(settings), settings);
+});
+
+test('stringifyAppSourceSettings returns empty string for empty settings', t => {
+  t.is(stringifyAppSourceSettings(undefined), '');
+  t.is(stringifyAppSourceSettings(null), '');
+  t.is(stringifyAppSourceSettings(''), '');
+});
+
+test('stringifyAppSourceSettings returns empty string for non-serializable settings', t => {
+  const settings: Record<string, unknown> = {};
+  settings.self = settings;
+
+  t.is(stringifyAppSourceSettings(settings), '');
+});


### PR DESCRIPTION
## Summary

Platform app browser sources could be created with `appSettings: {}` even though the platform app source pipeline expects a serialized string.

When those settings were used to build the browser source URL, Electron/JS would serialize the object to `"[object Object]"`, producing malformed URLs like:

`...&settings=%5Bobject%20Object%5D&source=true`

which is
`...&settings=[object Object]&source=true`

Example from real OBS logs:
```
[000:00:00:22.488.149.200][39932][Info] [BrowserMessage] Update called with source id: 58, {"url":"https://platform-cdn.streamlabs.com/beta/44d30dca5c/1.0.1/overlay.html?app_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOi8vcGxhdGZvcm0uc3RyZWFtbGFicy5jb20vYXBpL3YxL2FwcC80NGQzMGRjYTVjL2luc3RhbGwvYmV0YSIsImlhdCI6MTY4MTQ5NzgyNiwibmJmIjoxNjgxNDk3ODI2LCJqdGkiOiJaQTBhUTgxZkxwbkZyTm5IIiwic3ViIjo1NDQ5MTUyMywicHJ2IjoiODdlMGFmMWVmOWZkMTU4MTJmZGVjOTcxNTNhMTRlMGIwNDc1NDZhYSIsImFpZCI6ODMxfQ.OSaRf0dcp5gvyvdBu6Yx0apKMR9_ZerR4y_43ipfSvs&settings=%5Bobject%20Object%5D&source=true"}
```

## Root Cause

The platform app source flow had a long-standing type mismatch (it is present in the current `master`):
- `PlatformAppManager` models `appSettings` as a `string`
- `setAppSourceSettings()` accepts a `string`
- `getPageUrlForSource()` appends `settings` directly into a query param
- but `createAppSource()` initialized `appSettings` with `{}`

That meant new sources could start life in the wrong shape and immediately generate invalid browser URLs before later updates corrected them.

## Bottom line

Likely, previous OBS versions were able to tolerate this, but newer browser source crashes.