### PR TITLE
Fixed advanced recording naming

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -444,7 +444,7 @@ export class OutputSettingsService extends Service {
 
     const fileFormat = this.settingsService.findSettingValue(
       advanced,
-      'Advanced',
+      'Recording',
       'FilenameFormatting',
     );
     const muxerSettings = this.settingsService.findSettingValue(output, 'Recording', 'MuxerCustom');

--- a/test/regular/api/streaming.ts
+++ b/test/regular/api/streaming.ts
@@ -5,7 +5,7 @@ import {
   EStreamingState,
   ERecordingState,
 } from '../../../app/services/streaming/streaming-api';
-import { SettingsService } from '../../../app/services/settings';
+import { OutputSettingsService, SettingsService } from '../../../app/services/settings';
 import { reserveUserFromPool, withPoolUser } from '../../helpers/webdriver/user';
 
 // not a react hook
@@ -84,6 +84,28 @@ test('Recording via API', async (t: TExecutionContext) => {
 
   recordingStatus = (await client.fetchNextEvent()).data;
   t.is(recordingStatus, ERecordingState.Offline, 'Recording status should be Offline');
+});
+
+test('Recording filename formatting is read from advanced recording settings', async t => {
+  const client = await getApiClient();
+  const settingsService = client.getResource<SettingsService>('SettingsService');
+  const outputSettingsService =
+    client.getResource<OutputSettingsService>('OutputSettingsService');
+  const customFilenamePattern = '%CCYY-%MM-%DD_%hh-%mm-%ss-%s-%%';
+
+  const advancedSettings = settingsService.state.Advanced.formData;
+  advancedSettings.forEach(subcategory => {
+    subcategory.parameters.forEach(setting => {
+      if (setting.name === 'FilenameFormatting') {
+        setting.value = customFilenamePattern;
+      }
+    });
+  });
+  settingsService.setSettings('Advanced', advancedSettings);
+
+  const recordingSettings = outputSettingsService.getRecordingSettings('horizontal');
+
+  t.is(recordingSettings.fileFormat, customFilenamePattern);
 });
 
 // TODO: Fix this test


### PR DESCRIPTION
## Summary

This fixes the desktop-side regression where recording filename formatting was not being read correctly from Advanced settings.

`OutputSettingsService.getRecordingSettings()` was looking up `FilenameFormatting` under the wrong subcategory. The advanced settings API exposes this field under the `Recording` subcategory, but the desktop code was trying to read it from `Advanced`, which caused `recordingSettings.fileFormat` to resolve to `undefined`.

This change:
- updates `OutputSettingsService.getRecordingSettings()` to read `FilenameFormatting` from the `Recording` subcategory in Advanced settings
- adds a regression test that saves a custom advanced filename pattern and verifies `OutputSettingsService` returns that exact value

## Context

This was one half of the “Recordings do not follow Advanced Filename Formatting” issue.