### PR TITLE
Fixed audio monitoring behavior for controlled browser sources

### DIFF
--- a/app/services/audio/audio.ts
+++ b/app/services/audio/audio.ts
@@ -111,8 +111,23 @@ export class AudioService extends StatefulService<IAudioSourcesState> {
         .getPropertiesFormData()
         .find(data => data.name === 'reroute_audio');
       if (formData) {
+        const isControlledViaObs = !!formData.value;
+
+        if (
+          audioSource &&
+          !audioSource.isControlledViaObs && //  only run when the checkbox is changing from off to on
+          isControlledViaObs &&
+          audioSource.monitoringType === obs.EMonitoringType.MonitoringOnly
+        ) {
+          // When the option "Control audio via Streamlabs Desktop" is unchecked, the browser engine plays directly to
+          // the system audio device (Desktop Audio). The monitoring setting is just a saved state in this case.
+          // When it is checked, monitoring behaves like other sources and we need to make sure that it is reset
+          // to conform to the OBS default behavior. Users can opt back into monitoring afterward.
+          this.setSettings(source.sourceId, { monitoringType: obs.EMonitoringType.None });
+        }
+
         this.UPDATE_AUDIO_SOURCE(source.sourceId, {
-          isControlledViaObs: !!formData.value,
+          isControlledViaObs,
         });
       }
 


### PR DESCRIPTION
This change fixes the following issue:

> When selecting `Control audio via Streamlabs Desktop`  on a browser source, the audio should stop playing through the desktop audio and add a different source in the audio mixer. It does add a source to the audio mixer but it also still plays through desktop. 

This change aligns the behavior with upstream OBS by avoiding the forced browser source monitoring path and clearing the legacy `Monitor Only` state when browser audio control is enabled.