### PR TITLE
Always establish vertical video context.

### DIFF
--- a/app/services/scene-collections/nodes/scene-items.ts
+++ b/app/services/scene-collections/nodes/scene-items.ts
@@ -59,9 +59,6 @@ export class SceneItemsNode extends Node<ISchema, {}> {
   @Inject('DualOutputService')
   dualOutputService: DualOutputService;
 
-  @Inject('VideoSettingsService')
-  videoSettingsService: VideoSettingsService;
-
   getItems(context: IContext) {
     return context.scene.getNodes().slice().reverse();
   }
@@ -142,11 +139,7 @@ export class SceneItemsNode extends Node<ISchema, {}> {
     // on first load, a dual output scene needs to assign displays and contexts to the scene items
     // but if the scene item already has a display assigned, skip it
     if (this.dualOutputService.views.hasNodeMap(context.scene.id)) {
-      // nodes must be assigned to a context, so if it doesn't exist, establish it
-      this.videoSettingsService.validateVideoContext();
-
       const nodeMap = this.dualOutputService.views.sceneNodeMaps[context.scene.id];
-
       const verticalNodeIds = Object.values(nodeMap);
 
       this.data.items.forEach(item => {

--- a/app/services/scene-collections/nodes/scenes.ts
+++ b/app/services/scene-collections/nodes/scenes.ts
@@ -2,6 +2,7 @@ import { ArrayNode } from './array-node';
 import { SceneItemsNode } from './scene-items';
 import { ScenesService, Scene } from '../../scenes';
 import { SourcesService } from '../../sources';
+import { VideoSettingsService } from '../../settings-v2/video';
 import { HotkeysNode } from './hotkeys';
 import { SceneFiltersNode } from './scene-filters';
 
@@ -19,6 +20,7 @@ export class ScenesNode extends ArrayNode<ISceneSchema, {}, Scene> {
 
   scenesService: ScenesService = ScenesService.instance;
   sourcesService: SourcesService = SourcesService.instance;
+  videoSettingsService: VideoSettingsService = VideoSettingsService.instance;
 
   getItems() {
     return this.scenesService.views.scenes;
@@ -64,6 +66,9 @@ export class ScenesNode extends ArrayNode<ISceneSchema, {}, Scene> {
       ids[item.id] = true;
       return true;
     });
+
+    // Verify vertical video context exists here so it is only checked once per scene instead of per scene item
+    this.videoSettingsService.validateVideoContext('vertical');
   }
 
   loadItem(obj: ISceneSchema): Promise<() => Promise<void>> {

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -94,16 +94,11 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     vertical: null as IVideoInfo,
   };
 
-  establishedContext = new Subject();
+  establishedContext = new Subject<TDisplayType>();
 
   init() {
     this.establishVideoContext();
-
-    if (this.dualOutputService.views.activeDisplays.vertical) {
-      this.establishVideoContext('vertical');
-    }
-
-    this.establishedContext.next();
+    this.establishVideoContext('vertical');
   }
 
   contexts = {
@@ -324,6 +319,8 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
         `${this.outputResolutions.horizontal.outputWidth}x${this.outputResolutions.horizontal.outputHeight}`,
       );
     }
+
+    this.establishedContext.next(display);
 
     return !!this.contexts[display];
   }

--- a/app/services/transitions.ts
+++ b/app/services/transitions.ts
@@ -184,8 +184,8 @@ export class TransitionsService extends StatefulService<ITransitionsState> {
     );
 
     // a video context must be initialized before loading the scene transition
-    const establishedContext = this.videoSettingsService.establishedContext.subscribe(() => {
-      if (!this.studioModeTransition) this.createStudioModeTransition();
+    const establishedContext = this.videoSettingsService.establishedContext.subscribe(display => {
+      if (display === 'horizontal' && !this.studioModeTransition) this.createStudioModeTransition();
       establishedContext.unsubscribe();
     });
   }


### PR DESCRIPTION
Always establish the vertical video context on app start. This optimizes run time functionality by paving the way to remove checks for the vertical video context's existence. The most impactful check for performance is checking for the vertical video context every time a scene item node is loaded in the root. This is now moved to a single check before starting to load a scene collection.