### PR TITLE
Only record stream errors for streams that actually went live.

### DIFF
--- a/app/services/diagnostics.ts
+++ b/app/services/diagnostics.ts
@@ -253,6 +253,8 @@ export class DiagnosticsService extends PersistentStatefulService<IDiagnosticsSe
     });
 
     this.streamingService.streamErrorCreated.subscribe((error: string) => {
+      // Only record stream errors in the diag report for streams that actually went live
+      if (!this.streaming) return;
       const { platforms, destinations, type } = this.formatStreamInfo();
       this.UPDATE_STREAM({ error, platforms, destinations, type });
     });


### PR DESCRIPTION
Fix for:

- [Diag shows incorrect information](https://app.asana.com/1/1083097041131/task/1214164136821741)