### PR TITLE
Add remove stale node map entries to repair on load collection.

### DIFF
--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -685,6 +685,14 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     if (!sceneNodes) return;
     const corruptedNodeIds = new Set<string>();
 
+    const sceneNodeMap = this.views.sceneNodeMaps[sceneId];
+    const invertedSceneNodeMap = invert(sceneNodeMap);
+
+    // The keys in the nodemap are the ids for the horizontal nodes. Initialize with all keys
+    // and delete entries as nodes are visited; whatever remains are stale entries whose
+    // horizontal node no longer exists in the scene.
+    const horizontalNodeIds = new Set<string>(Object.keys(sceneNodeMap));
+
     // Iterate over the scene nodes in reverse order to automatically handle correctly ordering
     // any nodes created as a part of the validation process. This optimizes validation by skipping
     // an extra loop over the nodes to reorder them.
@@ -693,11 +701,15 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
       if (corruptedNodeIds.has(node.id)) return;
 
       // confirm partner node exists
-      const nodeMap =
-        node?.display === 'vertical'
-          ? invert(this.views.sceneNodeMaps[sceneId])
-          : this.views.sceneNodeMaps[sceneId];
+      const nodeMap = node?.display === 'vertical' ? invertedSceneNodeMap : sceneNodeMap;
       const partnerNode = this.validatePartnerNode(node, nodeMap, sceneNodes);
+
+      // Remove from horizontal node ids because we have confirmed this entry.
+      // Any nodes added as a horizontal partner node for a vertical node do not need
+      // to be validated again in the node map
+      if (node.display === 'horizontal') {
+        horizontalNodeIds.delete(node.id);
+      }
 
       // confirm source and output for scene items
       if (node.isItem() && partnerNode.isItem()) {
@@ -709,6 +721,13 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
       }
 
       this.sceneNodeHandled.next(index);
+    });
+
+    // After confirming all of the scene items, `horizontalNodeIds` should be empty.
+    // If there are any remaining entries, these are stale entries in the scene node map.
+    // To repair the scene node map, delete these incorrect entries.
+    horizontalNodeIds.forEach((horizontalId: string) => {
+      this.sceneCollectionsService.removeNodeMapEntry(sceneId, horizontalId);
     });
 
     this.SET_IS_LOADING(false);

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -869,19 +869,6 @@ export class SettingsService extends StatefulService<ISettingsServiceState> {
       this.findSetting(this.state.Output.formData, 'Streaming', 'StreamEncoder');
     const encoderIsValid = !!encoderSetting.options.find(opt => opt.value === encoderSetting.value);
 
-    console.log(
-      "this.findSetting(this.state.Output.formData, 'Streaming', 'Encoder')",
-      JSON.stringify(this.findSetting(this.state.Output.formData, 'Streaming', 'Encoder'), null, 2),
-    );
-    console.log(
-      "this.findSetting(this.state.Output.formData, 'Streaming', 'StreamEncoder')",
-      JSON.stringify(
-        this.findSetting(this.state.Output.formData, 'Streaming', 'StreamEncoder'),
-        null,
-        2,
-      ),
-    );
-
     // The backend incorrectly defaults to obs_x264 in Simple mode rather x264.
     // In this case we shouldn't do anything here.
     if (encoderSetting.value === 'obs_x264') return;


### PR DESCRIPTION
The repair on load for dual output scene collection is missing cleanup of stale node map entries. If entries are never properly cleaned up, it could leave behind stale entries that are still mapped over, causing performance delays.