### PR TITLE
Fixed encoder rescale in factory API

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -633,10 +633,25 @@ export class OutputSettingsService extends Service {
     );
 
     if (mode === 'Advanced') {
-      const rescaling = this.settingsService.findSettingValue(output, 'Recording', 'RecRescale');
+      const rescaling = this.settingsService.findSettingValue(output, 'Streaming', 'Rescale');
 
-      const outputWidth = this.videoSettingsService.outputResolutions[display].outputWidth;
-      const outputHeight = this.videoSettingsService.outputResolutions[display].outputHeight;
+      let outputWidth = this.videoSettingsService.outputResolutions[display].outputWidth;
+      let outputHeight = this.videoSettingsService.outputResolutions[display].outputHeight;
+
+      const rescaleResolution = this.settingsService.findSettingValue(
+        output,
+        'Streaming',
+        'RescaleRes',
+      );
+
+      if (rescaling && rescaleResolution) {
+        const [rescaleWidth, rescaleHeight] = rescaleResolution.split('x').map(Number);
+
+        if (Number.isFinite(rescaleWidth) && Number.isFinite(rescaleHeight)) {
+          outputWidth = rescaleWidth;
+          outputHeight = rescaleHeight;
+        }
+      }
 
       const audioTrack = this.settingsService.findSettingValue(output, 'Streaming', 'TrackIndex');
 

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1848,8 +1848,10 @@ export class StreamingService
         | IEnhancedBroadcastingAdvancedStreaming;
 
       const resolution = this.videoSettingsService.outputResolutions[display];
-      stream.outputWidth = resolution.outputWidth;
-      stream.outputHeight = resolution.outputHeight;
+      if (!stream.rescaling) {
+        stream.outputWidth = resolution.outputWidth;
+        stream.outputHeight = resolution.outputHeight;
+      }
 
       if (!isEnhancedBroadcasting) {
         // stream audio track

--- a/test/regular/api/streaming.ts
+++ b/test/regular/api/streaming.ts
@@ -107,6 +107,37 @@ test('Recording filename formatting is read from advanced recording settings', a
   t.is(recordingSettings.fileFormat, customFilenamePattern);
 });
 
+test('Advanced streaming rescale output is read from streaming settings', async t => {
+  const client = await getApiClient();
+  const settingsService = client.getResource<SettingsService>('SettingsService');
+  const outputSettingsService = client.getResource<OutputSettingsService>('OutputSettingsService');
+
+  const setOutputParam = (name: string, value: unknown) => {
+    const outputSettings = settingsService.state.Output.formData;
+    outputSettings.forEach(subcategory => {
+      subcategory.parameters.forEach(setting => {
+        if (setting.name === name) setting.value = value as never;
+      });
+    });
+    settingsService.setSettings('Output', outputSettings);
+  };
+
+  setOutputParam('Mode', 'Advanced');
+  setOutputParam('Rescale', true);
+  setOutputParam('RecRescale', false);
+  setOutputParam('RescaleRes', '960x540');
+
+  const streamingSettings = outputSettingsService.getStreamingSettings('horizontal') as {
+    rescaling: boolean;
+    outputWidth: number;
+    outputHeight: number;
+  };
+
+  t.true(streamingSettings.rescaling);
+  t.is(streamingSettings.outputWidth, 960);
+  t.is(streamingSettings.outputHeight, 540);
+});
+
 test('Stream delay is applied via API', async t => {
   const streamKey = (await reserveUserFromPool(t, 'twitch')).streamKey;
   const client = await getApiClient();


### PR DESCRIPTION
### Description
This fixes a regression found in encoder rescale settings when using new factory API.

### Root cause
Advanced streaming was reading the recording rescale flag (`RecRescale`) instead of the streaming flag (`Rescale`), then overwriting the rescale size with the global Video output size before starting the stream. So the UI could show 960x540, but the streaming factory still got the original output resolution.