### PR TITLE
Main window component optimizations.

### DIFF
--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import * as remote from '@electron/remote';
 import cx from 'classnames';
 import { Menu } from 'antd';
@@ -259,7 +259,7 @@ class LiveDockController {
   }
 }
 
-export default function LiveDockWithContext() {
+function LiveDockWithContext() {
   const controller = useMemo(() => new LiveDockController(), []);
   return (
     <LiveDockCtx.Provider value={controller}>
@@ -268,11 +268,30 @@ export default function LiveDockWithContext() {
   );
 }
 
+export default memo(LiveDockWithContext);
+
+const StreamTimer = memo(function StreamTimer({
+  streamingStatus,
+}: {
+  streamingStatus: EStreamingState;
+}) {
+  const ctrl = useController(LiveDockCtx);
+  const [elapsed, setElapsed] = useState('');
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setElapsed(streamingStatus === EStreamingState.Live ? ctrl.getElapsedStreamTime() : '');
+    }, 200);
+    return () => clearInterval(id);
+  }, [streamingStatus]);
+
+  return <span className={styles.liveDockTimer}>{elapsed}</span>;
+});
+
 function LiveDock() {
   const ctrl = useController(LiveDockCtx);
 
   const [visibleChat, setVisibleChat] = useState('default');
-  const [elapsedStreamTime, setElapsedStreamTime] = useState('');
 
   const {
     hasLiveDockFeature,
@@ -303,19 +322,6 @@ function LiveDock() {
   const collapsed = useRealmObject(Services.CustomizationService.state).livedockCollapsed;
   const hideViewerCount = useRealmObject(Services.CustomizationService.state).hideViewerCount;
   const viewerCount = hideViewerCount ? $t('Viewers Hidden') : currentViewers;
-
-  useEffect(() => {
-    const elapsedInterval = window.setInterval(() => {
-      if (streamingStatus === EStreamingState.Live) {
-        setElapsedStreamTime(ctrl.getElapsedStreamTime());
-      } else {
-        setElapsedStreamTime('');
-      }
-    }, 200);
-
-    return () => clearInterval(elapsedInterval);
-  }, [streamingStatus]);
-
   useEffect(() => {
     if (isRestreaming && streamingStatus === EStreamingState.Starting) {
       Services.RestreamService.actions.refreshChat();
@@ -372,7 +378,7 @@ function LiveDock() {
               })}
             />
             <span className={styles.liveDockText}>{liveText}</span>
-            <span className={styles.liveDockTimer}>{elapsedStreamTime}</span>
+            <StreamTimer streamingStatus={streamingStatus} />
           </div>
           <div className={styles.liveDockViewerCount}>
             <i

--- a/app/components-react/shared/TitleBar.tsx
+++ b/app/components-react/shared/TitleBar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { memo, useEffect, useMemo, useState } from 'react';
 import cx from 'classnames';
 import { useVuex } from '../hooks';
 import { Services } from '../service-provider';
@@ -12,7 +12,7 @@ import * as remote from '@electron/remote';
 import Banner from 'components-react/root/Banner';
 import { useRealmObject } from 'components-react/hooks/realm';
 
-export default function TitleBar(props: { windowId: string; className?: string }) {
+function TitleBar(props: { windowId: string; className?: string }) {
   const { CustomizationService, StreamingService, WindowsService } = Services;
 
   const isMaximizable = remote.getCurrentWindow().isMaximizable() !== false;
@@ -30,13 +30,14 @@ export default function TitleBar(props: { windowId: string; className?: string }
   const primeTheme = /prime/.test(theme);
   const [errorState, setErrorState] = useState(false);
 
-  useEffect(lifecycle, []);
-
-  function lifecycle() {
-    if (Utils.isDevMode()) {
-      ipcRenderer.on('unhandledErrorState', () => setErrorState(true));
-    }
-  }
+  useEffect(() => {
+    if (!Utils.isDevMode()) return;
+    const handler = () => setErrorState(true);
+    ipcRenderer.on('unhandledErrorState', handler);
+    return () => {
+      ipcRenderer.removeListener('unhandledErrorState', handler);
+    };
+  }, []);
 
   function minimize() {
     remote.getCurrentWindow().minimize();
@@ -96,3 +97,5 @@ export default function TitleBar(props: { windowId: string; className?: string }
     </>
   );
 }
+
+export default memo(TitleBar);

--- a/app/components-react/windows/Main.tsx
+++ b/app/components-react/windows/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import fs from 'fs';
 import * as remote from '@electron/remote';
 import cx from 'classnames';
@@ -119,12 +119,9 @@ export default function Main() {
     return !bulkLoadFinished ? loadedTheme() || 'night-theme' : realmTheme;
   }, [bulkLoadFinished, realmTheme]);
 
-  const updateStyleBlockers = useCallback(
-    (val: boolean) => {
-      WindowsService.actions.updateStyleBlockers('main', val);
-    },
-    [showOnboarding],
-  );
+  const updateStyleBlockers = useCallback((val: boolean) => {
+    WindowsService.actions.updateStyleBlockers('main', val);
+  }, []);
 
   const onDropHandler = useCallback(
     async (event: React.DragEvent) => {
@@ -202,14 +199,21 @@ export default function Main() {
   }
 
   useEffect(() => {
-    const unsubscribe = StatefulService.store.subscribe((_, state) => {
+    let unsubscribe: (() => void) | null = null;
+    unsubscribe = StatefulService.store.subscribe((_, state) => {
       if (state.bulkLoadFinished) setBulkLoadFinished(true);
       if (state.i18nReady) seti18nReady(true);
+      if (state.bulkLoadFinished && state.i18nReady && unsubscribe) {
+        unsubscribe();
+        unsubscribe = null;
+      }
     });
 
     windowSizeHandler();
 
-    return unsubscribe;
+    return () => {
+      if (unsubscribe) unsubscribe();
+    };
   }, []);
 
   useEffect(() => {
@@ -336,25 +340,29 @@ interface ILiveDockContainerProps {
   onLeft?: boolean;
 }
 
-function LiveDockContainer(p: ILiveDockContainerProps) {
-  const isDockCollapsed = useRealmObject(Services.CustomizationService.state).livedockCollapsed;
+const Chevron = memo(function Chevron(p: {
+  onLeft?: boolean;
+  isDockCollapsed: boolean;
+  setCollapsed: (val: boolean) => void;
+}) {
+  return (
+    <div
+      className={cx(styles.liveDockChevron, p.onLeft && styles.left)}
+      onClick={() => p.setCollapsed(!p.isDockCollapsed)}
+    >
+      <i
+        className={cx({
+          'icon-back': (!p.onLeft && p.isDockCollapsed) || (p.onLeft && !p.isDockCollapsed),
+          ['icon-down icon-right']:
+            (p.onLeft && p.isDockCollapsed) || (!p.onLeft && !p.isDockCollapsed),
+        })}
+      />
+    </div>
+  );
+});
 
-  function Chevron() {
-    return (
-      <div
-        className={cx(styles.liveDockChevron, p.onLeft && styles.left)}
-        onClick={() => p.setCollapsed(!isDockCollapsed)}
-      >
-        <i
-          className={cx({
-            'icon-back': (!p.onLeft && isDockCollapsed) || (p.onLeft && !isDockCollapsed),
-            ['icon-down icon-right']:
-              (p.onLeft && isDockCollapsed) || (!p.onLeft && !isDockCollapsed),
-          })}
-        />
-      </div>
-    );
-  }
+const LiveDockContainer = memo(function LiveDockContainer(p: ILiveDockContainerProps) {
+  const isDockCollapsed = useRealmObject(Services.CustomizationService.state).livedockCollapsed;
 
   const transitionName = useMemo(() => {
     if ((p.onLeft && isDockCollapsed) || (!p.onLeft && !isDockCollapsed)) {
@@ -367,7 +375,11 @@ function LiveDockContainer(p: ILiveDockContainerProps) {
     <Animation transitionName={transitionName} transitionAppear>
       {isDockCollapsed && (
         <div className={cx(styles.liveDockCollapsed, p.onLeft && styles.left)} key="collapsed">
-          <Chevron />
+          <Chevron
+            onLeft={p.onLeft}
+            isDockCollapsed={isDockCollapsed}
+            setCollapsed={p.setCollapsed}
+          />
         </div>
       )}
       {!isDockCollapsed && (
@@ -385,10 +397,14 @@ function LiveDockContainer(p: ILiveDockContainerProps) {
             style={{ width: `${p.width}px` }}
           >
             <LiveDock />
-            <Chevron />
+            <Chevron
+              onLeft={p.onLeft}
+              isDockCollapsed={isDockCollapsed}
+              setCollapsed={p.setCollapsed}
+            />
           </div>
         </ResizeBar>
       )}
     </Animation>
   );
-}
+});


### PR DESCRIPTION
Addresses unnecessary re-renders in the main window layout that were causing performance degradation, particularly during streaming.

 - `LiveDock` — extracted `elapsedStreamTime` into a standalone memoized `StreamTimer` component. Previously the 200ms streaming timer intervalcalled `setState` on `LiveDock` itself, causing the entire dock subtree to re-render 5× per second during streaming. The timer now updates in isolation.
 - `LiveDockWithContext` — wrapped with `memo`. Takes no props, so it was re-rendering on every `Main` re-render (triggered frequently by `hideStyleBlockers` toggling during sidebar animations and dock resizes) with no benefit.
 - `LiveDockContainer` — wrapped with `memo`. Its props only change on window resize or dock drag, so it no longer re-renders during style blocker transitions. Also extracted the internal Chevron function out of the LiveDockContainer body — previously React created a new component type on every render, causing unmount/remount cycles instead of updates.
 - `TitleBar` — wrapped with `memo`. Props (`windowId`, `className`) are stable in normal operation; re-renders were purely from `Main` propagation.
 - `Main` — fixed incorrect dependency array on `updateStyleBlockers`. `showOnboarding` was listed as a dependency but never used inside the callback, causing a new function reference on every onboarding state change.