### PR TITLE
Fix dual output stream shutdown (some streams do not end bug)

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1658,31 +1658,9 @@ export class StreamingService
       this.stopReplayBuffer();
     }
 
-    // Stop the horizontal stream. On the `Stop` signal in `handleStreamingSignal`, all other streaming
-    // instances will be stopped and destroyed. Otherwise, just cleanup all of the streaming instances.
-    if (
-      this.contexts.horizontal.streaming &&
-      this.state.status.horizontal.streaming !== EStreamingState.Offline
-    ) {
-      this.contexts.horizontal.streaming.stop(force);
-
-      // Return because in dual output mode, the vertical stream will be stopped in the `handleStreamingSignal`
-      return;
-    }
-
-    // Stop the vertical stream first because in dual output mode, the horizontal stream will always be
-    // stopped in the `handleStreamingSignal`
-    if (
-      this.contexts.vertical.streaming &&
-      this.state.status.vertical.streaming !== EStreamingState.Offline
-    ) {
-      this.contexts.vertical.streaming.stop(force);
-    }
-
-    // For Twitch dual streaming, the enhanced broadcasting instance is in the `enhancedBroadcasting` context
-    // rather than a display context. Stop it directly.
-    if (this.contexts.enhancedBroadcasting.streaming) {
-      this.contexts.enhancedBroadcasting.streaming.stop(force);
+    // Stop every active streaming output immediately. Relying on later cleanup can leave the
+    // vertical stream alive while vertical recording or replay buffer finishes shutting down.
+    if (this.stopActiveStreamingInstances(force)) {
       return;
     }
 
@@ -1705,6 +1683,34 @@ export class StreamingService
         $t('Error stopping stream: default streams do not exist.'),
       );
     }
+  }
+
+  private stopActiveStreamingInstances(force?: boolean): boolean {
+    let stopped = false;
+    const contextNames: TOutputContext[] = [
+      'vertical',
+      'horizontal',
+      'enhancedBroadcasting',
+      'stream',
+      'streamSecond',
+    ];
+
+    contextNames.forEach(contextName => {
+      const streaming = this.contexts[contextName].streaming;
+      if (!streaming) return;
+
+      const forceStop =
+        force ||
+        (this.isDisplayContext(contextName) &&
+          this.state.status[contextName].streaming === EStreamingState.Offline);
+
+      // OBS can briefly emit deactivate/offline while a reconnect timer is still armed.
+      // If the instance still exists, force-stopping it cancels that pending reconnect.
+      streaming.stop(forceStop);
+      stopped = true;
+    });
+
+    return stopped;
   }
 
   private async createEnhancedBroadcastSingleStream() {
@@ -3666,6 +3672,13 @@ export class StreamingService
         (contextName === 'horizontal' && skipHorizontal) ||
         this.contexts[contextName].streaming === undefined ||
         this.contexts[contextName].streaming === null
+      ) {
+        continue;
+      }
+
+      if (
+        this.isDisplayContext(contextName) &&
+        this.state.status[contextName].streaming === EStreamingState.Offline
       ) {
         continue;
       }

--- a/test/regular/streaming/dual-output-end-stream.ts
+++ b/test/regular/streaming/dual-output-end-stream.ts
@@ -1,0 +1,174 @@
+import {
+  clickGoLive,
+  prepareToGoLive,
+  submit,
+  waitForSettingsWindowLoaded,
+  waitForStreamStart,
+} from '../../helpers/modules/streaming';
+import { clickButton, focusMain, waitForDisplayed } from '../../helpers/modules/core';
+import { toggleDualOutputMode } from '../../helpers/modules/dual-output';
+import { test, TExecutionContext, useWebdriver } from '../../helpers/webdriver';
+import { logOut, withUser } from '../../helpers/webdriver/user';
+import { getApiClient } from '../../helpers/api-client';
+import { fillForm } from '../../helpers/modules/forms';
+import { sleep } from '../../helpers/sleep';
+import { SettingsService } from '../../../app/services/settings';
+import { StreamSettingsService } from '../../../app/services/settings/streaming';
+import {
+  ERecordingState,
+  EStreamingState,
+  IStreamingServiceApi,
+} from '../../../app/services/streaming/streaming-api';
+
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
+useWebdriver();
+
+test(
+  'End Stream stops both dual output streams while vertical recording is active',
+  withUser('twitch', { prime: true, multistream: true }),
+  async (t: TExecutionContext) => {
+    t.timeout(3 * 60 * 1000, 'Dual output End Stream test timed out');
+
+    const { streamingService } = await configureVerticalRecordingOnStreamStart(t);
+
+    try {
+      await toggleDualOutputMode();
+      await prepareToGoLive();
+
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        trovo: true,
+      });
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        trovoDisplay: 'vertical',
+        twitchDisplay: 'horizontal',
+        primaryChat: 'Twitch',
+      });
+      await submit();
+
+      await waitForDisplayed("h1=You're live!", { timeout: 60000 });
+      await waitForStreamStart();
+      await waitForDualStreamingStatus(streamingService, EStreamingState.Live);
+      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Recording);
+
+      await focusMain();
+      await clickButton('End Stream');
+
+      await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000, 5000);
+      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000);
+
+      const status = streamingService.getModel().status;
+      t.is(status.horizontal.streaming, EStreamingState.Offline);
+      t.is(status.vertical.streaming, EStreamingState.Offline);
+    } finally {
+      await stopStreamingIfNeeded(streamingService);
+      await logOut(t);
+    }
+  },
+);
+
+async function configureVerticalRecordingOnStreamStart(
+  t: TExecutionContext,
+): Promise<{ streamingService: IStreamingServiceApi }> {
+  const client = await getApiClient();
+  const settingsService = client.getResource<SettingsService>('SettingsService');
+  const streamSettingsService = client.getResource<StreamSettingsService>('StreamSettingsService');
+  const streamingService = client.getResource<IStreamingServiceApi>('StreamingService');
+
+  const outputSettings = settingsService.state.Output.formData;
+  outputSettings.forEach(subcategory => {
+    subcategory.parameters.forEach(setting => {
+      if (setting.name === 'FilePath') setting.value = t.context.cacheDir;
+    });
+  });
+  settingsService.setSettings('Output', outputSettings);
+
+  const generalSettings = settingsService.state.General.formData;
+  generalSettings.forEach(subcategory => {
+    subcategory.parameters.forEach(setting => {
+      if (setting.name === 'RecordWhenStreaming') setting.value = true;
+      if (setting.name === 'KeepRecordingWhenStreamStops') setting.value = false;
+      if (setting.name === 'WarnBeforeStoppingStream') setting.value = false;
+    });
+  });
+  settingsService.setSettings('General', generalSettings);
+
+  streamSettingsService.setGoLiveSettings({ recording: 'vertical' });
+
+  return { streamingService };
+}
+
+async function waitForDualStreamingStatus(
+  streamingService: IStreamingServiceApi,
+  expectedStatus: EStreamingState,
+  timeout = 15000,
+  stableDuration = 0,
+) {
+  const endTime = Date.now() + timeout;
+  let stableSince: number | null = null;
+
+  while (Date.now() < endTime) {
+    const status = streamingService.getModel().status;
+
+    if (
+      status.horizontal.streaming === expectedStatus &&
+      status.vertical.streaming === expectedStatus
+    ) {
+      if (!stableDuration) return;
+
+      if (!stableSince) stableSince = Date.now();
+      if (Date.now() - stableSince >= stableDuration) return;
+    } else {
+      stableSince = null;
+    }
+
+    await sleep(250);
+  }
+
+  const status = streamingService.getModel().status;
+  throw new Error(
+    `Dual output streams did not reach ${expectedStatus}. Horizontal: ${status.horizontal.streaming}; vertical: ${status.vertical.streaming}`,
+  );
+}
+
+async function waitForVerticalRecordingStatus(
+  streamingService: IStreamingServiceApi,
+  expectedStatus: ERecordingState,
+  timeout = 15000,
+) {
+  const endTime = Date.now() + timeout;
+
+  while (Date.now() < endTime) {
+    const status = streamingService.getModel().status;
+    if (status.vertical.recording === expectedStatus) return;
+
+    await sleep(250);
+  }
+
+  const status = streamingService.getModel().status;
+  throw new Error(
+    `Vertical recording did not reach ${expectedStatus}. Current status: ${status.vertical.recording}`,
+  );
+}
+
+async function stopStreamingIfNeeded(streamingService: IStreamingServiceApi) {
+  await sleep(3000);
+
+  const status = streamingService.getModel().status;
+  const isStreaming =
+    status.horizontal.streaming !== EStreamingState.Offline ||
+    status.vertical.streaming !== EStreamingState.Offline;
+
+  if (!isStreaming) return;
+
+  streamingService.toggleStreaming();
+  await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000).catch(
+    () => void 0,
+  );
+  await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000).catch(
+    () => void 0,
+  );
+}

--- a/test/regular/streaming/dual-output.ts
+++ b/test/regular/streaming/dual-output.ts
@@ -3,7 +3,6 @@ import {
   prepareToGoLive,
   submit,
   waitForSettingsWindowLoaded,
-  waitForStreamStart,
 } from '../../helpers/modules/streaming';
 import {
   click,
@@ -34,13 +33,6 @@ import { getApiClient } from '../../helpers/api-client';
 import { fillForm } from '../../helpers/modules/forms';
 import { showSettingsWindow } from '../../helpers/modules/settings/settings';
 import { sleep } from '../../helpers/sleep';
-import { SettingsService } from '../../../app/services/settings';
-import { StreamSettingsService } from '../../../app/services/settings/streaming';
-import {
-  ERecordingState,
-  EStreamingState,
-  IStreamingServiceApi,
-} from '../../../app/services/streaming/streaming-api';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -358,150 +350,3 @@ test(
     t.pass();
   },
 );
-
-test(
-  'End Stream stops both dual output streams while vertical recording is active',
-  withUser('twitch', { prime: true, multistream: true }),
-  async (t: TExecutionContext) => {
-    const { streamingService } = await configureVerticalRecordingOnStreamStart(t);
-
-    try {
-      await toggleDualOutputMode();
-      await prepareToGoLive();
-
-      await clickGoLive();
-      await waitForSettingsWindowLoaded();
-      await fillForm({
-        trovo: true,
-      });
-      await waitForSettingsWindowLoaded();
-      await fillForm({
-        trovoDisplay: 'vertical',
-        twitchDisplay: 'horizontal',
-        primaryChat: 'Twitch',
-      });
-      await submit();
-
-      await waitForDisplayed("h1=You're live!", { timeout: 60000 });
-      await waitForStreamStart();
-      await waitForDualStreamingStatus(streamingService, EStreamingState.Live);
-      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Recording);
-
-      await focusMain();
-      await clickButton('End Stream');
-
-      await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000, 5000);
-      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000);
-
-      const status = streamingService.getModel().status;
-      t.is(status.horizontal.streaming, EStreamingState.Offline);
-      t.is(status.vertical.streaming, EStreamingState.Offline);
-    } finally {
-      await stopStreamingIfNeeded(streamingService);
-      await logOut(t);
-    }
-  },
-);
-
-async function configureVerticalRecordingOnStreamStart(
-  t: TExecutionContext,
-): Promise<{ streamingService: IStreamingServiceApi }> {
-  const client = await getApiClient();
-  const settingsService = client.getResource<SettingsService>('SettingsService');
-  const streamSettingsService = client.getResource<StreamSettingsService>('StreamSettingsService');
-  const streamingService = client.getResource<IStreamingServiceApi>('StreamingService');
-
-  const outputSettings = settingsService.state.Output.formData;
-  outputSettings.forEach(subcategory => {
-    subcategory.parameters.forEach(setting => {
-      if (setting.name === 'FilePath') setting.value = t.context.cacheDir;
-    });
-  });
-  settingsService.setSettings('Output', outputSettings);
-
-  const generalSettings = settingsService.state.General.formData;
-  generalSettings.forEach(subcategory => {
-    subcategory.parameters.forEach(setting => {
-      if (setting.name === 'RecordWhenStreaming') setting.value = true;
-      if (setting.name === 'KeepRecordingWhenStreamStops') setting.value = false;
-      if (setting.name === 'WarnBeforeStoppingStream') setting.value = false;
-    });
-  });
-  settingsService.setSettings('General', generalSettings);
-
-  streamSettingsService.setGoLiveSettings({ recording: 'vertical' });
-
-  return { streamingService };
-}
-
-async function waitForDualStreamingStatus(
-  streamingService: IStreamingServiceApi,
-  expectedStatus: EStreamingState,
-  timeout = 15000,
-  stableDuration = 0,
-) {
-  const endTime = Date.now() + timeout;
-  let stableSince: number | null = null;
-
-  while (Date.now() < endTime) {
-    const status = streamingService.getModel().status;
-
-    if (
-      status.horizontal.streaming === expectedStatus &&
-      status.vertical.streaming === expectedStatus
-    ) {
-      if (!stableDuration) return;
-
-      if (!stableSince) stableSince = Date.now();
-      if (Date.now() - stableSince >= stableDuration) return;
-    } else {
-      stableSince = null;
-    }
-
-    await sleep(250);
-  }
-
-  const status = streamingService.getModel().status;
-  throw new Error(
-    `Dual output streams did not reach ${expectedStatus}. Horizontal: ${status.horizontal.streaming}; vertical: ${status.vertical.streaming}`,
-  );
-}
-
-async function waitForVerticalRecordingStatus(
-  streamingService: IStreamingServiceApi,
-  expectedStatus: ERecordingState,
-  timeout = 15000,
-) {
-  const endTime = Date.now() + timeout;
-
-  while (Date.now() < endTime) {
-    const status = streamingService.getModel().status;
-    if (status.vertical.recording === expectedStatus) return;
-
-    await sleep(250);
-  }
-
-  const status = streamingService.getModel().status;
-  throw new Error(
-    `Vertical recording did not reach ${expectedStatus}. Current status: ${status.vertical.recording}`,
-  );
-}
-
-async function stopStreamingIfNeeded(streamingService: IStreamingServiceApi) {
-  await sleep(3000);
-
-  const status = streamingService.getModel().status;
-  const isStreaming =
-    status.horizontal.streaming !== EStreamingState.Offline ||
-    status.vertical.streaming !== EStreamingState.Offline;
-
-  if (!isStreaming) return;
-
-  streamingService.toggleStreaming();
-  await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000).catch(
-    () => void 0,
-  );
-  await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000).catch(
-    () => void 0,
-  );
-}

--- a/test/regular/streaming/dual-output.ts
+++ b/test/regular/streaming/dual-output.ts
@@ -3,6 +3,7 @@ import {
   prepareToGoLive,
   submit,
   waitForSettingsWindowLoaded,
+  waitForStreamStart,
 } from '../../helpers/modules/streaming';
 import {
   click,
@@ -33,6 +34,13 @@ import { getApiClient } from '../../helpers/api-client';
 import { fillForm } from '../../helpers/modules/forms';
 import { showSettingsWindow } from '../../helpers/modules/settings/settings';
 import { sleep } from '../../helpers/sleep';
+import { SettingsService } from '../../../app/services/settings';
+import { StreamSettingsService } from '../../../app/services/settings/streaming';
+import {
+  ERecordingState,
+  EStreamingState,
+  IStreamingServiceApi,
+} from '../../../app/services/streaming/streaming-api';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -350,3 +358,150 @@ test(
     t.pass();
   },
 );
+
+test(
+  'End Stream stops both dual output streams while vertical recording is active',
+  withUser('twitch', { prime: true, multistream: true }),
+  async (t: TExecutionContext) => {
+    const { streamingService } = await configureVerticalRecordingOnStreamStart(t);
+
+    try {
+      await toggleDualOutputMode();
+      await prepareToGoLive();
+
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        trovo: true,
+      });
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        trovoDisplay: 'vertical',
+        twitchDisplay: 'horizontal',
+        primaryChat: 'Twitch',
+      });
+      await submit();
+
+      await waitForDisplayed("h1=You're live!", { timeout: 60000 });
+      await waitForStreamStart();
+      await waitForDualStreamingStatus(streamingService, EStreamingState.Live);
+      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Recording);
+
+      await focusMain();
+      await clickButton('End Stream');
+
+      await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000, 5000);
+      await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000);
+
+      const status = streamingService.getModel().status;
+      t.is(status.horizontal.streaming, EStreamingState.Offline);
+      t.is(status.vertical.streaming, EStreamingState.Offline);
+    } finally {
+      await stopStreamingIfNeeded(streamingService);
+      await logOut(t);
+    }
+  },
+);
+
+async function configureVerticalRecordingOnStreamStart(
+  t: TExecutionContext,
+): Promise<{ streamingService: IStreamingServiceApi }> {
+  const client = await getApiClient();
+  const settingsService = client.getResource<SettingsService>('SettingsService');
+  const streamSettingsService = client.getResource<StreamSettingsService>('StreamSettingsService');
+  const streamingService = client.getResource<IStreamingServiceApi>('StreamingService');
+
+  const outputSettings = settingsService.state.Output.formData;
+  outputSettings.forEach(subcategory => {
+    subcategory.parameters.forEach(setting => {
+      if (setting.name === 'FilePath') setting.value = t.context.cacheDir;
+    });
+  });
+  settingsService.setSettings('Output', outputSettings);
+
+  const generalSettings = settingsService.state.General.formData;
+  generalSettings.forEach(subcategory => {
+    subcategory.parameters.forEach(setting => {
+      if (setting.name === 'RecordWhenStreaming') setting.value = true;
+      if (setting.name === 'KeepRecordingWhenStreamStops') setting.value = false;
+      if (setting.name === 'WarnBeforeStoppingStream') setting.value = false;
+    });
+  });
+  settingsService.setSettings('General', generalSettings);
+
+  streamSettingsService.setGoLiveSettings({ recording: 'vertical' });
+
+  return { streamingService };
+}
+
+async function waitForDualStreamingStatus(
+  streamingService: IStreamingServiceApi,
+  expectedStatus: EStreamingState,
+  timeout = 15000,
+  stableDuration = 0,
+) {
+  const endTime = Date.now() + timeout;
+  let stableSince: number | null = null;
+
+  while (Date.now() < endTime) {
+    const status = streamingService.getModel().status;
+
+    if (
+      status.horizontal.streaming === expectedStatus &&
+      status.vertical.streaming === expectedStatus
+    ) {
+      if (!stableDuration) return;
+
+      if (!stableSince) stableSince = Date.now();
+      if (Date.now() - stableSince >= stableDuration) return;
+    } else {
+      stableSince = null;
+    }
+
+    await sleep(250);
+  }
+
+  const status = streamingService.getModel().status;
+  throw new Error(
+    `Dual output streams did not reach ${expectedStatus}. Horizontal: ${status.horizontal.streaming}; vertical: ${status.vertical.streaming}`,
+  );
+}
+
+async function waitForVerticalRecordingStatus(
+  streamingService: IStreamingServiceApi,
+  expectedStatus: ERecordingState,
+  timeout = 15000,
+) {
+  const endTime = Date.now() + timeout;
+
+  while (Date.now() < endTime) {
+    const status = streamingService.getModel().status;
+    if (status.vertical.recording === expectedStatus) return;
+
+    await sleep(250);
+  }
+
+  const status = streamingService.getModel().status;
+  throw new Error(
+    `Vertical recording did not reach ${expectedStatus}. Current status: ${status.vertical.recording}`,
+  );
+}
+
+async function stopStreamingIfNeeded(streamingService: IStreamingServiceApi) {
+  await sleep(3000);
+
+  const status = streamingService.getModel().status;
+  const isStreaming =
+    status.horizontal.streaming !== EStreamingState.Offline ||
+    status.vertical.streaming !== EStreamingState.Offline;
+
+  if (!isStreaming) return;
+
+  streamingService.toggleStreaming();
+  await waitForDualStreamingStatus(streamingService, EStreamingState.Offline, 30000).catch(
+    () => void 0,
+  );
+  await waitForVerticalRecordingStatus(streamingService, ERecordingState.Offline, 45000).catch(
+    () => void 0,
+  );
+}


### PR DESCRIPTION
### Summary
Fix for the following issue:
> Dual output streams, or streams that have vertical recording active at the same time are not ending when selecting end stream. 

Fix dual output stream shutdown so End Stream stops all active streaming outputs immediately, including vertical streams that are running alongside vertical recording/replay buffer outputs.

Adds a regression test for dual output streaming with vertical recording enabled.

### Motivation

The reported issue showed that when dual output streaming was active, especially with vertical recording running at the same time, selecting End Stream did not reliably end every stream output.

The previous stop flow stopped the horizontal stream first and relied on later cleanup from OBS output signals to stop the remaining streaming instances. That cleanup could be skipped while vertical recording or replay buffer was still active, leaving the vertical streaming output alive. In reconnect scenarios, OBS could also briefly report the vertical stream as offline and then reconnect it, which made the issue easier to miss.
