### PR TITLE
Fix display component IPC call to set output region.

### DIFF
--- a/app/components-react/shared/Display.tsx
+++ b/app/components-react/shared/Display.tsx
@@ -68,8 +68,7 @@ export default function Display(props: DisplayProps) {
 
   function handleResize() {
     if (!obsDisplay.current) return;
-    const [width, height] = v.baseResolution.split('x');
-    obsDisplay.current.resize(Number(width), Number(height));
+    obsDisplay.current.refreshOutputRegion();
   }
 
   function onClickHandler(event: React.MouseEvent) {


### PR DESCRIPTION
# Fix: `handleResize` passes wrong dimensions to OBS

## Issue

`handleResize` fires when the canvas resolution changes (e.g. the user switches aspect ratio). The old code called:

```ts
obsDisplay.current.resize(Number(width), Number(height))
```

`resize()` expects the **pixel size of the DOM element** so OBS knows how large the render surface is. Instead it was receiving the **canvas resolution** (e.g. 1080×1920). This caused two problems:

1. **Wrong data sent to OBS.** OBS was told the display element was the size of the canvas, which it wasn't. The DOM element did not change size — only the aspect ratio of the content inside it changed.

2. **Triggered a corrective resize.** `resize()` writes those wrong dimensions into `currentPosition`. On the next poll, `trackElement` compared `currentPosition` against the real element size via `getBoundingClientRect()`, detected a mismatch, and called `resize()` again with the correct DOM dimensions to fix it. Every base resolution change caused two `resizeOBSDisplay` IPC calls instead of zero.

What actually needs to happen when the canvas resolution changes: OBS recalculates how the preview content fits inside the display element (letterboxing/pillarboxing). This changes the **offset and size of the preview region** within the element. The editor uses these values to translate mouse clicks into scene coordinates, so they must be re-fetched. `refreshOutputRegion()` does exactly that.

## Fix

```ts
// Before
obsDisplay.current.resize(Number(width), Number(height));

// After
obsDisplay.current.refreshOutputRegion();
```

## Comparison

| | Before | After |
|---|---|---|
| What triggered it | Canvas resolution change | Canvas resolution change |
| What `resize()` expects | DOM element pixel size | — not called |
| What was passed to `resize()` | Canvas resolution (wrong) | — not called |
| DOM element changed? | No | No |
| `currentPosition` corrupted? | Yes — set to canvas dims | No |
| Corrective resize from `trackElement`? | Yes | No |
| IPC calls fired | 4 (`resizeOBSDisplay` × 2, `getOBSDisplayPreviewOffset`, `getOBSDisplayPreviewSize`) | 2 (`getOBSDisplayPreviewOffset`, `getOBSDisplayPreviewSize`) |
| Mouse coordinate translation updated? | Yes (after corrective resize) | Yes |
