### PR TITLE
Show recording active when using AI highlighter.

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -2109,9 +2109,11 @@ export class StreamingService
 
     // To prevent errors, if the recording display is not set to a valid value,
     // correct it to the default display, which is 'horizontal'.
+    // Also show recording UI when using AI highlighter
     if (
       !this.views.settings.recording ||
-      !['horizontal', 'vertical', 'both'].includes(this.views.settings.recording)
+      !['horizontal', 'vertical', 'both'].includes(this.views.settings.recording) ||
+      this.highlighterService.views.useAiHighlighter
     ) {
       const settings = cloneDeep(this.views.settings);
       this.streamSettingsService.setSettings({


### PR DESCRIPTION
Fix for:

- [Using AI highlighter appears to not start a recording](https://app.asana.com/1/1083097041131/project/1207748235152481/task/1214326983167113?focus=true)