### PR TITLE
use recording encoder settings

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -886,6 +886,14 @@ export class OutputSettingsService extends Service {
     };
   }
 
+  getRecordingVideoEncoderSettings(mode: TOutputSettingsMode): IRecordingEncoderSettings {
+    const output = this.settingsService.state.Output.formData;
+    const video = this.settingsService.state.Video.formData;
+    const streaming = this.getStreamingEncoderSettings(output, video);
+
+    return this.getRecordingEncoderSettings(output, video, mode, streaming);
+  }
+
   /**
    * This method helps to simplify tuning the encoder's settings
    * This method can patch ONLY Advanced settings

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -886,12 +886,29 @@ export class OutputSettingsService extends Service {
     };
   }
 
-  getRecordingVideoEncoderSettings(mode: TOutputSettingsMode): IRecordingEncoderSettings {
+  getRecordingVideoEncoderSettings(mode: TOutputSettingsMode): ISettings {
     const output = this.settingsService.state.Output.formData;
     const video = this.settingsService.state.Video.formData;
     const streaming = this.getStreamingEncoderSettings(output, video);
+    const recording = this.getRecordingEncoderSettings(output, video, mode, streaming);
 
-    return this.getRecordingEncoderSettings(output, video, mode, streaming);
+    const encoderSettings: ISettings = {
+      bitrate: recording.bitrate,
+    };
+
+    if (recording.rateControl != null) {
+      encoderSettings.rate_control = recording.rateControl;
+    }
+
+    if (recording.keyint_sec != null) {
+      encoderSettings.keyint_sec = recording.keyint_sec;
+    }
+
+    if (recording.x264opts != null) {
+      encoderSettings.x264opts = recording.x264opts;
+    }
+
+    return encoderSettings;
   }
 
   /**

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -417,10 +417,6 @@ export class OutputSettingsService extends Service {
         ? EObsAdvancedEncoder.obs_x264
         : convertedEncoderName;
 
-    console.log(
-      `MLH getRecordingSettings encoder name to convert: ${encoder} converted name: ${convertedEncoderName} final value to use: ${videoEncoder}`,
-    );
-
     const lowCPU: boolean = convertedEncoderName === EObsSimpleEncoder.x264_lowcpu;
 
     const overwrite: boolean = this.settingsService.findSettingValue(
@@ -898,14 +894,6 @@ export class OutputSettingsService extends Service {
 
     if (recording.rateControl != null) {
       encoderSettings.rate_control = recording.rateControl;
-    }
-
-    if (recording.keyint_sec != null) {
-      encoderSettings.keyint_sec = recording.keyint_sec;
-    }
-
-    if (recording.x264opts != null) {
-      encoderSettings.x264opts = recording.x264opts;
     }
 
     return encoderSettings;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -2373,10 +2373,15 @@ export class StreamingService
         key === 'videoEncoder' &&
         (contextName !== 'enhancedBroadcasting' || isEnhancedBroadcastingContext)
       ) {
-        const encoderSettings =
-          type === 'streaming'
-            ? this.outputSettingsService.getStreamingVideoEncoderSettings(mode)
-            : undefined;
+        let encoderSettings;
+        switch (type) {
+          case 'streaming':
+            encoderSettings = this.outputSettingsService.getStreamingVideoEncoderSettings(mode);
+            break;
+          case 'recording':
+            encoderSettings = this.outputSettingsService.getRecordingVideoEncoderSettings(mode);
+            break;
+        }
 
         if (encoderSettings) {
           instance.videoEncoder = VideoEncoderFactory.create(

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -27,6 +27,7 @@ import {
   SimpleRecordingFactory,
   AdvancedReplayBufferFactory,
   SimpleReplayBufferFactory,
+  ISettings,
 } from '../../../obs-api';
 import { Inject } from 'services/core/injector';
 import moment from 'moment';
@@ -2373,7 +2374,7 @@ export class StreamingService
         key === 'videoEncoder' &&
         (contextName !== 'enhancedBroadcasting' || isEnhancedBroadcastingContext)
       ) {
-        let encoderSettings;
+        let encoderSettings: ISettings | undefined;
         switch (type) {
           case 'streaming':
             encoderSettings = this.outputSettingsService.getStreamingVideoEncoderSettings(mode);


### PR DESCRIPTION
Updated to use recorder settings when `type == recording` (before it only used `streaming` value). Below is the details for a recording with bitrate set to 6900:
<img width="416" height="199" alt="image" src="https://github.com/user-attachments/assets/1c9fcf74-34d1-4ffa-98e1-c482dacc58a8" />


Fix for asana ticket:
https://app.asana.com/1/1083097041131/project/1209632301705219/task/1214411913252959?focus=true