### PR TITLE
Fix performance stats not pinning in footer.

### DIFF
--- a/app/components-react/shared/PerformanceMetrics.tsx
+++ b/app/components-react/shared/PerformanceMetrics.tsx
@@ -63,11 +63,12 @@ export default memo(function PerformanceMetrics(props: {
     [props.mode, pinnedStats],
   );
 
-  const showAttribute = useCallback(
-    (attribute: keyof IPinnedStatistics) => {
-      return props.mode === 'full' || pinnedStats[attribute];
+  const updatePinnedStats = useCallback(
+    (key: keyof IPinnedStatistics, value: boolean) => {
+      if (props.mode === 'limited') return;
+      CustomizationService.actions.setSettings({ pinnedStatistics: { [key]: value } });
     },
-    [props.mode, pinnedStats],
+    [props.mode, CustomizationService.actions],
   );
 
   return (
@@ -90,7 +91,7 @@ export default memo(function PerformanceMetrics(props: {
             label={data.label}
             icon={data.icon}
             isPinned={pinnedStats[attribute]}
-            onToggle={showAttribute}
+            onToggle={updatePinnedStats}
           />
         );
       })}


### PR DESCRIPTION
# Performance Statistics Not Pinning in Studio Footer

## Issue

Clicking a performance metric in the metrics window no longer toggled it in the studio footer. During the [memoization refactor](https://github.com/streamlabs/desktop/pull/5880), `showAttribute` — a read-only callback that returns  whether a stat is visible — was mistakenly passed as the `onToggle` handler for `MetricItem`. The actual `updatePinnedStats` logic that calls `CustomizationService.actions.setSettings` was dropped entirely.

## Fix

Replaced `showAttribute` with a `updatePinnedStats` callback (guarded by `mode === 'limited'`) and passed it as `onToggle`, restoring the pin/unpin behavior on click.