### PR TITLE
Ensure advanced recording creates every selected audio track

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -2283,6 +2283,15 @@ export class StreamingService
       recording.outputWidth = resolution.outputWidth;
       recording.outputHeight = resolution.outputHeight;
 
+      // create recording tracks, if necessary
+      if (Number.isFinite(recording.mixer)) {
+        for (let index = 1; index <= 6; index++) {
+          if (recording.mixer & (1 << (index - 1))) {
+            await this.validateOrCreateAudioTrack(index);
+          }
+        }
+      }
+
       // to prevent reference errors, cast the recording instance
       this.contexts[display].recording = recording as IAdvancedRecording;
     } else {


### PR DESCRIPTION
## Summary
Ensure advanced recording creates every selected audio track from the `RecTracks` mixer bitmask before starting.

## Context
The Factory API advanced recording path only attached audio encoders for `AudioTrackFactory` slots that already existed. The current code created the streaming track(s), but not all selected recording tracks, so recordings with tracks 1-6 selected could still produce only one or two audio streams.
