### PR TITLE
Handle AbortError from guest cam.

### DIFF
--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -147,6 +147,9 @@ export class ProtocolLinksService extends Service {
   private guestCamJoin(info: IProtocolLinkInfo) {
     const hash = info.path.replace('/', '');
 
-    this.guestCamService.joinAsGuest(hash);
+    this.guestCamService.joinAsGuest(hash).catch((e: unknown) => {
+      if (e instanceof DOMException && e.name === 'AbortError') return;
+      console.error('Failed to join guest cam session', e);
+    });
   }
 }

--- a/app/services/protocol-links.ts
+++ b/app/services/protocol-links.ts
@@ -148,7 +148,7 @@ export class ProtocolLinksService extends Service {
     const hash = info.path.replace('/', '');
 
     this.guestCamService.joinAsGuest(hash).catch((e: unknown) => {
-      if (e instanceof DOMException && e.name === 'AbortError') return;
+      if ((e as { name?: string } | null)?.name === 'AbortError') return;
       console.error('Failed to join guest cam session', e);
     });
   }


### PR DESCRIPTION
# Handle AbortError from guestCamService.joinAsGuest in protocol links

## Issue

`guestCamJoin` called `guestCamService.joinAsGuest()` without handling the returned promise. When the app launches with a `slobs://join/<hash>` protocol link, `joinAsGuest` calls `cleanUpSocketConnection()` followed by `startListeningForGuests()`, which makes fetch requests via `getSocketConfig`. If any in-flight fetch is cancelled during connection cleanup — an expected race condition during initialization — the resulting `AbortError` propagated to an unhandled promise rejection, logging an uncaught exception on every affected launch.

## Fix

**`protocol-links.ts`** — Added `.catch()` to the `joinAsGuest()` call in`guestCamJoin`. `AbortError` is silently swallowed since it indicates a fetch was cancelled by connection cleanup, which is expected and requires no recovery. All other rejection types are logged via `console.error` so genuine failures remain visible.

## Result

| Metric | Before | After |
|---|---|---|
| Unhandled promise rejections on launch with `slobs://join` link | 1 per launch | 0 |
| `AbortError` visibility | surfaced as uncaught exception | silently ignored (expected condition) |
| Other `joinAsGuest` failures | silently swallowed | logged via `console.error` |
