### PR TITLE
output-settings: convert seconds into minutes for SplitTime

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -464,11 +464,8 @@ export class OutputSettingsService extends Service {
         'Recording',
         'RecSplitFile',
       );
-      const splitTime = this.settingsService.findSettingValue(
-        output,
-        'Recording',
-        'RecSplitFileTime',
-      );
+      const splitTime =
+        this.settingsService.findSettingValue(output, 'Recording', 'RecSplitFileTime') * 60; // convert seconds to minutes
       const splitSize = this.settingsService.findSettingValue(
         output,
         'Recording',


### PR DESCRIPTION
* backend currently uses seconds for splitTime (which works well for the unit test). However, user expects "minutes" so we will convert here.
<img width="872" height="334" alt="image" src="https://github.com/user-attachments/assets/60fd26e2-a9c7-48a7-9294-70635aefafed" />
