### PR TITLE
Fix show/hide stream scheduler.

### DIFF
--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -544,11 +544,13 @@ export class YoutubeService
     this.state.backupStreamSettings.context = !context ? 'horizontal' : context;
 
     if (!this.streamingService.views.isMultiplatformMode) {
+      // Note: This was previously changed to `rtmp_custom` for dual streaming but
+      // it now works with `rtmp_common` as well.
       this.streamSettingsService.setSettings(
         {
           platform: 'youtube',
           key: streamKey,
-          streamType: 'rtmp_custom',
+          streamType: 'rtmp_common',
           server: 'rtmp://a.rtmp.youtube.com/live2',
         },
         context,

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -682,10 +682,7 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
    * Returns true if given platforms have a capability
    */
   supports(capability: TPlatformCapability, targetPlatforms?: TPlatform[]): boolean {
-    const platforms =
-      capability === 'stream-schedule'
-        ? this.linkedPlatforms
-        : targetPlatforms || this.enabledPlatforms;
+    const platforms = targetPlatforms || this.enabledPlatforms;
 
     for (const platform of platforms) {
       if (getPlatformService(platform).hasCapability(capability)) return true;


### PR DESCRIPTION
# Fix YouTube horizontal stream type and stream scheduler visibility

## Issue

1.  The YouTube horizontal (single-platform) stream was using `rtmp_custom` stream type, which was an earlier workaround for dual streaming compatibility but is no longer necessary.
2.  The stream scheduler was incorrectly using `linkedPlatforms` when checking for the stream-schedule capability, causing it to show/hide based on which platforms are linked rather than which are actively enabled for the stream.

## Fix
1.  Reverted the YouTube horizontal stream `streamType` from `rtmp_custom` back to `rtmp_common` in `youtube.ts` because dual streaming now works correctly with the common stream type.
2.  Use `enabledPlatforms` for the `stream-schedule` capability check.