### PR TITLE
Fixed Dual Output audio tracks mapping

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1285,7 +1285,7 @@ export class StreamingService
       if (this.views.isTwitchDualStreaming) {
         await this.createStreaming({
           output: 'both',
-          audioTrack: 1,
+          audioTrack: this.getStreamingAudioTrack(),
           start: true,
           context: 'enhancedBroadcasting',
           isEnhancedBroadcasting: true,
@@ -1301,7 +1301,7 @@ export class StreamingService
 
         this.createStreaming({
           output: 'horizontal',
-          audioTrack: 1,
+          audioTrack: this.getStreamingAudioTrack(),
           start: true,
           context: 'horizontal',
           isEnhancedBroadcasting: false,
@@ -1310,7 +1310,7 @@ export class StreamingService
         // For dual output without enhanced broadcasting, the vertical stream instance will be created and started after the horizontal stream.
         this.createStreaming({
           output: 'vertical',
-          audioTrack: 2,
+          audioTrack: this.getStreamingAudioTrack(),
           start: true,
           context: 'vertical',
           isEnhancedBroadcasting: false,
@@ -1323,7 +1323,7 @@ export class StreamingService
       } else {
         await this.createStreaming({
           output: 'horizontal',
-          audioTrack: 1,
+          audioTrack: this.getStreamingAudioTrack(),
           start: true,
           context: 'horizontal',
           isEnhancedBroadcasting: this.state.enhancedBroadcasting,
@@ -1557,7 +1557,7 @@ export class StreamingService
           await this.validateOrCreateOutputInstance({
             display: 'vertical',
             type: 'streaming',
-            audioTrack: 2,
+            audioTrack: this.getStreamingAudioTrack(),
             context: 'vertical',
             start: true,
             isEnhancedBroadcasting: false,
@@ -1598,7 +1598,7 @@ export class StreamingService
         await this.validateOrCreateOutputInstance({
           display: 'horizontal',
           type: 'streaming',
-          audioTrack: 1,
+          audioTrack: this.getStreamingAudioTrack(),
           context: 'horizontal',
           start: true,
         });
@@ -1658,7 +1658,7 @@ export class StreamingService
       await this.validateOrCreateOutputInstance({
         display: nextDisplay,
         type: 'streaming',
-        audioTrack: nextDisplay === 'horizontal' ? 1 : 2,
+        audioTrack: this.getStreamingAudioTrack(),
         context: nextDisplay,
         start: true,
         isEnhancedBroadcasting: false,
@@ -1707,7 +1707,7 @@ export class StreamingService
       if (this.views.shouldSetupRestream) {
         await this.createStreaming({
           output: 'horizontal',
-          audioTrack: 1,
+          audioTrack: this.getStreamingAudioTrack(),
           start: true,
           context: 'horizontal',
           isEnhancedBroadcasting: false,
@@ -1845,7 +1845,7 @@ export class StreamingService
 
   private async createEnhancedBroadcastSingleStream() {
     const twitchDisplay = this.views.getPlatformDisplayType('twitch');
-    const audioTrack = twitchDisplay === 'horizontal' ? 1 : 2;
+    const audioTrack = this.getStreamingAudioTrack();
 
     // Always create the enhanced broadcasting streaming instance first
     await this.validateOrCreateOutputInstance({
@@ -1991,9 +1991,10 @@ export class StreamingService
 
       if (!isEnhancedBroadcasting) {
         // stream audio track
-        const defaultAudioTrack = display === 'horizontal' ? 1 : 2;
-        this.validateOrCreateAudioTrack(index ?? defaultAudioTrack);
-        stream.audioTrack = index ?? defaultAudioTrack;
+        const audioTrack = index ?? stream.audioTrack ?? this.getStreamingAudioTrack();
+
+        this.validateOrCreateAudioTrack(audioTrack);
+        stream.audioTrack = audioTrack;
       }
 
       // Twitch VOD audio track
@@ -2151,6 +2152,11 @@ export class StreamingService
     }
 
     return Promise.resolve(this.contexts[contextName].streaming);
+  }
+
+  private getStreamingAudioTrack() {
+    const audioTrack = this.settingsService.views.streamTrack + 1;
+    return Number.isFinite(audioTrack) && audioTrack > 0 ? audioTrack : 1;
   }
 
   /**


### PR DESCRIPTION
This PR changes desktop’s Dual Output streaming setup to use the user-configured stream audio track for both horizontal and vertical streaming outputs, instead of hard-coding horizontal to track 1 and vertical to track 2.

OSN PR:
https://github.com/streamlabs/obs-studio-node/pull/1694

## Background

Dual Output previously assumed this mapping:

- horizontal stream: audio track 1
- vertical stream: audio track 2

That caused vertical streams to be silent when the user’s audio sources were routed only to the normal stream track. In the reported case, desktop created the vertical stream on track 2, while the scene collection only routed sources to track 1.

The issue was not that OBS failed to encode audio. Desktop was configuring the vertical output to use a different mixer track than the user’s stream audio setup.

The better contract is that desktop should use the configured stream audio track consistently, and the backend should be responsible for allowing multiple outputs to consume that same track safely.