### PR TITLE
Move check for global rescale before target setup.

### DIFF
--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -11,7 +11,7 @@ import { ScenesService, SceneItem, TSceneNode } from 'services/scenes';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2/video';
 import { TPlatform } from 'services/platforms';
 import { Subject } from 'rxjs';
-import { IVideoInfo } from 'obs-studio-node';
+import { EScaleType, IVideoInfo } from 'obs-studio-node';
 import { ICustomStreamDestination, StreamSettingsService } from 'services/settings/streaming';
 import {
   ISceneCollectionsManifestEntry,
@@ -505,9 +505,17 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
         'Streaming',
         'Rescale',
       );
-      if (globalRescaleOutput) {
+      const globalRescaleFilter = this.settingsService.findSettingValue(
+        output,
+        'Streaming',
+        'RescaleFilter',
+      );
+      if (globalRescaleOutput || globalRescaleFilter !== EScaleType.Disable) {
         // `Output` not a typo, it is different from above
-        this.settingsService.setSettingValue('Output', 'Rescale', false);
+        this.settingsService.setSettingsPatch({
+          Output: { Rescale: false, RescaleFilter: EScaleType.Disable },
+        });
+
         // TODO: find a cleaner way to make dual output recalculate its settings for the vertical display
         // since even after disabling "rescale output" its settings persists, and looks stretched.
         this.settingsService.refreshVideoSettings();

--- a/app/services/dual-output/dual-output.ts
+++ b/app/services/dual-output/dual-output.ts
@@ -326,9 +326,6 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     // confirm custom destinations have a default display
     this.confirmDestinationDisplays();
 
-    // Disable global Rescale Output
-    this.disableGlobalRescaleIfNeeded();
-
     /**
      * Handles enabling/disabling performance mode when toggling displays
      */
@@ -446,8 +443,6 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     this.toggleDualOutputMode(status);
 
     if (this.state.dualOutputMode) {
-      this.disableGlobalRescaleIfNeeded();
-
       // All dual output scene collections will have been validated when the collection was switched
       // so there is no need to validate the scene nodes again. So just convert the single output collection
       // to dual output if needed.
@@ -493,34 +488,6 @@ export class DualOutputService extends PersistentStatefulService<IDualOutputServ
     }
 
     this.SET_SHOW_DUAL_OUTPUT(status);
-  }
-
-  disableGlobalRescaleIfNeeded() {
-    // TODO: this could be improved, either by state tracking or making it compatible with dual output
-    // For now, disable global Rescale Output under Streaming if dual output is enabled
-    if (this.state.dualOutputMode) {
-      const output = this.settingsService.state.Output.formData;
-      const globalRescaleOutput = this.settingsService.findSettingValue(
-        output,
-        'Streaming',
-        'Rescale',
-      );
-      const globalRescaleFilter = this.settingsService.findSettingValue(
-        output,
-        'Streaming',
-        'RescaleFilter',
-      );
-      if (globalRescaleOutput || globalRescaleFilter !== EScaleType.Disable) {
-        // `Output` not a typo, it is different from above
-        this.settingsService.setSettingsPatch({
-          Output: { Rescale: false, RescaleFilter: EScaleType.Disable },
-        });
-
-        // TODO: find a cleaner way to make dual output recalculate its settings for the vertical display
-        // since even after disabling "rescale output" its settings persists, and looks stretched.
-        this.settingsService.refreshVideoSettings();
-      }
-    }
   }
 
   convertSingleOutputToDualOutputCollection() {

--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -670,30 +670,10 @@ export class OutputSettingsService extends Service {
     );
 
     if (mode === 'Advanced') {
-      const rescaleFilter =
-        this.settingsService.findSettingValue(output, 'Streaming', 'RescaleFilter') ??
-        (this.settingsService.findSettingValue(output, 'Streaming', 'Rescale')
-          ? EScaleType.Bilinear
-          : EScaleType.Disable);
-      const rescaling = rescaleFilter !== EScaleType.Disable;
-
-      let outputWidth = this.videoSettingsService.outputResolutions[display].outputWidth;
-      let outputHeight = this.videoSettingsService.outputResolutions[display].outputHeight;
-
-      const rescaleResolution = this.settingsService.findSettingValue(
+      const { rescaling, rescaleFilter, outputWidth, outputHeight } = this.getGlobalRescaleSettings(
         output,
-        'Streaming',
-        'RescaleRes',
+        display,
       );
-
-      if (rescaling && rescaleResolution) {
-        const [rescaleWidth, rescaleHeight] = rescaleResolution.split('x').map(Number);
-
-        if (Number.isFinite(rescaleWidth) && Number.isFinite(rescaleHeight)) {
-          outputWidth = rescaleWidth;
-          outputHeight = rescaleHeight;
-        }
-      }
 
       const audioTrack = this.settingsService.findSettingValue(output, 'Streaming', 'TrackIndex');
 
@@ -727,6 +707,59 @@ export class OutputSettingsService extends Service {
         customEncSettings,
       } as ISimpleStreamingOutputSettings;
     }
+  }
+
+  /**
+   * Get Global Rescale Settings by Display
+   * @remark Currently, streaming instances with the vertical display cannot use global rescale output because
+   * the global rescale settings are for the horizontal display
+   * TODO: refactor when backend changes for per-display rescale are implemented
+   *
+   * @param output - Output settings
+   * @param display - Display for streaming instance
+   * @returns Global Rescale setings
+   */
+  private getGlobalRescaleSettings(output: ISettingsSubCategory[], display: TDisplayType) {
+    let outputWidth = this.videoSettingsService.outputResolutions[display].outputWidth;
+    let outputHeight = this.videoSettingsService.outputResolutions[display].outputHeight;
+
+    if (display === 'vertical') {
+      return {
+        rescaling: false,
+        rescaleFilter: EScaleType.Disable,
+        outputWidth,
+        outputHeight,
+      };
+    }
+
+    const rescaleFilter =
+      this.settingsService.findSettingValue(output, 'Streaming', 'RescaleFilter') ??
+      (this.settingsService.findSettingValue(output, 'Streaming', 'Rescale')
+        ? EScaleType.Bilinear
+        : EScaleType.Disable);
+    const rescaling = rescaleFilter !== EScaleType.Disable;
+
+    const rescaleResolution = this.settingsService.findSettingValue(
+      output,
+      'Streaming',
+      'RescaleRes',
+    );
+
+    if (rescaling && rescaleResolution) {
+      const [rescaleWidth, rescaleHeight] = rescaleResolution.split('x').map(Number);
+
+      if (Number.isFinite(rescaleWidth) && Number.isFinite(rescaleHeight)) {
+        outputWidth = rescaleWidth;
+        outputHeight = rescaleHeight;
+      }
+    }
+
+    return {
+      rescaling,
+      rescaleFilter,
+      outputWidth,
+      outputHeight,
+    };
   }
 
   private getStreamingEncoderSettings(

--- a/app/services/settings/settings.ts
+++ b/app/services/settings/settings.ts
@@ -20,7 +20,6 @@ import {
   encoderFieldsMap,
   obsEncoderToEncoderFamily,
   EFileFormat,
-  EEncoderFamily,
   convertFileFormatToRecordingFormat,
   EncoderQueryService,
 } from './output';
@@ -37,6 +36,7 @@ import fs from 'fs';
 import path from 'path';
 import { Services } from 'components-react/service-provider';
 import { UserService } from 'app-services';
+import { EScaleType } from '../../../obs-api';
 
 export enum ESettingsCategory {
   AI = 'AI',
@@ -96,6 +96,8 @@ export interface ISettingsValues extends Record<TCategoryName, Dictionary<TObsVa
     DelayEnable: boolean;
     DelaySec?: number;
     PreserveDelay?: boolean;
+    Rescale?: boolean;
+    RescaleFilter?: EScaleType;
     RecRB?: boolean;
     RecRBTime?: number;
     RecFormat: string;

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1990,12 +1990,6 @@ export class StreamingService
         | IAdvancedStreaming
         | IEnhancedBroadcastingAdvancedStreaming;
 
-      const resolution = this.videoSettingsService.outputResolutions[display];
-      if (!stream.rescaling) {
-        stream.outputWidth = resolution.outputWidth;
-        stream.outputHeight = resolution.outputHeight;
-      }
-
       if (!isEnhancedBroadcasting) {
         // stream audio track
         const audioTrack = index ?? stream.audioTrack ?? this.getStreamingAudioTrack();

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -404,11 +404,20 @@ export class StreamingService
    * Make a transition to Live
    */
   async goLive(newSettings?: IGoLiveSettings) {
+    /**
+     * VALIDATE STREAM SETTINGS
+     */
     // Ensure valid encoders for logged out users
     if (!this.userService.isLoggedIn) {
       this.settingsService.validateEncoders();
     }
 
+    // Disable "Rescale Output" for dual output mode to prevent issues with scaling vertical/horizontal views.
+    this.dualOutputService.disableGlobalRescaleIfNeeded();
+
+    /**
+     * SET TARGET GO LIVE SETTINGS
+     */
     // To ensure that the correct chat renders if dual streaming Twitch, make sure that Twitch is the primary platform
     if (
       this.userService.state.auth?.primaryPlatform !== 'twitch' &&
@@ -472,7 +481,7 @@ export class StreamingService
     }
 
     /**
-     * Set custom destination stream settings
+     * SET CUSTOM DESTINATIONS SETTINGS
      */
     settings.customDestinations.forEach(destination => {
       // only update enabled custom destinations
@@ -489,8 +498,6 @@ export class StreamingService
       destination.video = this.videoSettingsService.contexts[display];
       destination.mode = display === 'horizontal' ? 'landscape' : 'portrait';
     });
-    // Disable "Rescale Output" for dual output mode to prevent issues with scaling vertical/horizontal views.
-    this.dualOutputService.disableGlobalRescaleIfNeeded();
 
     // save enabled platforms to reuse setting with the next app start
     this.streamSettingsService.setSettings({ goLiveSettings: settings });

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -413,9 +413,6 @@ export class StreamingService
       this.settingsService.validateEncoders();
     }
 
-    // Disable "Rescale Output" for dual output mode to prevent issues with scaling vertical/horizontal views.
-    this.dualOutputService.disableGlobalRescaleIfNeeded();
-
     /**
      * SET TARGET GO LIVE SETTINGS
      */

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -28,6 +28,7 @@ import {
   AdvancedReplayBufferFactory,
   SimpleReplayBufferFactory,
   ISettings,
+  EScaleType,
 } from '../../../obs-api';
 import { Inject } from 'services/core/injector';
 import moment from 'moment';
@@ -1996,6 +1997,13 @@ export class StreamingService
 
         this.validateOrCreateAudioTrack(audioTrack);
         stream.audioTrack = audioTrack;
+      }
+
+      // An extra safeguard to ensure that the vertical video context does not have global rescale
+      // TODO: remove this when the comprehensive fix is done
+      if (display === 'vertical') {
+        stream.rescaling = false;
+        stream.rescaleFilter = EScaleType.Disable;
       }
 
       // Twitch VOD audio track


### PR DESCRIPTION
# Move global rescale check when going live

## Issue
In `StreamingService.goLive()`, `dualOutputService.disableGlobalRescaleIfNeeded()` was being called after platform and custom destination targets had already been configured When a user had "Rescale Output" enabled globally and then went live in dual output mode, the rescale setting was applied while building the per-target video contexts for the vertical/horizontal displays — causing scaling issues on targets using the vertical display before being disabled too late to take effect.

## Fix
Removed all checks to disable global rescale settings in dual output mode to allow global rescale for streaming instances the use the horizontal display and disable only for streaming instances that use the vertical display. This is a temporary solution until backend changes are made for the vertical display to have its own global rescale settings.