### PR TITLE
Update OSN: Fixing Dual Output audio

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.20",
+      "version": "0.26.22",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Aleksandr Voitenko	Fixing Dual Output audio by moving encoder ownership out of AudioTrackFactory and into each advanced output (#1694)
Richard Osborne	Reapply "osn-replay-buffer: invoke output handler to save replays (#1689)"