### PR TITLE
Onboarding and platform chat fixes

### DIFF
--- a/app/components-react/pages/onboarding/Connect.tsx
+++ b/app/components-react/pages/onboarding/Connect.tsx
@@ -69,7 +69,7 @@ export function Connect() {
   // streamlabs and trovo are added separarely on markup below
   const platforms: TPlatform[] = RecordingModeService.views.isRecordingModeEnabled
     ? ['youtube']
-    : ['twitch', 'youtube', 'tiktok', 'kick', 'facebook', 'twitter'];
+    : ['twitch', 'youtube', 'tiktok', 'kick', 'facebook'];
 
   const shouldAddTrovo = !RecordingModeService.views.isRecordingModeEnabled;
 

--- a/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
+++ b/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
@@ -7,7 +7,7 @@ import cx from 'classnames';
 import PlatformLogo from 'components-react/shared/PlatformLogo';
 import commonStyles from './Common.m.less';
 import { $t } from 'services/i18n';
-import { confirmAsync } from 'components-react/modals';
+import { promptAction } from 'components-react/modals';
 import Form from 'components-react/shared/inputs/Form';
 import { ListInput } from 'components-react/shared/inputs';
 import { Button } from 'antd';
@@ -30,7 +30,6 @@ export function PrimaryPlatformSelect() {
     'youtube',
     'tiktok',
     'kick',
-    'patreon',
     'facebook',
     'twitter',
     'trovo',
@@ -45,17 +44,6 @@ export function PrimaryPlatformSelect() {
       value: 'youtube',
       label: 'YouTube',
       image: <PlatformLogo platform="youtube" />,
-    },
-
-    {
-      value: 'tiktok',
-      label: 'TikTok',
-      image: <PlatformLogo platform="tiktok" size={14} />,
-    },
-    {
-      value: 'kick',
-      label: 'Kick',
-      image: <PlatformLogo platform="kick" size={14} />,
     },
     {
       value: 'facebook',
@@ -72,12 +60,25 @@ export function PrimaryPlatformSelect() {
       label: 'X (Twitter)',
       image: <PlatformLogo platform="twitter" size={14} />,
     },
+    {
+      value: 'tiktok',
+      label: 'TikTok',
+      image: <PlatformLogo platform="tiktok" size={14} />,
+    },
+    {
+      value: 'kick',
+      label: 'Kick',
+      image: <PlatformLogo platform="kick" size={14} />,
+    },
   ].filter(opt => {
     return linkedPlatforms.includes(opt.value as TPlatform);
   });
   const [selectedPlatform, setSelectedPlatform] = useState(
     platformOptions.length ? platformOptions[0].value : '',
   );
+
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshAttempted, setRefreshAttempted] = useState(false);
 
   // There's probably a better way to do this
   useEffect(() => {
@@ -95,8 +96,29 @@ export function PrimaryPlatformSelect() {
     // TODO: This is probably dead code now
     if (linkedPlatforms.length) {
       setSelectedPlatform(linkedPlatforms[0]);
+      return;
+    }
+
+    // The user has an SLID but we see no linked platforms, which can happen when
+    // `fetchLinkedPlatforms` silently fails. Try once more before falling back to
+    // the "Connect a Content Platform" UI, which would otherwise ask them to
+    // reconnect platforms they may already have linked server-side.
+    if (!refreshAttempted) {
+      setRefreshAttempted(true);
+      refreshLinkedPlatforms();
     }
   }, [linkedPlatforms.length, isPrime]);
+
+  async function refreshLinkedPlatforms() {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await UserService.actions.return.updateLinkedPlatforms();
+    } finally {
+      // If linked platforms were successfully refreshed, the "Select a Primary Platform" will show
+      setRefreshing(false);
+    }
+  }
 
   // You may be confused why this component doesn't ever call `next()` to
   // continue to the next step.  The index-based step system makes this more
@@ -113,18 +135,21 @@ export function PrimaryPlatformSelect() {
   }
 
   async function onSkip() {
-    const result = await confirmAsync({
+    await promptAction({
       title: $t('Log Out?'),
-      content: $t(
+      message: $t(
         'Streamlabs Desktop requires that you have a connected platform account in order to use all of its features. By skipping this step, you will be logged out and some features may be unavailable.',
       ),
-      okText: $t('Log Out'),
+      btnText: $t('Log Out'),
+      btnType: 'primary',
+      cancelBtnPosition: 'left',
+      fn: () => {
+        finishSLAuth();
+        OnboardingService.actions.finish();
+      },
+      secondaryActionText: $t('Refresh Platforms'),
+      secondaryActionFn: refreshLinkedPlatforms,
     });
-
-    if (result) {
-      await finishSLAuth();
-      if (isLogin) OnboardingService.actions.finish();
-    }
   }
 
   async function selectPrimary(primary?: TPlatform) {
@@ -138,7 +163,9 @@ export function PrimaryPlatformSelect() {
     return (
       <div className={styles.pageContainer}>
         <div className={styles.container}>
-          <h1 className={commonStyles.titleContainer}>{$t('Select a Primary Platform')}</h1>
+          <h1 className={commonStyles.titleContainer} style={{ marginTop: '0px !important' }}>
+            {$t('Select a Primary Platform')}
+          </h1>
           <p style={{ marginBottom: 30, maxWidth: 400, textAlign: 'center' }}>
             {$t(
               'Your Streamlabs account has multiple connected content platforms. Please select the primary platform you will be streaming to using Streamlabs Desktop.',

--- a/app/i18n/en-US/onboarding.json
+++ b/app/i18n/en-US/onboarding.json
@@ -243,5 +243,6 @@
   "Free, forever.": "Free, forever.",
   "From $27/mo": "From $27/mo",
   "Continue with Free": "Continue with Free",
-  "Select Profile": "Select Profile"
+  "Select Profile": "Select Profile",
+  "Refresh Platforms": "Refresh Platforms"
 }

--- a/app/services/onboarding/onboarding-v2.ts
+++ b/app/services/onboarding/onboarding-v2.ts
@@ -38,6 +38,7 @@ interface IOnboardingInitialization {
 type TNavigationModifier =
   | 'recordingMode'
   | 'loggedIn'
+  | 'isPartialSLAuth'
   | 'isUltra'
   | 'obsInstalled'
   | 'lessThanTwoPlatforms'
@@ -159,7 +160,7 @@ class OnboardingPath {
       // TODO: This is gross since there are 3 optional steps after Login but before Devices
       // and each one can lead to either of the others in line, there's gotta be a better way
       [EOnboardingSteps.Login]: () => {
-        if (modifiers.loggedIn && modifiers.lessThanTwoPlatforms) {
+        if ((modifiers.loggedIn || modifiers.isPartialSLAuth) && modifiers.lessThanTwoPlatforms) {
           return { name: EOnboardingSteps.ConnectMore };
         }
         if (modifiers.obsInstalled) return { name: EOnboardingSteps.OBSImport };
@@ -252,6 +253,7 @@ export class OnboardingV2Service extends Service {
   get modifiers(): TModifiers {
     return {
       loggedIn: this.userService.views.isLoggedIn,
+      isPartialSLAuth: this.userService.views.isPartialSLAuth,
       isUltra: this.userService.views.isPrime,
       recordingMode: this.recordingModeService.views.isRecordingModeEnabled,
       obsInstalled: this.obsImporterService.views.isOBSinstalled(),
@@ -272,20 +274,6 @@ export class OnboardingV2Service extends Service {
   }
 
   showOnboarding() {
-    if (Utils.env.SLD_FORCE_ONBOARDING_STEP !== undefined) {
-      const isValidStep = Object.values(EOnboardingSteps).some(
-        step => step === Utils.env.SLD_FORCE_ONBOARDING_STEP,
-      );
-
-      if (isValidStep) {
-        this.initalizeView({
-          startingStep: { name: Utils.env.SLD_FORCE_ONBOARDING_STEP as EOnboardingSteps },
-          isSingleton: true,
-        });
-        return;
-      }
-    }
-
     this.initalizeView({
       startingStep: { name: EOnboardingSteps.Splash, isSkippable: false, isClosable: false },
       isSingleton: false,

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -313,6 +313,12 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   @Inject('TikTokService') tiktokService: TikTokService;
 
   setPrimaryPlatform(platform: TPlatform) {
+    // Patreon and Instagram cannot be primary platforms — they can only be merged
+    // into an existing account, never logged in with directly. Several code paths
+    // (stream-shift go-live, switchPlatforms, etc.) pick `targets[0]`/`enabledPlatforms[0]`
+    // without filtering, which would otherwise leave chat resolving to Patreon's
+    // stream-page placeholder.
+    if (platform === 'patreon' || platform === 'instagram') return;
     this.SET_PRIMARY_PLATFORM(platform);
   }
 


### PR DESCRIPTION
# Title

Fixes: Onboarding partial SLAuth flow, primary platform refresh, chat filtering

# Issues

- Users in partial SLAuth state in onboarding modal (have an SLID but no linked primary platform) couldn't reach the `ConnectMore` step from `Login` — the `lessThanTwoPlatforms` branch only fired for `loggedIn` users.
- Full screen onboarding `Connect` listed Twitter twice (once in the main platforms grid and again as a separate "X" item rendered below).
- When `fetchLinkedPlatforms` silently failed after SLID login, `PrimaryPlatformSelect` rendered with no options and only a "Log Out" escape — users with platforms linked server-side were forced to log out and reconnect.
- Merge-only platforms were selectable as a primary platform in `PrimaryPlatformSelect`.
- Multistream chat could resolve to merge-only stream-page placeholder.

# Fixes

- **Onboarding navigation (`onboarding-v2.ts`)** — added `isPartialSLAuth` modifier so the `Login → ConnectMore` step fires for partial-auth users, not just fully logged-in users. Also removed the dead `SLD_FORCE_ONBOARDING_STEP` env override branch in `showOnboarding()`.
- **Old Connect (`Connect.tsx`)** — removed `'twitter'` from the platforms grid array since X is rendered separately below.
- **PrimaryPlatformSelect (`PrimaryPlatformSelect.tsx`)** —
  - Auto-retries `UserService.updateLinkedPlatforms()` once when `linkedPlatforms` is empty before falling back to the empty-state UI.
  - Replaced `confirmAsync` skip dialog with `promptAction`, exposing a "Refresh Platforms" secondary button so users have an escape hatch other than logging out.
- **Primary platform validation (`user/index.ts`)** — `UserService.setPrimaryPlatform` now rejects merge-only platforms, preventing downstream callers from corrupting the primary platform when their `targets[0]` / `enabledPlatforms[0]` happens to be a merge-only platform.
