### PR TITLE
Fixes for multistream and placeholder chat.

### DIFF
--- a/app/components-react/root/LiveDock.tsx
+++ b/app/components-react/root/LiveDock.tsx
@@ -382,7 +382,7 @@ function LiveDock() {
 
     const service = getPlatformService(primaryChat!);
 
-    if (!service.hasCapability('chat') && !hasLiveDockFeature('chat-offline')) {
+    if (!service.hasCapability('chat') && !service.hasLiveDockFeature('chat-offline')) {
       return <OfflineChat chatEnabled={false} primaryPlatform={primaryChat} />;
     }
 

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -453,52 +453,45 @@ export class RestreamService extends StatefulService<IRestreamState> {
         targetInfo.streamKey = `${ttSettings.serverUrl}/${ttSettings.streamKey}`;
       }
 
+      // treat twitter as a custom destination
+      if (platform === 'twitter') {
+        targetInfo.platform = 'relay';
+        targetInfo.streamKey = `${this.twitterService.state.ingest}/${this.twitterService.state.streamKey}`;
+      }
+
+      // treat instagram as a custom destination
+      if (platform === 'instagram') {
+        targetInfo.platform = 'relay';
+        targetInfo.streamKey = `${this.instagramService.state.settings.streamUrl}${this.instagramService.state.streamKey}`;
+      }
+
+      // treat kick as a custom destination
+      if (platform === 'kick') {
+        targetInfo.platform = 'relay';
+        targetInfo.streamKey = `${this.kickService.state.ingest}/${this.kickService.state.streamKey}`;
+      }
+
+      // treat patreon as a custom destination
+      if (platform === 'patreon') {
+        targetInfo.platform = 'patreon';
+        targetInfo.streamKey = `${this.patreonService.state.ingest}/${this.patreonService.state.streamKey}`;
+      }
+
       // reassign platforms to displays if in dual output mode
       if (isDualOutputMode) {
-        const modesToRestream = this.streamInfo.displaysToRestream.map(display =>
-          this.getMode(display),
-        );
+        const mode = this.getPlatformMode(platform) ?? 'landscape';
 
-        // treat twitter as a custom destination
-        if (platform === 'twitter') {
-          targetInfo.platform = 'relay';
-          targetInfo.streamKey = `${this.twitterService.state.ingest}/${this.twitterService.state.streamKey}`;
+        // Add platform if the display is being restreamed in dual output mode
+        if (modesToRestream.includes(mode)) {
+          // In order to restream a platform to a display in dual output mode,
+          // assign the platform to a `mode`, which denotes the display context
+          platforms.push({ ...targetInfo, mode });
         }
-
-        // treat instagram as a custom destination
-        if (platform === 'instagram') {
-          targetInfo.platform = 'relay';
-          targetInfo.streamKey = `${this.instagramService.state.settings.streamUrl}${this.instagramService.state.streamKey}`;
-        }
-
-        // treat kick as a custom destination
-        if (platform === 'kick') {
-          targetInfo.platform = 'relay';
-          targetInfo.streamKey = `${this.kickService.state.ingest}/${this.kickService.state.streamKey}`;
-        }
-
-        // treat patreon as a custom destination
-        if (platform === 'patreon') {
-          targetInfo.platform = 'patreon';
-          targetInfo.streamKey = `${this.patreonService.state.ingest}/${this.patreonService.state.streamKey}`;
-        }
-
-        // reassign platforms to displays if in dual output mode
-        if (isDualOutputMode) {
-          const mode = this.getPlatformMode(platform) ?? 'landscape';
-
-          // Add platform if the display is being restreamed in dual output mode
-          if (modesToRestream.includes(mode)) {
-            // In order to restream a platform to a display in dual output mode,
-            // assign the platform to a `mode`, which denotes the display context
-            platforms.push({ ...targetInfo, mode });
-          }
-        } else {
-          platforms.push({ ...targetInfo, mode: 'landscape' as TOutputOrientation });
-        }
-
-        return platforms;
+      } else {
+        platforms.push({ ...targetInfo, mode: 'landscape' as TOutputOrientation });
       }
+
+      return platforms;
     }, []);
   }
 

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -313,12 +313,6 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
   @Inject('TikTokService') tiktokService: TikTokService;
 
   setPrimaryPlatform(platform: TPlatform) {
-    // Patreon and Instagram cannot be primary platforms — they can only be merged
-    // into an existing account, never logged in with directly. Several code paths
-    // (stream-shift go-live, switchPlatforms, etc.) pick `targets[0]`/`enabledPlatforms[0]`
-    // without filtering, which would otherwise leave chat resolving to Patreon's
-    // stream-page placeholder.
-    if (platform === 'patreon' || platform === 'instagram') return;
     this.SET_PRIMARY_PLATFORM(platform);
     this.primaryPlatformChanged.next(platform);
   }


### PR DESCRIPTION
# Fix restream platform relay handling broken by merge conflict resolution in 869078a

Commit `869078ac` ([Merge branch 'master' into staging](https://github.com/streamlabs/desktop/commit/869078ac3a7280630b81698926ee40784d34b600)) introduced bugs in multistreaming and primary chat.

## Issue 1

Commit `869078ac` ([Merge branch 'master' into staging](https://github.com/streamlabs/desktop/commit/869078ac3a7280630b81698926ee40784d34b600)) introduced two bugs in `setupPlatforms()` in `app/services/restream.ts` when resolving merge conflicts between staging and master (`b1d9d9b`).

1. **Wrong stream keys in single output mode** — The relay overrides for twitter, instagram, kick, and patreon (which replace the default `streamKey` with an ingest-based URL) were accidentally placed inside the `if (isDualOutputMode)` block. In single output mode these platforms would stream with the incorrect key from `getPlatformService(platform).state.streamKey` instead of their platform-specific ingest URLs, causing streams to fail or go to the wrong destination.

2. **No targets pushed in single output mode** — The single output mode fallback (`else { platforms.push({ ...targetInfo, mode: 'landscape' }) }`) was nested inside the `if (isDualOutputMode)` guard, making it unreachable dead code. As a result, in single output mode the `reduce` callback never pushed any platform to the targets array, so restream received no targets and nothing would stream.

## Fix 1

Moved the twitter, instagram, kick, and patreon relay override blocks outside the `isDualOutputMode` guard so they apply in all modes. Collapsed the redundant nested `if (isDualOutputMode)` check into a single `if/else` — the `if` branch handles dual output mode (mode-filtered target assignment) and the `else` branch handles single output mode (pushes all targets with `mode: 'landscape'`).

## Issue 2

### `app/services/user/index.ts` — `setPrimaryPlatform` changes merged from master

The merge correctly brought in two changes to `UserService.setPrimaryPlatform` from master (`b1d9d9b`):

1. **Guard against merge-only platforms as primary** — Patreon and Instagram can only be linked (never logged into directly), so `setPrimaryPlatform` now returns early if called with either. This prevents chat and stream-info routing from resolving to a platform that has no streaming capability.

2. **`primaryPlatformChanged` subject** — A new `Subject<TPlatform>` is emitted whenever the primary platform changes, allowing downstream code (stream-shift go-live, `switchPlatforms`, etc.) to react without polling.\

## Fix 2

Removed guard against merge-only platforms as primary, which was removed on 'master'.

---

## Issue 3 (new)

### `app/components-react/root/LiveDock.tsx` — wrong platform checked for `chat-offline`

The merge combined two independently correct changes that interacted badly in the `chat` useMemo:

- **Staging** changed `primaryChat` to resolve dynamically — `enabledPlatforms[0]` when the primary platform is not currently streaming — so `primaryChat` can be a different platform than the logged-in user's.
- **Master** added `&& !hasLiveDockFeature('chat-offline')` to the capability check, but `hasLiveDockFeature` on the controller checks the **logged-in user's** platform features (`ctrl.platform`), not the `primaryChat` platform's.

**Result:** When the logged-in platform (e.g. Twitch, which has `chat-offline`) differs from `primaryChat` (e.g. Instagram, which has no `chat` capability), the `OfflineChat` placeholder is suppressed and `<Chat>` is rendered for a platform with no chat support.

**Fix (`LiveDock.tsx`):** Replace `hasLiveDockFeature('chat-offline')` with `service.hasLiveDockFeature('chat-offline')` inside the `chat` useMemo, checking the feature against the `primaryChat` platform's service rather than the controller's logged-in platform service.