### PR TITLE
Bundle: Update TwitchService to lookup games using a unique Id

### DIFF
--- a/app/components-react/windows/go-live/GameSelector.tsx
+++ b/app/components-react/windows/go-live/GameSelector.tsx
@@ -24,16 +24,19 @@ export default function GameSelector(p: TProps) {
   const isTikTok = platform === 'tiktok';
   const isKick = platform === 'kick';
 
-  if (isTrovo) {
-    selectedGameName = Services.TrovoService.state.channelInfo.gameName;
-  }
-
-  if (isTikTok) {
-    selectedGameName = Services.TikTokService.state.gameName;
-  }
-
-  if (isKick) {
-    selectedGameName = Services.KickService.state.gameName;
+  switch (platform) {
+    case 'twitch':
+      selectedGameName = Services.TwitchService.state.settings.gameName;
+      break;
+    case 'trovo':
+      selectedGameName = Services.TrovoService.state.channelInfo.gameName;
+      break;
+    case 'tiktok':
+      selectedGameName = Services.TikTokService.state.gameName;
+      break;
+    case 'kick':
+      selectedGameName = Services.KickService.state.gameName;
+      break;
   }
 
   const { isSearching, setIsSearching, games, setGames } = useModule(() => {
@@ -68,7 +71,8 @@ export default function GameSelector(p: TProps) {
     // game images available for Twitch, Trovo, and Kick only
     if (!['twitch', 'trovo', 'kick'].includes(platform)) return;
     if (!selectedGameName) return;
-    const game = await platformService.fetchGame(selectedGameName);
+    // Twitch api can return multiple games with the same name, so we have to find the one with the matching id
+    const game = await platformService.fetchGame(isTwitch ? selectedGameId : selectedGameName);
     if (!game || game.name !== selectedGameName) return;
     setGames(
       games.map(opt => (opt.value === selectedGameId ? { ...opt, image: game.image } : opt)),
@@ -79,7 +83,7 @@ export default function GameSelector(p: TProps) {
     if (searchString.length < 2 && platform !== 'tiktok') return;
     const games =
       (await fetchGames(searchString))?.map(g => ({
-        value: ['trovo', 'tiktok', 'kick'].includes(platform) ? g.id : g.name,
+        value: ['trovo', 'tiktok', 'kick', 'twitch'].includes(platform) ? g.id : g.name,
         label: g.name,
         image: g?.image,
       })) ?? [];

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -498,14 +498,18 @@ export class TwitchService
   }
 
   async putChannelInfo(settings: Partial<ITwitchStartStreamOptions>): Promise<void> {
-    this.twitchTagsService.actions.setTags(settings.tags);
+    if (settings.tags) {
+      this.twitchTagsService.actions.setTags(settings.tags);
+    } else {
+      console.warn('Trying to update Twitch channel info without tags, skipping tag update');
+    }
     const hasPermission = await this.hasScope('channel:manage:broadcast');
     const scopedTags = hasPermission ? settings.tags : undefined;
 
     // Twitch seems to require you to add a label with disabled to remove it
     const labels = this.twitchContentClassificationService.options.map(option => ({
       id: option.value,
-      is_enabled: settings.contentClassificationLabels.includes(option.value),
+      is_enabled: settings.contentClassificationLabels?.includes(option.value),
     }));
 
     const updateInfo = async (tags: ITwitchStartStreamOptions['tags'] | undefined) =>
@@ -537,13 +541,13 @@ export class TwitchService
         }
 
         const offendingTags = offendingTagsStr.split(', ').map(str => str.toLowerCase());
-        const newTags = settings.tags.filter(tag => !offendingTags.includes(tag.toLowerCase()));
+        const newTags = settings.tags?.filter(tag => !offendingTags.includes(tag.toLowerCase()));
 
         // If we fail the second time we're throwing our hands up and let it blow up as before
         await updateInfo(newTags);
 
         // Remove the offending tags from their list, they can't use them anyways
-        this.twitchTagsService.actions.setTags(newTags);
+        if (newTags) this.twitchTagsService.actions.setTags(newTags);
         this.SET_STREAM_SETTINGS({
           title: settings.title,
           game: settings.game,

--- a/app/services/platforms/twitch.ts
+++ b/app/services/platforms/twitch.ts
@@ -35,6 +35,7 @@ import { EAvailableFeatures } from 'services/incremental-rollout';
 export interface ITwitchStartStreamOptions {
   title: string;
   game?: string;
+  gameName: string;
   video?: IVideo;
   tags: string[];
   mode?: TOutputOrientation;
@@ -120,6 +121,7 @@ export class TwitchService
     settings: {
       title: '',
       game: '',
+      gameName: '',
       video: undefined,
       mode: undefined,
       tags: [],
@@ -378,6 +380,7 @@ export class TwitchService
       this.requestTwitch<{
         data: {
           title: string;
+          game_id: string;
           game_name: string;
           is_branded_content: boolean;
           content_classification_labels: string[];
@@ -385,7 +388,8 @@ export class TwitchService
       }>(`${this.apiBase}/helix/channels?broadcaster_id=${this.twitchId}`).then(json => {
         return {
           title: json.data[0].title,
-          game: json.data[0].game_name,
+          game: json.data[0].game_id,
+          gameName: json.data[0].game_name,
           is_branded_content: json.data[0].is_branded_content,
           content_classification_labels: json.data[0].content_classification_labels,
         };
@@ -412,6 +416,7 @@ export class TwitchService
       tags,
       title: channelInfo.title,
       game: channelInfo.game,
+      gameName: channelInfo.gameName,
       isBrandedContent: channelInfo.is_branded_content,
       isEnhancedBroadcasting,
       contentClassificationLabels: channelInfo.content_classification_labels,
@@ -447,6 +452,7 @@ export class TwitchService
       this.requestTwitch<{
         data: {
           title: string;
+          game_id: string;
           game_name: string;
           is_branded_content: boolean;
           content_classification_labels: string[];
@@ -454,7 +460,8 @@ export class TwitchService
       }>(`${this.apiBase}/helix/channels?broadcaster_id=${this.twitchId}`).then(json => {
         return {
           title: settings?.stream_title ?? json.data[0].title,
-          game: json.data[0].game_name,
+          game: json.data[0].game_id,
+          gameName: json.data[0].game_name,
           is_branded_content: json.data[0].is_branded_content,
           content_classification_labels: json.data[0].content_classification_labels,
         };
@@ -465,7 +472,7 @@ export class TwitchService
     ]);
 
     const title = settings?.stream_title ?? channelInfo.title;
-    const game = settings?.game_name ?? channelInfo.game;
+    const game = settings?.game_id ?? channelInfo.game;
 
     const tags: string[] = this.twitchTagsService.views.hasTags
       ? this.twitchTagsService.views.tags
@@ -475,6 +482,7 @@ export class TwitchService
       tags,
       title,
       game,
+      gameName: channelInfo.gameName,
       isBrandedContent: channelInfo.is_branded_content,
       isEnhancedBroadcasting: this.settingsService.isEnhancedBroadcasting(),
       contentClassificationLabels: channelInfo.content_classification_labels,
@@ -489,30 +497,15 @@ export class TwitchService
     }).then(json => json.total);
   }
 
-  async putChannelInfo({
-    title,
-    game,
-    tags = [],
-    contentClassificationLabels = [],
-    isBrandedContent = false,
-    isEnhancedBroadcasting = false,
-  }: ITwitchStartStreamOptions): Promise<void> {
-    let gameId = '';
-    const isUnlisted = game === UNLISTED_GAME_CATEGORY.name;
-    if (isUnlisted) gameId = '0';
-    if (game && !isUnlisted) {
-      gameId = await this.requestTwitch<{ data: { id: string }[] }>(
-        `${this.apiBase}/helix/games?name=${encodeURIComponent(game)}`,
-      ).then(json => json.data[0].id);
-    }
-    this.twitchTagsService.actions.setTags(tags);
+  async putChannelInfo(settings: Partial<ITwitchStartStreamOptions>): Promise<void> {
+    this.twitchTagsService.actions.setTags(settings.tags);
     const hasPermission = await this.hasScope('channel:manage:broadcast');
-    const scopedTags = hasPermission ? tags : undefined;
+    const scopedTags = hasPermission ? settings.tags : undefined;
 
     // Twitch seems to require you to add a label with disabled to remove it
     const labels = this.twitchContentClassificationService.options.map(option => ({
       id: option.value,
-      is_enabled: contentClassificationLabels.includes(option.value),
+      is_enabled: settings.contentClassificationLabels.includes(option.value),
     }));
 
     const updateInfo = async (tags: ITwitchStartStreamOptions['tags'] | undefined) =>
@@ -521,9 +514,9 @@ export class TwitchService
         method: 'PATCH',
         body: JSON.stringify({
           tags,
-          title,
-          game_id: gameId,
-          is_branded_content: isBrandedContent,
+          title: settings.title,
+          game_id: settings.game,
+          is_branded_content: settings.isBrandedContent,
           content_classification_labels: labels,
         }),
       });
@@ -544,14 +537,19 @@ export class TwitchService
         }
 
         const offendingTags = offendingTagsStr.split(', ').map(str => str.toLowerCase());
-        const newTags = tags.filter(tag => !offendingTags.includes(tag.toLowerCase()));
+        const newTags = settings.tags.filter(tag => !offendingTags.includes(tag.toLowerCase()));
 
         // If we fail the second time we're throwing our hands up and let it blow up as before
         await updateInfo(newTags);
 
         // Remove the offending tags from their list, they can't use them anyways
         this.twitchTagsService.actions.setTags(newTags);
-        this.SET_STREAM_SETTINGS({ title, game, tags: newTags });
+        this.SET_STREAM_SETTINGS({
+          title: settings.title,
+          game: settings.game,
+          gameName: settings.gameName,
+          tags: newTags,
+        });
 
         // Notify the user of the tags that were removed
         // TODO: I don't personally like calling Notification code from here
@@ -571,10 +569,11 @@ export class TwitchService
     }
 
     this.SET_STREAM_SETTINGS({
-      title,
-      game,
-      tags,
-      isEnhancedBroadcasting,
+      title: settings.title,
+      game: settings.game,
+      gameName: settings.gameName,
+      tags: settings.tags,
+      isEnhancedBroadcasting: settings.isEnhancedBroadcasting,
     });
   }
 
@@ -594,12 +593,12 @@ export class TwitchService
     return data.map(g => ({ id: g.id, name: g.name, image: g.box_art_url }));
   }
 
-  async fetchGame(name: string): Promise<IGame> {
-    if (name === UNLISTED_GAME_CATEGORY.name) return UNLISTED_GAME_CATEGORY;
+  async fetchGame(id: string): Promise<IGame> {
+    if (id === UNLISTED_GAME_CATEGORY.id) return UNLISTED_GAME_CATEGORY;
 
     const gamesResponse = await platformAuthorizedRequest<{
       data: { id: string; name: string; box_art_url: string }[];
-    }>('twitch', `${this.apiBase}/helix/games?name=${encodeURIComponent(name)}`);
+    }>('twitch', `${this.apiBase}/helix/games?id=${encodeURIComponent(id)}`);
     return gamesResponse.data.map(g => {
       const imageTemplate = g.box_art_url;
       const imageSize = this.gameImageSize;


### PR DESCRIPTION
* update TwitchService to support lookups via Id to resolve issue where the rest api has returned
two games with same name (Atlas) which caused lookups 'by name' to fail. Update this service to behave like the sibling `TrovoService` implementation, which looks up games via a unique Id.
* update `TwitchService.putChannelInfo()` to follow the newer pattern established by `PatreonService.putChannelInfo` to resolve a warning and conform to interface definition
* fix Asana ticket: https://app.asana.com/1/1083097041131/project/1207748235152481/task/1214826891398601
* Locally verified by running `test/regular/streaming/twitch.js`