### PR TITLE
Update OSN: use obs-31.2 game capture libraries

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.22",
+      "version": "0.26.23",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
Richard	MacOS getDevice() optimization, set CI env var, & add getVideoDevices() test (#1691)