### PR TITLE
Platform UI fixes.

### DIFF
--- a/app/components-react/pages/onboarding/Common.m.less
+++ b/app/components-react/pages/onboarding/Common.m.less
@@ -9,7 +9,7 @@
   }
 
   margin-bottom: 40px;
-  margin-top: 144px;
+  // margin-top: 144px;
 }
 
 .subtitle-container {

--- a/app/components-react/pages/onboarding/Connect.tsx
+++ b/app/components-react/pages/onboarding/Connect.tsx
@@ -95,7 +95,7 @@ export function Connect() {
   return (
     <div className={styles.pageContainer}>
       <div className={styles.container}>
-        <h1 className={commonStyles.titleContainer} style={{ marginTop: 0 }}>
+        <h1 className={commonStyles.titleContainer} style={{ marginTop: '0px !important' }}>
           {title}
         </h1>
         {isSignup ? (

--- a/app/components-react/pages/onboarding/Connect.tsx
+++ b/app/components-react/pages/onboarding/Connect.tsx
@@ -95,9 +95,7 @@ export function Connect() {
   return (
     <div className={styles.pageContainer}>
       <div className={styles.container}>
-        <h1 className={commonStyles.titleContainer} style={{ marginTop: '0px !important' }}>
-          {title}
-        </h1>
+        <h1 className={commonStyles.titleContainer}>{title}</h1>
         {isSignup ? (
           <Signup onSignupLinkClick={() => setIsSignup(false)} onSuccess={afterLogin} />
         ) : (

--- a/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
+++ b/app/components-react/pages/onboarding/PrimaryPlatformSelect.tsx
@@ -23,17 +23,19 @@ export function PrimaryPlatformSelect() {
   }));
   const { loading, authInProgress, authPlatform, finishSLAuth } = useModule(LoginModule);
 
-  // Note: Patreon is intentionally left out of the platform options since it cannot
-  // be a primary platform if there are other platforms linked
   const platforms: TPlatform[] = [
     'twitch',
     'youtube',
     'tiktok',
     'kick',
+    'patreon',
     'facebook',
     'twitter',
     'trovo',
   ];
+
+  // Note: Patreon is intentionally left out of the platform options since it cannot
+  // be a primary platform if there are other platforms linked
   const platformOptions = [
     {
       value: 'twitch',
@@ -44,6 +46,16 @@ export function PrimaryPlatformSelect() {
       value: 'youtube',
       label: 'YouTube',
       image: <PlatformLogo platform="youtube" />,
+    },
+    {
+      value: 'tiktok',
+      label: 'TikTok',
+      image: <PlatformLogo platform="tiktok" size={14} />,
+    },
+    {
+      value: 'kick',
+      label: 'Kick',
+      image: <PlatformLogo platform="kick" size={14} />,
     },
     {
       value: 'facebook',
@@ -59,16 +71,6 @@ export function PrimaryPlatformSelect() {
       value: 'twitter',
       label: 'X (Twitter)',
       image: <PlatformLogo platform="twitter" size={14} />,
-    },
-    {
-      value: 'tiktok',
-      label: 'TikTok',
-      image: <PlatformLogo platform="tiktok" size={14} />,
-    },
-    {
-      value: 'kick',
-      label: 'Kick',
-      image: <PlatformLogo platform="kick" size={14} />,
     },
   ].filter(opt => {
     return linkedPlatforms.includes(opt.value as TPlatform);

--- a/app/components-react/shared/DisplaySelector.tsx
+++ b/app/components-react/shared/DisplaySelector.tsx
@@ -5,7 +5,6 @@ import { TDisplayType } from 'services/settings-v2';
 import { platformLabels, TPlatform } from 'services/platforms';
 import { useGoLiveSettings } from 'components-react/windows/go-live/useGoLiveSettings';
 import { TDisplayOutput } from 'services/streaming';
-import { IRadioMetadata } from './inputs/metadata';
 import { ICustomRadioOption } from './inputs/RadioInput';
 
 interface IDisplaySelectorProps {
@@ -90,10 +89,10 @@ export default function DisplaySelector(p: IDisplaySelectorProps) {
 
   // Convert displays array to Dictionary<TInputValue>
   const displayDict = useMemo(() => {
-    return displays.reduce((acc: Dictionary<IRadioMetadata>, curr) => {
+    return displays.reduce((acc: Dictionary<ICustomRadioOption>, curr) => {
       acc[curr.value] = curr;
       return acc;
-    }, {} as Dictionary<IRadioMetadata>);
+    }, {} as Dictionary<ICustomRadioOption>);
   }, [displays]);
 
   const name = `${p.platform || `destination${p.index}`}Display`;

--- a/app/components-react/shared/inputs/RadioInput.tsx
+++ b/app/components-react/shared/inputs/RadioInput.tsx
@@ -101,11 +101,7 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           className={p.className}
           style={p?.style}
         >
-          <Space
-            size={p?.gapsize ?? undefined}
-            direction={p?.direction ?? 'vertical'}
-            style={p?.style}
-          >
+          <Space size={p?.gapsize ?? undefined} direction={p?.direction ?? 'vertical'}>
             {p.options.map(option => {
               return (
                 <React.Fragment key={option.value}>

--- a/app/components-react/shared/inputs/RadioInput.tsx
+++ b/app/components-react/shared/inputs/RadioInput.tsx
@@ -13,6 +13,7 @@ export interface ICustomRadioOption {
   defaultValue?: string;
   icon?: string;
   tooltip?: string;
+  children?: React.ReactNode;
 }
 
 interface ICustomRadioGroupProps {
@@ -100,19 +101,27 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           className={p.className}
           style={p?.style}
         >
-          <Space size={p?.gapsize ?? undefined} direction={p?.direction ?? 'vertical'}>
+          <Space
+            size={p?.gapsize ?? undefined}
+            direction={p?.direction ?? 'vertical'}
+            style={p?.style}
+          >
             {p.options.map(option => {
               return (
-                <Radio
-                  key={option.value}
-                  value={option.value}
-                  disabled={p.disabled}
-                  name={`${p.name}-${option.value}`}
-                >
-                  {option.label}
-                  {option.description && <br />}
-                  {option.description && <span style={{ fontSize: 12 }}>{option.description}</span>}
-                </Radio>
+                <React.Fragment key={option.value}>
+                  <Radio
+                    value={option.value}
+                    disabled={p.disabled}
+                    name={`${p.name}-${option.value}`}
+                  >
+                    {option.label}
+                    {option.description && <br />}
+                    {option.description && (
+                      <span style={{ fontSize: 12 }}>{option.description}</span>
+                    )}
+                  </Radio>
+                  {option.children}
+                </React.Fragment>
               );
             })}
           </Space>

--- a/app/components-react/shared/inputs/TagsInput.tsx
+++ b/app/components-react/shared/inputs/TagsInput.tsx
@@ -10,7 +10,7 @@ import { $t } from '../../../services/i18n';
 import Message from '../Message';
 
 // select which features from the antd lib we are going to use
-const ANT_SELECT_FEATURES = ['showSearch', 'loading', 'size'] as const;
+const ANT_SELECT_FEATURES = ['showSearch', 'loading', 'size', 'maxTagCount'] as const;
 
 interface ICustomTagsProps<TValue> extends Omit<ICustomListProps<SingleType<TValue>>, 'options'> {
   max?: number;
@@ -22,6 +22,8 @@ interface ICustomTagsProps<TValue> extends Omit<ICustomListProps<SingleType<TVal
   mode?: 'tags' | 'multiple';
   tokenSeparators?: string[];
   dropdownStyle?: React.CSSProperties;
+  nomargin?: boolean;
+  nolabel?: boolean;
 }
 
 export type TTagsInputProps<TValue> = TSlobsInputProps<
@@ -32,7 +34,11 @@ export type TTagsInputProps<TValue> = TSlobsInputProps<
 >;
 
 export const TagsInput = InputComponent(<T extends any[]>(p: TTagsInputProps<T>) => {
-  const { inputAttrs, wrapperAttrs } = useInput('tags', p, ['tokenSeparators', 'dropdownStyle']);
+  const { inputAttrs, wrapperAttrs } = useInput('tags', p, [
+    'tokenSeparators',
+    'dropdownStyle',
+    'maxTagCount',
+  ]);
   const options = p.options || [];
   const tagsMap = useMemo(() => keyBy(options, 'value'), [options]);
 
@@ -47,7 +53,7 @@ export const TagsInput = InputComponent(<T extends any[]>(p: TTagsInputProps<T>)
     if (p.tagRender) {
       return p.tagRender(tagProps, tag);
     }
-    return <Tag {...tagProps}>{tag.label}</Tag>;
+    return <Tag {...tagProps}>{tag?.label}</Tag>;
   }
 
   function dropdownRender(menu: JSX.Element) {
@@ -74,7 +80,11 @@ export const TagsInput = InputComponent(<T extends any[]>(p: TTagsInputProps<T>)
   const displayValue = (inputAttrs.value || []).map((val: string) => tagsMap[val]?.label);
 
   return (
-    <InputWrapper {...wrapperAttrs}>
+    <InputWrapper
+      {...wrapperAttrs}
+      nolabel={p?.nolabel}
+      style={{ margin: p.nomargin ? '0px' : 'inherit' }}
+    >
       <Select
         {...inputAttrs}
         // search by label instead value
@@ -91,6 +101,10 @@ export const TagsInput = InputComponent(<T extends any[]>(p: TTagsInputProps<T>)
           // TODO: index
           // @ts-ignore
           inputAttrs['showSearch']
+        }
+        data-max-tag-count={
+          // @ts-ignore
+          inputAttrs['maxTagCount']
         }
       >
         {options.length > 0 && options.map((opt, ind) => renderOption(opt, ind, p))}

--- a/app/components-react/shared/inputs/TagsInput.tsx
+++ b/app/components-react/shared/inputs/TagsInput.tsx
@@ -83,7 +83,10 @@ export const TagsInput = InputComponent(<T extends any[]>(p: TTagsInputProps<T>)
     <InputWrapper
       {...wrapperAttrs}
       nolabel={p?.nolabel}
-      style={{ margin: p.nomargin ? '0px' : 'inherit' }}
+      style={{
+        ...wrapperAttrs.style,
+        ...(p.nomargin ? { margin: '0px' } : {}),
+      }}
     >
       <Select
         {...inputAttrs}

--- a/app/components-react/windows/go-live/CommonPlatformFields.tsx
+++ b/app/components-react/windows/go-live/CommonPlatformFields.tsx
@@ -141,6 +141,7 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
               max={maxCharacters}
               layout={p.layout}
               size="large"
+              uncontrolled={false}
             />
 
             {/*DESCRIPTION*/}
@@ -152,6 +153,7 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
                 label={$t('Description')}
                 required={descriptionIsRequired}
                 layout={p.layout}
+                uncontrolled={false}
               />
             )}
 

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.m.less
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.m.less
@@ -1,0 +1,21 @@
+.patreon-tags {
+  width: 100%;
+
+  :global(.ant-space.ant-space-horizontal.ant-space-align-center) {
+    margin-left: 16px;
+    width: calc(100% - 16px);
+  }
+
+  :global(.ant-space-item):last-child {
+    width: 100%;
+    flex: 1;
+  }
+
+  :global(.ant-col.ant-col-16.ant-form-item-control) {
+    max-width: 100% !important;
+  }
+
+  :global(.ant-radio-wrapper) {
+    margin-right: 0px;
+  }
+}

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
@@ -35,6 +35,8 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
       allRuleValues: rules.map(rule => rule.value),
       allTiersValue: paidRule?.value,
     };
+    // Note: PatreonService.accessRules is assumed to be static or memoized itself
+    // so it's safe to omit it from dependencies
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -58,26 +60,22 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
     }
   }
 
-  const onTagsChange = useCallback(
-    (newValues: string[]) => {
-      const addedAllTiers =
-        !!allTiersValue && newValues.includes(allTiersValue) && !allTiersSelected;
-      const stripped = allTiersValue ? newValues.filter(v => v !== allTiersValue) : newValues;
+  function onTagsChange(newValues: string[]) {
+    const addedAllTiers = !!allTiersValue && newValues.includes(allTiersValue) && !allTiersSelected;
+    const stripped = allTiersValue ? newValues.filter(v => v !== allTiersValue) : newValues;
 
-      if (newValues.length === 0) {
-        updateSettings({ accessRules: allTiersValue ? [allTiersValue] : [] });
-        return;
-      }
+    if (newValues.length === 0) {
+      updateSettings({ accessRules: allTiersValue ? [allTiersValue] : [] });
+      return;
+    }
 
-      if (addedAllTiers) {
-        updateSettings({ accessRules: [allTiersValue!] });
-        return;
-      }
+    if (addedAllTiers) {
+      updateSettings({ accessRules: [allTiersValue!] });
+      return;
+    }
 
-      updateSettings({ accessRules: stripped });
-    },
-    [allTiersValue, allTiersSelected, updateSettings],
-  );
+    updateSettings({ accessRules: stripped });
+  }
 
   const tagsValue = useMemo(() => {
     return allTiersSelected && allTiersValue ? [allTiersValue] : patreonSettings.accessRules;

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { CommonPlatformFields } from '../CommonPlatformFields';
 import Form from '../../../shared/inputs/Form';
-import { createBinding, InputComponent, TagsInput } from '../../../shared/inputs';
+import { createBinding, InputComponent, RadioInput, TagsInput } from '../../../shared/inputs';
 import PlatformSettingsLayout, { IPlatformComponentParams } from './PlatformSettingsLayout';
 import { IPatreonStartStreamOptions } from '../../../../services/platforms/patreon';
 import { $t } from 'services/i18n/i18n';
 import { Services } from 'components-react/service-provider';
+import styles from './PatreonEditStreamInfo.m.less';
 
-/***
- * Stream Settings for Patreon
- */
+type TPatreonAudienceType = 'all' | 'paid';
+
 export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams<'patreon'>) => {
   const { PatreonService } = Services;
 
@@ -21,6 +21,46 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
   const bind = createBinding(patreonSettings, newPatreonSettings =>
     updateSettings(newPatreonSettings),
   );
+
+  const [audienceType, setAudienceType] = useState<TPatreonAudienceType>('all');
+
+  const paidOptions = useMemo(
+    () => PatreonService.accessRules.filter(rule => rule.label.toLowerCase() !== 'free'),
+    [],
+  );
+
+  const audienceOptions = useMemo(
+    () => [
+      { value: 'all', label: $t('All Members') },
+      {
+        value: 'paid',
+        label: $t('Paid'),
+        children: (
+          <TagsInput
+            placeholder={$t('Select Tier')}
+            {...bind.accessRules}
+            value={audienceType === 'all' ? undefined : patreonSettings.accessRules}
+            options={paidOptions}
+            layout="horizontal"
+            disabled={audienceType === 'all'}
+            style={{ width: '100%', flex: 1 }}
+            maxTagCount="responsive"
+            nomargin
+            nolabel
+          />
+        ),
+      },
+    ],
+    [audienceType, paidOptions],
+  );
+
+  const updateAudienceType = useCallback((value: TPatreonAudienceType) => {
+    setAudienceType(value);
+    if (value === 'all') {
+      const rules = PatreonService.accessRules.map(rule => rule.value);
+      updateSettings({ accessRules: rules });
+    }
+  }, []);
 
   return (
     <Form name="patreon-settings">
@@ -37,12 +77,15 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
           />
         }
         requiredFields={
-          <TagsInput
+          <RadioInput
+            name="patreon-audience"
             label={$t('Audience')}
-            placeholder={$t('Select Tier')}
-            {...bind.accessRules}
-            options={PatreonService.accessRules}
-            layout={p.layout}
+            options={audienceOptions}
+            value={audienceType}
+            onChange={value => updateAudienceType(value as TPatreonAudienceType)}
+            layout="inline"
+            direction="horizontal"
+            className={styles.patreonTags}
             required
           />
         }

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useMemo, useState, useCallback } from 'react';
 import { CommonPlatformFields } from '../CommonPlatformFields';
 import Form from '../../../shared/inputs/Form';
 import { createBinding, InputComponent, RadioInput, TagsInput } from '../../../shared/inputs';
@@ -13,54 +13,104 @@ type TPatreonAudienceType = 'all' | 'paid';
 export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams<'patreon'>) => {
   const { PatreonService } = Services;
 
+  const patreonSettings = p.value;
+
   function updateSettings(patch: Partial<IPatreonStartStreamOptions>) {
     p.onChange({ ...patreonSettings, ...patch });
   }
 
-  const patreonSettings = p.value;
   const bind = createBinding(patreonSettings, newPatreonSettings =>
     updateSettings(newPatreonSettings),
   );
 
-  const [audienceType, setAudienceType] = useState<TPatreonAudienceType>('all');
+  // Memoize tier options and related values to avoid unnecessary calculations on each render
+  const { allTiersRule, tierOptions, allRuleValues, allTiersValue } = useMemo(() => {
+    const rules = PatreonService.accessRules;
+    const paidRule = rules.find(rule => rule.label.toLowerCase() === 'paid');
+    return {
+      allTiersRule: paidRule,
+      tierOptions: rules.filter(
+        rule => rule.label.toLowerCase() !== 'free' && rule.value !== paidRule?.value,
+      ),
+      allRuleValues: rules.map(rule => rule.value),
+      allTiersValue: paidRule?.value,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  const paidOptions = useMemo(
-    () => PatreonService.accessRules.filter(rule => rule.label.toLowerCase() !== 'free'),
-    [],
+  const [audienceType, setAudienceType] = useState<TPatreonAudienceType>(() => {
+    const ruleCount = patreonSettings.accessRules.length;
+    return ruleCount === 0 || ruleCount === allRuleValues.length ? 'all' : 'paid';
+  });
+
+  const allTiersSelected = useMemo(() => {
+    const saved = patreonSettings.accessRules;
+    if (allTiersValue && saved.length === 1 && saved[0] === allTiersValue) return true;
+    return saved.length === 0;
+  }, [patreonSettings.accessRules, allTiersValue]);
+
+  function updateAudienceType(value: TPatreonAudienceType) {
+    setAudienceType(value);
+    if (value === 'all') {
+      updateSettings({ accessRules: allRuleValues });
+    } else {
+      updateSettings({ accessRules: allTiersValue ? [allTiersValue] : [] });
+    }
+  }
+
+  const onTagsChange = useCallback(
+    (newValues: string[]) => {
+      const addedAllTiers =
+        !!allTiersValue && newValues.includes(allTiersValue) && !allTiersSelected;
+      const stripped = allTiersValue ? newValues.filter(v => v !== allTiersValue) : newValues;
+
+      if (newValues.length === 0) {
+        updateSettings({ accessRules: allTiersValue ? [allTiersValue] : [] });
+        return;
+      }
+
+      if (addedAllTiers) {
+        updateSettings({ accessRules: [allTiersValue!] });
+        return;
+      }
+
+      updateSettings({ accessRules: stripped });
+    },
+    [allTiersValue, allTiersSelected, updateSettings],
   );
 
-  const audienceOptions = useMemo(
-    () => [
-      { value: 'all', label: $t('All Members') },
-      {
-        value: 'paid',
-        label: $t('Paid'),
-        children: (
+  const tagsValue = useMemo(() => {
+    return allTiersSelected && allTiersValue ? [allTiersValue] : patreonSettings.accessRules;
+  }, [patreonSettings.accessRules, allTiersSelected, allTiersValue]);
+
+  const tagsOptions = useMemo(() => {
+    return allTiersRule
+      ? [{ ...allTiersRule, label: $t('All Tiers') }, ...tierOptions]
+      : tierOptions;
+  }, [allTiersRule, tierOptions]);
+
+  const audienceOptions = [
+    { value: 'all', label: $t('All Members') },
+    {
+      value: 'paid',
+      label: $t('Paid'),
+      children:
+        audienceType === 'paid' ? (
           <TagsInput
             placeholder={$t('Select Tier')}
             {...bind.accessRules}
-            value={audienceType === 'all' ? undefined : patreonSettings.accessRules}
-            options={paidOptions}
+            value={tagsValue}
+            onChange={onTagsChange}
+            options={tagsOptions}
             layout="horizontal"
-            disabled={audienceType === 'all'}
             style={{ width: '100%', flex: 1 }}
             maxTagCount="responsive"
             nomargin
             nolabel
           />
-        ),
-      },
-    ],
-    [audienceType, paidOptions],
-  );
-
-  const updateAudienceType = useCallback((value: TPatreonAudienceType) => {
-    setAudienceType(value);
-    if (value === 'all') {
-      const rules = PatreonService.accessRules.map(rule => rule.value);
-      updateSettings({ accessRules: rules });
-    }
-  }, []);
+        ) : null,
+    },
+  ];
 
   return (
     <Form name="patreon-settings">

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -48,35 +48,10 @@ class GoLiveSettingsState extends StreamInfoView<IGoLiveSettingsState> {
    * Update settings for a specific platform
    */
   updatePlatform(platform: TPlatform, patch: Partial<IGoLiveSettings['platforms'][TPlatform]>) {
-    const currentSettings = this.state.platforms[platform] as
-      | { title?: string; description?: string }
-      | undefined;
-
-    // Platform forms commonly send `{...settings, ...patch}` to onChange, which can
-    // carry empty title/description. Drop those fields from the patch to avoid accidentally
-    // clearing saved title/description when user is just trying to update other settings.
-    const validatedPatch = { ...patch } as Partial<IGoLiveSettings['platforms'][TPlatform]> & {
-      title?: string;
-      description?: string;
-    };
-
-    if (currentSettings) {
-      if ('title' in validatedPatch && !validatedPatch.title && currentSettings.title) {
-        delete validatedPatch.title;
-      }
-
-      if (
-        'description' in validatedPatch &&
-        !validatedPatch.description &&
-        currentSettings.description
-      ) {
-        delete validatedPatch.description;
-      }
-    }
     const updated = {
       platforms: {
         ...this.state.platforms,
-        [platform]: { ...this.state.platforms[platform], ...validatedPatch },
+        [platform]: { ...this.state.platforms[platform], ...patch },
       },
     };
 

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -48,10 +48,35 @@ class GoLiveSettingsState extends StreamInfoView<IGoLiveSettingsState> {
    * Update settings for a specific platform
    */
   updatePlatform(platform: TPlatform, patch: Partial<IGoLiveSettings['platforms'][TPlatform]>) {
+    const currentSettings = this.state.platforms[platform] as
+      | { title?: string; description?: string }
+      | undefined;
+
+    // Platform forms commonly send `{...settings, ...patch}` to onChange, which can
+    // carry empty title/description. Drop those fields from the patch to avoid accidentally
+    // clearing saved title/description when user is just trying to update other settings.
+    const validatedPatch = { ...patch } as Partial<IGoLiveSettings['platforms'][TPlatform]> & {
+      title?: string;
+      description?: string;
+    };
+
+    if (currentSettings) {
+      if ('title' in validatedPatch && !validatedPatch.title && currentSettings.title) {
+        delete validatedPatch.title;
+      }
+
+      if (
+        'description' in validatedPatch &&
+        !validatedPatch.description &&
+        currentSettings.description
+      ) {
+        delete validatedPatch.description;
+      }
+    }
     const updated = {
       platforms: {
         ...this.state.platforms,
-        [platform]: { ...this.state.platforms[platform], ...patch },
+        [platform]: { ...this.state.platforms[platform], ...validatedPatch },
       },
     };
 

--- a/app/i18n/en-US/patreon.json
+++ b/app/i18n/en-US/patreon.json
@@ -4,5 +4,6 @@
   "Select Tier": "Select Tier",
   "Stream Shift cannot be used with Patreon": "Stream Shift cannot be used with Patreon",
   "All Members": "All Members",
-  "Paid": "Paid"
+  "Paid": "Paid",
+  "All Tiers": "All Tiers"
 }

--- a/app/i18n/en-US/patreon.json
+++ b/app/i18n/en-US/patreon.json
@@ -2,5 +2,7 @@
   "Campaign ID": "Campaign ID",
   "Audience": "Audience",
   "Select Tier": "Select Tier",
-  "Stream Shift cannot be used with Patreon": "Stream Shift cannot be used with Patreon"
+  "Stream Shift cannot be used with Patreon": "Stream Shift cannot be used with Patreon",
+  "All Members": "All Members",
+  "Paid": "Paid"
 }


### PR DESCRIPTION
# Platform onboarding, access-rule tags, and Go Live form fixes

# Issues
- New platform was missing from the onboarding flow, so users couldn't connect it during initial setup.
- The Go Live window had no UI for selecting the platform's audience access rules / tiers when starting a stream.
- Editing a field in one platform's Go Live form cleared unrelated fields on other platforms when the shared form state updated.
- The title and description fields on `CommonPlatformFields` were being cleared whenever the form re-synced after a platform settings update.
- The platform access-rules selector wasn't filtering correctly: "All Tiers" and individual tiers could end up in inconsistent states (free tier showing, "All Tiers" not deselecting when a specific tier was picked, empty selection not restoring the default).

# Changes

**Onboarding (`04cb9b5e`)**
- Added the platform to the onboarding `Connect` step and `PrimaryPlatformSelect` list so it can be linked alongside the other platforms.

**Access-rule tags input (`d8b705b7`)**
- Added an Audience radio control (`All Members` / `Paid`) to the platform's Go Live edit panel.
- Added a `TagsInput`-backed tier picker shown when `Paid` is selected, with new `patreon.json` strings.
- Extended `RadioInput` and `TagsInput` shared components to support the layout, child-rendering, and label behaviors the new panel needs; small `DisplaySelector` adjustment for consistency.
- Added a `PatreonEditStreamInfo.m.less` module for the panel-specific styling.

**Go Live form — unrelated-field clearing (`34f2853b`)**
- Hardened `useGoLiveSettings` so a `setPlatformSettings` update merges into the existing platform state instead of replacing the whole settings object, which was wiping fields owned by other platforms.

**Go Live form — title/description clearing (`a426e355`)**
- Reverted the over-eager re-sync in `useGoLiveSettings` that was overwriting in-progress edits, and updated `CommonPlatformFields` so title/description stay bound to the active form state instead of being reset on every platform update.

**Platform rules filtering (`83e91c47`)**
- Reworked the `Paid` tier picker so the audience state is fully derived from `accessRules`:
  - Selecting `Paid` preselects the API's "all tiers" rule as a single tag.
  - Picking a specific tier removes the "All Tiers" tag.
  - Clearing all tiers restores "All Tiers" automatically.
  - Picking `All Members` hides the tier picker entirely instead of disabling it.
- Filters the `free` rule out of the dropdown, and relabels the API's "paid" rule as `All Tiers` for display only — the stored value remains the real API key so what's sent to the backend is unchanged.