### PR TITLE
AI highlighter toggle fix and update games.

### DIFF
--- a/app/components-react/highlighter/supportedGames/SupportedGames.tsx
+++ b/app/components-react/highlighter/supportedGames/SupportedGames.tsx
@@ -3,6 +3,7 @@ import styles from './SupportedGames.m.less';
 import { supportedGames } from 'services/highlighter/models/game-config.models';
 import { Tooltip } from 'antd';
 import { EGame } from 'services/highlighter/models/ai-highlighter.models';
+import Scrollable from 'components-react/shared/Scrollable';
 
 export default function SupportedGames({
   gamesVisible,
@@ -45,42 +46,44 @@ export default function SupportedGames({
       {games.length > gamesVisible && (
         <Tooltip
           overlay={
-            <div
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'flex-start', // Align items to the left
-                justifyContent: 'flex-start', // Align content to the top
-                padding: '16px',
-                marginTop: '8px',
-              }}
-            >
-              <h1 style={{ marginBottom: '8px' }}>Supported games</h1>
-              {gamesSortedAlphabetical.map((game, index) => (
-                <div
-                  onClick={e => emitClick && emitClick(game.value)}
-                  key={game.value + index}
-                  style={{
-                    cursor: 'pointer',
-                    display: 'flex',
-                    marginBottom: 8,
-                    width: '100%',
-                    alignItems: 'center', // Ensure items inside each row are aligned properly
-                    justifyContent: 'flex-start', // Align items to the left
-                  }}
-                >
-                  <img
-                    width={'40px'}
-                    height={'40px'}
-                    className={styles.thumbnail}
-                    style={{ marginRight: 0 }}
-                    src={game.image}
-                    alt={game.label}
-                  />
-                  <p style={{ marginBottom: 0, marginLeft: 4 }}>{game.label}</p>
-                </div>
-              ))}
-            </div>
+            <Scrollable style={{ maxHeight: '80vh' }}>
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'flex-start', // Align items to the left
+                  justifyContent: 'flex-start', // Align content to the top
+                  padding: '16px',
+                  marginTop: '8px',
+                }}
+              >
+                <h1 style={{ marginBottom: '8px' }}>Supported games</h1>
+                {gamesSortedAlphabetical.map((game, index) => (
+                  <div
+                    onClick={e => emitClick && emitClick(game.value)}
+                    key={game.value + index}
+                    style={{
+                      cursor: 'pointer',
+                      display: 'flex',
+                      marginBottom: 8,
+                      width: '100%',
+                      alignItems: 'center', // Ensure items inside each row are aligned properly
+                      justifyContent: 'flex-start', // Align items to the left
+                    }}
+                  >
+                    <img
+                      width={'40px'}
+                      height={'40px'}
+                      className={styles.thumbnail}
+                      style={{ marginRight: 0 }}
+                      src={game.image}
+                      alt={game.label}
+                    />
+                    <p style={{ marginBottom: 0, marginLeft: 4 }}>{game.label}</p>
+                  </div>
+                ))}
+              </div>
+            </Scrollable>
           }
         >
           <div

--- a/app/components-react/windows/go-live/GameSelector.tsx
+++ b/app/components-react/windows/go-live/GameSelector.tsx
@@ -11,7 +11,10 @@ import { IListOption } from '../../shared/inputs/ListInput';
 import { Services } from '../../service-provider';
 import { injectState, useModule } from 'slap';
 
-type TProps = TSlobsInputProps<{ platform: TPlatform; layout?: TInputLayout }, string>;
+type TProps = TSlobsInputProps<
+  { platform: TPlatform; layout?: TInputLayout; onNameChange?: (name: string) => void },
+  string
+>;
 
 export default function GameSelector(p: TProps) {
   const { platform } = p;
@@ -140,6 +143,10 @@ export default function GameSelector(p: TProps) {
       onSearch={onSearch}
       onSelect={(val, opts) => {
         onSelect(opts.labelrender);
+
+        if (p.onNameChange && typeof opts.label === 'string') {
+          p.onNameChange(opts.label);
+        }
       }}
       filterOption={filterOption}
       debounce={500}

--- a/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
@@ -82,9 +82,15 @@ function TwitchRequiredFields(p: IPlatformComponentParams<'twitch'>) {
 
   return (
     <>
-      <GameSelector key="twitch-game" platform={'twitch'} {...bind.game} layout={p.layout} />
+      <GameSelector
+        key="twitch-game"
+        platform={'twitch'}
+        {...bind.game}
+        onNameChange={bind.gameName.onChange}
+        layout={p.layout}
+      />
       {p.isAiHighlighterEnabled && (
-        <AiHighlighterToggle key="ai-toggle" game={bind.gameName?.value} cardIsExpanded={false} />
+        <AiHighlighterToggle key="ai-toggle" game={bind.gameName.value} cardIsExpanded={false} />
       )}
       {isEnhancedBroadcastingVisible && !isUpdateMode && (
         <InputWrapper

--- a/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/TwitchEditStreamInfo.tsx
@@ -84,7 +84,7 @@ function TwitchRequiredFields(p: IPlatformComponentParams<'twitch'>) {
     <>
       <GameSelector key="twitch-game" platform={'twitch'} {...bind.game} layout={p.layout} />
       {p.isAiHighlighterEnabled && (
-        <AiHighlighterToggle key="ai-toggle" game={bind.game?.value} cardIsExpanded={false} />
+        <AiHighlighterToggle key="ai-toggle" game={bind.gameName?.value} cardIsExpanded={false} />
       )}
       {isEnhancedBroadcastingVisible && !isUpdateMode && (
         <InputWrapper

--- a/app/services/highlighter/models/ai-highlighter.models.ts
+++ b/app/services/highlighter/models/ai-highlighter.models.ts
@@ -71,6 +71,9 @@ export enum EGame {
   EA_SPORTS_FC_26 = 'ea_sports_fc_26',
   NBA_2K26 = 'nba_2k26',
   DEADLOCK = 'deadlock',
+  FORZA_HORIZON_6 = 'forza_horizon_6',
+  ENSHROUDED = 'enshrouded',
+  MINECRAFT = 'minecraft',
   UNSET = 'unset',
 }
 

--- a/app/services/highlighter/models/game-config.models.ts
+++ b/app/services/highlighter/models/game-config.models.ts
@@ -28,6 +28,15 @@ export const TERMS = {
   ROUND: { singular: 'round', plural: 'rounds' },
   STORM: { singular: 'storm event', plural: 'storm events' },
   MANUAL: { singular: 'manual clip', plural: 'manual clips' },
+  GREAT_AIR: { singular: 'great air', plural: 'great airs' },
+  GREAT_DRIFT: { singular: 'great drift', plural: 'great drifts' },
+  GREAT_SKILL_CHAIN: { singular: 'great skill chain', plural: 'great skill chains' },
+  LEVEL_UP: { singular: 'level up', plural: 'level ups' },
+  QUEST_UPDATE: { singular: 'quest update', plural: 'quest updates' },
+  SOUL_DISCOVERED: { singular: 'soul discovered', plural: 'souls discovered' },
+  TOTEM_OF_UNDYING_USED: { singular: 'totem of undying', plural: 'totems of undying' },
+  LOW_HEALTH: { singular: 'low health', plural: 'low health moments' },
+  BOSS_KILLED: { singular: 'boss killed', plural: 'bosses killed' },
 };
 
 export const EMOJI = {
@@ -49,6 +58,15 @@ export const EMOJI = {
   STORM: '⛈️',
   ROBOT: '🤖',
   MANUAL: '🎬',
+  AIRPLANE: '🛫',
+  DRIFT: '💨',
+  CHAIN: '🔗',
+  LEVEL_UP: '⬆️',
+  SCROLL: '📜',
+  GHOST: '👻',
+  SPARKLES: '✨',
+  BROKEN_HEART: '💔',
+  CROWN: '👑',
   FIRECRACKER: '🧨', // used for config fallback. ⚡ used in components as fallback
 };
 
@@ -594,6 +612,120 @@ const DEADLOCK: IGameConfig = {
   },
 };
 
+const FORZA_HORIZON_6: IGameConfig = {
+  name: EGame.FORZA_HORIZON_6,
+  label: 'Forza Horizon 6',
+  gameModes: '',
+  titleIcon: 'unset',
+  thumbnail: `${thumbnailPath}${EGame.FORZA_HORIZON_6}.png`,
+  state: EGameState.LIVE,
+  inputTypeMap: {
+    ...COMMON_TYPES,
+    ['great_air']: {
+      emoji: EMOJI.AIRPLANE,
+      description: TERMS.GREAT_AIR,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['great_drift']: {
+      emoji: EMOJI.DRIFT,
+      description: TERMS.GREAT_DRIFT,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['great_skill_chain']: {
+      emoji: EMOJI.CHAIN,
+      description: TERMS.GREAT_SKILL_CHAIN,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+  },
+  importModalConfig: {
+    accentColor: '#7B2CBF',
+    artwork: `${heroPath}${EGame.FORZA_HORIZON_6}.png`,
+    backgroundColor: '#151616',
+  },
+};
+
+const ENSHROUDED: IGameConfig = {
+  name: EGame.ENSHROUDED,
+  label: 'Enshrouded',
+  gameModes: '',
+  titleIcon: 'unset',
+  thumbnail: `${thumbnailPath}${EGame.ENSHROUDED}.png`,
+  state: EGameState.LIVE,
+  inputTypeMap: {
+    ...COMMON_TYPES,
+    ['level_up']: {
+      emoji: EMOJI.LEVEL_UP,
+      description: TERMS.LEVEL_UP,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['quest_update']: {
+      emoji: EMOJI.SCROLL,
+      description: TERMS.QUEST_UPDATE,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['soul_discovered']: {
+      emoji: EMOJI.GHOST,
+      description: TERMS.SOUL_DISCOVERED,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+  },
+  importModalConfig: {
+    accentColor: '#A55A2A',
+    artwork: `${heroPath}${EGame.ENSHROUDED}.png`,
+    backgroundColor: '#1A1410',
+  },
+};
+
+const MINECRAFT: IGameConfig = {
+  name: EGame.MINECRAFT,
+  label: 'Minecraft',
+  gameModes: '',
+  titleIcon: 'unset',
+  thumbnail: `${thumbnailPath}${EGame.MINECRAFT}.png`,
+  state: EGameState.LIVE,
+  inputTypeMap: {
+    ...COMMON_TYPES,
+    ['totem_of_undying_used']: {
+      emoji: EMOJI.SPARKLES,
+      description: TERMS.TOTEM_OF_UNDYING_USED,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['low_health']: {
+      emoji: EMOJI.BROKEN_HEART,
+      description: TERMS.LOW_HEALTH,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+    ['boss_killed']: {
+      emoji: EMOJI.CROWN,
+      description: TERMS.BOSS_KILLED,
+      orderPriority: 4,
+      includeInDropdown: true,
+      contextEvent: false,
+    },
+  },
+  importModalConfig: {
+    accentColor: '#5BA84A',
+    artwork: `${heroPath}${EGame.MINECRAFT}.png`,
+    backgroundColor: '#1D1A17',
+  },
+};
+
 const UNSET_CONFIG: IGameConfig = {
   name: EGame.UNSET,
   label: 'unset',
@@ -632,6 +764,9 @@ const GAME_CONFIGS: Record<EGame, IGameConfig> = {
   [EGame.EA_SPORTS_FC_26]: EA_SPORTS_FC_26,
   [EGame.NBA_2K26]: NBA_2K26,
   [EGame.DEADLOCK]: DEADLOCK,
+  [EGame.FORZA_HORIZON_6]: FORZA_HORIZON_6,
+  [EGame.ENSHROUDED]: ENSHROUDED,
+  [EGame.MINECRAFT]: MINECRAFT,
   [EGame.UNSET]: UNSET_CONFIG,
 };
 

--- a/test/regular/performance-metrics.ts
+++ b/test/regular/performance-metrics.ts
@@ -1,6 +1,8 @@
 import { useWebdriver, test } from '../helpers/webdriver';
 import { click, focusChild, select, waitForDisplayed } from '../helpers/modules/core';
 
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
 
 test('Performance metrics', async t => {
@@ -8,6 +10,13 @@ test('Performance metrics', async t => {
   await focusChild();
   await waitForDisplayed('h2=Live Stats');
   const $cpu = await select('[role=metric-cpu]');
+
+  // By default, the CPU usage is set to 0 to prevent NaN values on app start
+  // Wait until the CPU usage is updated to a value greater than 0
+  await $cpu.waitUntil(async () => parseFloat(await $cpu.getText()) > 0, {
+    timeout: 10000,
+    timeoutMsg: 'CPU usage should be greater than 0',
+  });
   const cpuUsage = parseFloat(await $cpu.getText());
   t.true(cpuUsage > 0, 'CPU usage should be greater than 0');
 });


### PR DESCRIPTION
# AI Highlighter Toggle Fix, Game Selector Name Sync, and Supported Games Updates

## Issues

**AI Highlighter Toggle not responding to game selection:**
`AiHighlighterToggle` was receiving `bind.game?.value`, which holds the game's internal ID/slug, instead of `bind.gameName?.value`, which holds the human-readable game name. Because the toggle uses the game name to look up AI highlighter support, it was never activating correctly when a game was selected.

**AI Highlighter Toggle not updating when game name changes:**
Even after fixing the prop passed to `AiHighlighterToggle`, the `gameName` state was never updated when the user selected a game in `GameSelector`. `GameSelector` only called `onSelect` with the internal value; the display name was silently discarded. As a result, `bind.gameName.value` remained stale (empty/undefined) and the toggle always received no game name.

**Supported games tooltip overflows on small screens:**
The "supported games" tooltip in `SupportedGames` had no maximum height or scroll, so when many games were listed the tooltip could overflow the viewport with no way to scroll.

**Flaky performance metrics test:**
The test read CPU usage immediately after opening the stats window. On app start, CPU usage is initialized to `0` to avoid `NaN`, so the assertion `cpuUsage > 0` could fail before the first real value arrived.

## Fixes

- **`TwitchEditStreamInfo.tsx`** — Changed `AiHighlighterToggle`'s `game` prop from `bind.game?.value` to `bind.gameName?.value` so the toggle receives the display name instead of the internal game ID.
- **`GameSelector.tsx`** — Added an optional `onNameChange` callback to `TProps`. When the user picks a game, the callback fires with `opts.label` (the display name), allowing consumers to keep a separate name binding in sync.
- **`TwitchEditStreamInfo.tsx`** — Wired `onNameChange={bind.gameName.onChange}` into `GameSelector` so `gameName` state is updated on every game selection.
- **`SupportedGames.tsx`** — Wrapped the tooltip content in `<Scrollable style={{ maxHeight: '80vh' }}>` so the game list scrolls instead of overflowing.
- **`game-config.models.ts` / `ai-highlighter.models.ts`** — Added 3 new supported games to the AI Highlighter game list.
- **`test/regular/performance-metrics.ts`** — Added a `waitUntil` poll before reading CPU usage so the test waits for a non-zero value (up to 10 s) rather than snapshotting the initial `0`.