### PR TITLE
Add websocket disconnect to shutdown.

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -48,6 +48,7 @@ import { StreamAvatarService } from 'services/stream-avatar/stream-avatar-servic
 import { NavigationService } from 'services/navigation';
 import { StreamingService } from 'services/streaming';
 import { VirtualWebcamService } from 'services/virtual-webcam';
+import { WebsocketService } from 'services/websocket';
 
 interface IAppState {
   loading: boolean;
@@ -104,6 +105,7 @@ export class AppService extends StatefulService<IAppState> {
   @Inject() private navigationService: NavigationService;
   @Inject() private streamingService: StreamingService;
   @Inject() private virtualWebcamService: VirtualWebcamService;
+  @Inject() private websocketService: WebsocketService;
 
   static initialState: IAppState = {
     loading: true,
@@ -213,6 +215,8 @@ export class AppService extends StatefulService<IAppState> {
       this.streamAvatarService.stopAvatarProcess();
       this.crashReporterService.beginShutdown();
       this.shutdownStarted.next();
+      this.recentEventsService.shutdown();
+      this.websocketService.disconnect();
       this.keyListenerService.shutdown();
       this.platformAppsService.unloadAllApps();
       await this.usageStatisticsService.flushEvents();

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -472,6 +472,10 @@ export class RecentEventsService extends StatefulService<IRecentEventsState> {
     this.unsubscribeFromSocketConnection();
   }
 
+  shutdown() {
+    this.unsubscribeFromSocketConnection();
+  }
+
   fetchRecentEvents() {
     const typeString = this.getEventTypesString();
     // eslint-disable-next-line

--- a/app/services/websocket.ts
+++ b/app/services/websocket.ts
@@ -244,6 +244,13 @@ export class WebsocketService extends Service {
       });
   }
 
+  disconnect() {
+    if (this.socket) {
+      this.socket.disconnect();
+      this.socket = undefined;
+    }
+  }
+
   private log(message: string, ...args: any[]) {
     console.debug(`WS: ${message}`, ...args);
 


### PR DESCRIPTION
# Websocket and Recent Events Cleanup on Shutdown

## Issues

Two resources were left open when the app closed:

**WebsocketService** held a persistent socket.io-client connection to the Streamlabs backend with no shutdown path. The only place `socket.disconnect()` was called was inside `openSocketConnection()` itself, wchich was to drop any existing connection before opening a new one. On app close, no disconnect was ever sent. The OS would eventually close the TCP connection via RST, but the server had no way to know the client was gone until its `pingTimeout` expired (typically ~5–30 seconds depending on server config), leaving the session object, room memberships, and event retry state alive on the server side for that window.

**RecentEventsService** subscribed to `websocketService.socketEvent` via an RxJS `Subscription` stored as `this.socketConnection`. The only place this was unsubscribed was `onLogout()`, called by the `withLifecycle` destroy callback when `userLogout` emits. During shutdown, `AppService` calls `userService.flushUserSession()` — not `logOut()` — so `userLogout` never fires and `onLogout()` is never reached. For any user who closes the app while logged in (the common case), the subscription was never cleaned up.

## Fixes

- Sends a proper socket.io disconnect packet before closing, allowing the server to tear down the session immediately rather than waiting for ping timeout.
- Unsubscribe from the `socketEvent` RxJS subscription on shutdown, covering the case that `onLogout()` does not.

The order matters: `recentEventsService.shutdown()` removes the observer before the source is closed. Any server-pushed events still in the socket.io buffer when `disconnect()` is called arrive before the TCP connection fully closes. Unsubscribing first ensures those events are not dispatched into `onSocketEvent()` against partially torn-down service state. The pattern is: remove observers, then close the source.

**Files changed:** `app/services/websocket.ts`, `app/services/recent-events.ts`, `app/services/app/app.ts`

## Performance Implications

Without the fix, the socket.io server retains each session for up to `pingInterval + pingTimeout` after the client process exits — typically 25–30 seconds on default socket.io configuration. During that window the server holds the session object, room memberships, and may retry any in-flight acknowledged events. With the fix, the session is released immediately on receipt of the disconnect packet.

The RxJS subscription itself has no meaningful post-exit footprint since V8 GC collects it when the renderer process terminates. The fix matters for correctness during the shutdown window — preventing `onSocketEvent` from being invoked with stale service state while the disconnect handshake completes.

| Metric | Before | After |
|---|---|---|
| Server session retention after app close | Up to ~30s (ping timeout) | Immediate on disconnect packet receipt |
| Server `disconnect` event latency | Up to ~30s | < 1 RTT |
| TCP port release | OS RST on process exit (~120s TIME_WAIT) | Graceful FIN after WS close frame |
| `onSocketEvent` calls during disconnect | Possible — subscription live during handshake | Eliminated — unsubscribed before disconnect |
| In-flight event retry risk on server | Present during timeout window | Eliminated |
