### PR TITLE
Move virtual camera shutdown to subscription in service.

### DIFF
--- a/app/services/app/app.ts
+++ b/app/services/app/app.ts
@@ -47,7 +47,6 @@ import { RealmService } from 'services/realm';
 import { StreamAvatarService } from 'services/stream-avatar/stream-avatar-service';
 import { NavigationService } from 'services/navigation';
 import { StreamingService } from 'services/streaming';
-import { VirtualWebcamService } from 'services/virtual-webcam';
 
 interface IAppState {
   loading: boolean;
@@ -103,7 +102,6 @@ export class AppService extends StatefulService<IAppState> {
   @Inject() private streamAvatarService: StreamAvatarService;
   @Inject() private navigationService: NavigationService;
   @Inject() private streamingService: StreamingService;
-  @Inject() private virtualWebcamService: VirtualWebcamService;
 
   static initialState: IAppState = {
     loading: true,
@@ -223,7 +221,6 @@ export class AppService extends StatefulService<IAppState> {
       await this.sceneCollectionsService.deinitialize();
       this.performanceService.stop();
       this.transitionsService.shutdown();
-      this.virtualWebcamService.stop();
       this.videoSettingsService.shutdown();
       await this.gameOverlayService.destroy();
       await this.fileManagerService.flushAll();

--- a/app/services/virtual-webcam.ts
+++ b/app/services/virtual-webcam.ts
@@ -5,7 +5,7 @@ import { getChecksum } from 'util/requests';
 import { byOS, OS } from 'util/operating-systems';
 import { Inject } from 'services/core/injector';
 import { SettingsService } from 'services/settings';
-import { UsageStatisticsService, SourcesService } from 'app-services';
+import { UsageStatisticsService, SourcesService, AppService } from 'app-services';
 import * as remote from '@electron/remote';
 import { Subject } from 'rxjs';
 import { VCamOutputType } from 'obs-studio-node';
@@ -58,6 +58,7 @@ interface IVirtualWebcamServiceState {
 }
 
 export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceState> {
+  @Inject() appService: AppService;
   @Inject() usageStatisticsService: UsageStatisticsService;
   @Inject() sourcesService: SourcesService;
   @Inject() settingsService: SettingsService;
@@ -75,6 +76,8 @@ export class VirtualWebcamService extends StatefulService<IVirtualWebcamServiceS
   signalInfoChanged = new Subject<IOBSOutputSignalInfo>();
 
   protected init(): void {
+    this.appService.shutdownStarted.subscribe(() => this.stop());
+
     byOS({
       [OS.Windows]: () => {
         this.setInstallStatus();


### PR DESCRIPTION
# Avoid unnecessary VirtualWebcamService initialization during app shutdown

## Issues

`shutdownHandler()` in `AppService` explicitly called `stop()` on `VirtualWebcamService`. Because services load lazily, this caused the service to be instantiated at shutdown time, even when the user never used the virtual camera during the session, triggering unnecessary OBS calls (Windows (`OBS_service_isVirtualCamPluginInstalled`) and Mac (`OBS_service_createVirtualCam`)) on every app close.

## Fixes

`VirtualWebcamService.init()` now subscribes to `AppService.shutdownStarted`, a `Subject` that fires early in the shutdown sequence before OBS is torn down. Since `Subject.next()` and `stop()` are both synchronous, the virtual cam is stopped inline before shutdown continues. The subscription only exists if the service was actually instantiated during the session, so users who never use virtual camera incur no cost. `AppService` no longer imports or references `VirtualWebcamService`.

**File(s) changed:**
- `desktop/app/services/app/app.ts`
- `desktop/app/services/virtual-webcam.ts`

## Performance Implications

| Scenario | Before | After |
|---|---|---|
| Virtual cam never used | `VirtualWebcamService` instantiated + `init()` run + OBS API called at shutdown | Skipped entirely |
| Virtual cam was used | `stop()` called from `shutdownHandler` | `stop()` called via `shutdownStarted` subscription |