### PR TITLE
Fix go live custom title.

### DIFF
--- a/app/components-react/shared/inputs/RadioInput.m.less
+++ b/app/components-react/shared/inputs/RadioInput.m.less
@@ -60,3 +60,9 @@
     padding: 0px 1px;
   }
 }
+
+.default-radio {
+  :global(.ant-form-item-label > label::after) {
+    margin: 0px !important;
+  }
+}

--- a/app/components-react/shared/inputs/RadioInput.tsx
+++ b/app/components-react/shared/inputs/RadioInput.tsx
@@ -42,7 +42,11 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
   };
 
   return (
-    <InputWrapper {...wrapperAttrs} data-title={p.label}>
+    <InputWrapper
+      {...wrapperAttrs}
+      data-title={p.label}
+      className={cx({ [styles.defaultRadio]: !p.buttons && !p.icons })}
+    >
       {p.buttons && (
         <Radio.Group
           {...inputProps}
@@ -104,7 +108,7 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           <Space size={p?.gapsize ?? undefined} direction={p?.direction ?? 'vertical'}>
             {p.options.map(option => {
               return (
-                <React.Fragment key={option.value}>
+                <React.Fragment key={`${p.name}-${option.value}`}>
                   <Radio
                     value={option.value}
                     disabled={p.disabled}

--- a/app/components-react/windows/go-live/CommonPlatformFields.tsx
+++ b/app/components-react/windows/go-live/CommonPlatformFields.tsx
@@ -141,7 +141,6 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
               max={maxCharacters}
               layout={p.layout}
               size="large"
-              uncontrolled={false}
             />
 
             {/*DESCRIPTION*/}
@@ -153,15 +152,8 @@ export const CommonPlatformFields = InputComponent((rawProps: IProps) => {
                 label={$t('Description')}
                 required={descriptionIsRequired}
                 layout={p.layout}
-                uncontrolled={false}
               />
             )}
-
-            {/* {aiHighlighterFeatureEnabled &&
-              enabledPlatforms &&
-              !enabledPlatforms.includes('twitch') && (
-                <AiHighlighterToggle game={undefined} cardIsExpanded={false} />
-              )} */}
           </div>
         )}
       </Animate>

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
@@ -16,12 +16,15 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
   const patreonSettings = p.value;
 
   function updateSettings(patch: Partial<IPatreonStartStreamOptions>) {
-    p.onChange({ ...patreonSettings, ...patch });
+    if ('accessRules' in patch && !('title' in patch)) {
+      // Prevent clearing the title when only updating access rules
+      p.onChange(patch);
+    } else {
+      p.onChange({ ...patreonSettings, ...patch });
+    }
   }
 
-  const bind = createBinding(patreonSettings, newPatreonSettings =>
-    updateSettings(newPatreonSettings),
-  );
+  const bind = createBinding(patreonSettings, updatedSettings => updateSettings(updatedSettings));
 
   // Memoize tier options and related values to avoid unnecessary calculations on each render
   const { allTiersRule, tierOptions, allRuleValues, allTiersValue } = useMemo(() => {

--- a/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/PatreonEditStreamInfo.tsx
@@ -127,7 +127,7 @@ export const PatreonEditStreamInfo = InputComponent((p: IPlatformComponentParams
         requiredFields={
           <RadioInput
             name="patreon-audience"
-            label={$t('Audience')}
+            label={$t('Patreon Audience')}
             options={audienceOptions}
             value={audienceType}
             onChange={value => updateAudienceType(value as TPatreonAudienceType)}

--- a/app/i18n/en-US/patreon.json
+++ b/app/i18n/en-US/patreon.json
@@ -5,5 +5,6 @@
   "Stream Shift cannot be used with Patreon": "Stream Shift cannot be used with Patreon",
   "All Members": "All Members",
   "Paid": "Paid",
-  "All Tiers": "All Tiers"
+  "All Tiers": "All Tiers",
+  "Patreon Audience": "Patreon Audience"
 }

--- a/test/regular/streaming/multistream.ts
+++ b/test/regular/streaming/multistream.ts
@@ -186,27 +186,33 @@ test(
     await waitForSettingsWindowLoaded();
 
     const twitchForm = useForm('twitch-settings');
-    await twitchForm.fillForm({
+    const twitchSettings = {
       customEnabled: true,
       title: 'twitch title',
       twitchGame: 'Fortnite',
       // TODO: Re-enable after reauthing userpool
       // twitchTags: ['100%'],
-    });
+    };
+    await twitchForm.fillForm(twitchSettings);
+    await twitchForm.assertFormContains(twitchSettings);
 
     const youtubeForm = useForm('youtube-settings');
-    await youtubeForm.fillForm({
+    const youtubeSettings = {
       customEnabled: true,
       title: 'youtube title',
       description: 'youtube description',
-    });
+    };
+    await youtubeForm.fillForm(youtubeSettings);
+    await youtubeForm.assertFormContains(youtubeSettings);
 
     const trovoForm = useForm('trovo-settings');
-    await trovoForm.fillForm({
+    const trovoSettings = {
       customEnabled: true,
-      trovoGame: 'Doom',
       title: 'trovo title',
-    });
+      trovoGame: 'Doom',
+    };
+    await trovoForm.fillForm(trovoSettings);
+    await trovoForm.assertFormContains(trovoSettings);
 
     await goLiveWithMultistream();
     await stopStream();

--- a/test/regular/streaming/patreon.ts
+++ b/test/regular/streaming/patreon.ts
@@ -6,6 +6,7 @@ import {
 } from '../../helpers/modules/streaming';
 import { addDummyAccount, withUser } from '../../helpers/webdriver/user';
 import { isDisplayed } from '../../helpers/modules/core';
+import { useForm } from '../../helpers/modules/forms';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -19,6 +20,16 @@ test('Streaming to Patreon', withUser('twitch', { prime: true }), async t => {
   await waitForSettingsWindowLoaded();
   // Because Patreon is a dummy account, the form won't load so just check for the button to be displayed
   await isDisplayed('button[data-name="patreon"]', { timeout: 10000 });
+
+  // TODO: Enable after user pool relaunched
+  // Update access rules and verify that the form doesn't reset the title
+  // const patreonForm = useForm('patreon-settings');
+  // const patreonSettings = {
+  //   title: 'patreon title',
+  //   patreonAudience: 'paid',
+  // };
+  // await patreonForm.fillForm(patreonSettings);
+  // await patreonForm.assertFormContains(patreonSettings);
 
   t.pass();
 });


### PR DESCRIPTION
## Title
Fix go live custom title.

## Issue
On the Go Live window, the custom title for Patreon was being cleared whenever the user updated access rules (audience/tier selection). The Patreon `updateSettings` call was always spreading the full `patreonSettings` object on top of the patch, which combined with the controlled `CommonPlatformFields` inputs (`uncontrolled={false}`) caused stale title state to overwrite the user's input. Additionally, the `Audience` `RadioInput` shared option keys with other radio groups, causing React reconciliation issues, and the audience label was generic.

## Fix
- `PatreonEditStreamInfo.tsx`: when a patch only updates `accessRules` (no `title`), pass the patch through directly instead of merging it onto the stale `patreonSettings`, so the title isn't clobbered.
- `CommonPlatformFields.tsx`: removed `uncontrolled={false}` from the title/description inputs so they no longer fight the parent state during access-rule updates; also removed the commented-out `AiHighlighterToggle` block.
- `RadioInput.tsx` / `RadioInput.m.less`: namespaced option keys with `${p.name}-${option.value}` to avoid duplicate React keys across radio groups, and added a `defaultRadio` class to zero out the label margin for the default (non-button/non-icon) variant.
- `PatreonEditStreamInfo.tsx` / `patreon.json`: relabeled the audience selector to "Patreon Audience" for clarity.
- Tests: `multistream.ts` now asserts each platform form retains the values it was filled with; `patreon.ts` has a commented-out title-persistence assertion ready to enable once the user pool is relaunched.