### PR TITLE
surface video-context init failures so UI can gate streaming

### DIFF
--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -96,6 +96,13 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
 
   establishedContext = new Subject<TDisplayType>();
 
+  /**
+   * Emitted when a video context fails to establish (e.g. graphics device lost
+   * during startup, leaving the libobs canvas mix as NULL). Consumers should
+   * gate streaming/recording start on this and surface a user-facing error.
+   */
+  videoContextError = new Subject<{ display: TDisplayType; error: string }>();
+
   init() {
     this.establishVideoContext();
     this.establishVideoContext('vertical');
@@ -315,12 +322,27 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     if (this.contexts[display]) return;
     this.SET_VIDEO_CONTEXT(display);
     this.contexts[display] = VideoFactory.create();
-    this.migrateSettings(display);
 
-    this.contexts[display].video = this.state[display];
-    this.contexts[display].legacySettings = this.state[display];
-    Video.video = this.state.horizontal;
-    Video.legacySettings = this.state.horizontal;
+    try {
+      this.migrateSettings(display);
+
+      this.contexts[display].video = this.state[display];
+      this.contexts[display].legacySettings = this.state[display];
+      Video.video = this.state.horizontal;
+      Video.legacySettings = this.state.horizontal;
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[VideoSettingsService] Failed to establish ${display} video context: ${message}`,
+      );
+      if (this.contexts[display]) {
+        this.contexts[display].destroy();
+        this.contexts[display] = null as IVideo;
+      }
+      this.DESTROY_VIDEO_CONTEXT(display);
+      this.videoContextError.next({ display, error: message });
+      return false;
+    }
 
     if (display === 'vertical') {
       // ensure vertical context as the same fps settings as the horizontal context


### PR DESCRIPTION
## Summary

Companion to streamlabs/obs-studio-node#1710 (`fix_streaming_crash_no_video`). With that PR in place, `osn::Video::set` will throw when `SetVideoContext` fails. This change catches that throw in `establishVideoContext`, tears down the partial context, and emits on a new `videoContextError` Subject so UI consumers can gate Go-Live / Record-Start and show a clear graphics-device error.

### Why

Today, when libobs canvas init fails (e.g. `DXGI_ERROR_DEVICE_REMOVED` during initial texture creation), the JS-side `Video` setters silently succeed, `this.contexts[display]` looks valid, and the first time the user clicks "Go Live" the server crashes inside `UpdateEncoders` — the Sentry crash this is targeted at.

### Changes

`app/services/settings-v2/video.ts`:

- Add `videoContextError = new Subject<{ display: TDisplayType; error: string }>()` as a sibling to `establishedContext`.
- Wrap the setter block in `establishVideoContext` (which will throw once osn-node#1710 ships) in `try/catch`.
- On catch: `destroy()` the half-initialized context, run `DESTROY_VIDEO_CONTEXT` mutation, emit on `videoContextError`, return `false`.

### Pairs with

- streamlabs/obs-studio-node#1710 — without it, no setter ever throws and this catch never runs. Safe to merge in either order; this PR is inert until the osn-node update gets pulled in via the next `Update osn` PR.

### Not in scope (follow-up)

- UI wiring — subscribing the streaming/recording start buttons (and any first-run setup wizard) to `videoContextError` and surfacing a modal. Once this lands and the new subject is available, a UI-only PR can subscribe to it without further service-layer work.

## Test plan
- [x] `yarn eslint app/services/settings-v2/video.ts` — clean.
- [x] `tsc --noEmit -p tsconfig.json` — clean.
- [ ] Once osn-node update is consumed: force a `SetVideoContext` failure (mock GPU-loss or repro on an affected machine) and confirm `videoContextError` emits, `this.contexts[display]` ends up null, app continues to load.
- [ ] Healthy path: confirm `establishVideoContext` still produces working contexts and `establishedContext` still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)