### PR TITLE
Collab Cam: reset native transceiver on feature teardown

### DIFF
--- a/app/services/guest-cam/index.ts
+++ b/app/services/guest-cam/index.ts
@@ -82,6 +82,7 @@ export interface IObsReturnTypes {
   func_stop_sender: {};
   func_stop_receiver: {};
   func_stop_producer: {};
+  func_reset_device: {};
 }
 
 interface IRoomResponse {
@@ -898,11 +899,19 @@ export class GuestCamService extends StatefulService<IGuestCamServiceState> {
       this.producer = null;
     }
 
-    // TODO: AFAIK there is no way to cleanly recreate the producer without
-    // entirely disconnecting destroying all state on the server. For now, we
-    // disconnect from the socket and start listening to guests again.
+    // Disconnect the socket and reset the native mediasoup transceiver so the
+    // next session starts from a clean device. Without the reset, the singleton
+    // transceiver in mediasoup-connector retains m_device across sessions and
+    // every subsequent func_load_device call hits the "Device already exists"
+    // early-return path, leaving stale WebRTC state in place.
     this.socket.disconnect();
     this.socket = null;
+
+    const sourceForReset = this.views.sources[0];
+    if (sourceForReset) {
+      this.makeObsRequest(sourceForReset.sourceId, 'func_reset_device');
+    }
+
     this.CLEAR_GUESTS();
   }
 


### PR DESCRIPTION
## Summary
- `cleanUpSocketConnection()` now calls `func_reset_device` after `socket.disconnect()` so the singleton `MediaSoupTransceiver` in `mediasoup-connector` is fully torn down and rebuilt between Collab Cam sessions.
- Replaces the existing TODO at the same call site (`AFAIK there is no way to cleanly recreate the producer without entirely disconnecting destroying all state on the server`) — that escape hatch is now in place.
- Pairs with **streamlabs/mediasoup-connector#37** which introduces the `func_reset_device` proc and makes `LoadDevice` idempotent.

## Context
Two SLD 1.20.9 support tickets ("Guests on Collab Cam are disconnecting after a few minutes") shared the same fingerprint in their native logs: `msoup_create LoadDevice failed error = 'Device already exists'` repeating every socket reconnect, accompanied by WebRTC state-drift symptoms and 15 s `Source::CallHandler` IPC freezes.

The singleton transceiver had no JS-callable reset; `Stop()` only ran from `~MediaSoupTransceiver` which only fired on full feature teardown via `msoup_destroy`. Within a single Collab Cam session, state drifted indefinitely across socket reconnects until the host fully disabled the feature or restarted the app.

This change uses the **conservative trigger** — reset only on `cleanUpSocketConnection()` (user disables Collab Cam, joins as guest, last guest source removed, logout). It deliberately does **not** call reset from `handleDisconnect`'s reconnect path, so transient socket blips don't trigger expensive native teardown.

## Safety vs. release ordering
The new `func_reset_device` proc is registered by mediasoup-connector#37. Against the currently shipped DLL (without that proc), `proc_handler` ignores unknown names, so `makeObsRequest('func_reset_device')` is a silent no-op. Merging this PR before the C++ ships in `obs-studio-node` is therefore safe; the behavior change only activates once a desktop release ships against a new osn version that includes the rebuilt DLL.

## Test plan
- [ ] `yarn lint && yarn typecheck` clean
- [ ] With the rebuilt mediasoup-connector DLL deployed: host a Collab Cam session, disable mid-session, confirm `func_reset_device` + `resetThreadCache` appear in `node-obs/logs/*.txt`
- [ ] Re-enable Collab Cam and host another session — confirm fresh device load + full transport / producer / consumer setup on the new transceiver
- [ ] Validate end-to-end with a guest joining from a separate machine (same-machine repro is blocked by the SFU)
- [ ] Sanity check against the currently shipped DLL (no rebuild) — feature continues to work, `func_reset_device` call no-ops without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)