### PR TITLE
Fix patreon as only enabled platform causing relog on app restart.

### DIFF
--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -321,10 +321,15 @@ export class GoLiveSettingsModule {
     /*
      * If there's exactly one enabled platform, set primaryChat to it,
      * ensures there's a primary platform if the user has multiple selected and then
-     * deselects all but one
+     * deselects all but one.
+     * Do not set merge-only platforms (Patreon, Instagram) as primary since they
+     * cannot be used for authentication on app restart.
      */
     if (this.state.enabledPlatforms.length === 1) {
-      this.setPrimaryChat(this.state.enabledPlatforms[0]);
+      const platform = this.state.enabledPlatforms[0];
+      if (platform !== 'patreon' && platform !== 'instagram') {
+        this.setPrimaryChat(platform);
+      }
     }
     /*
      * This should only trigger on free user mode: when toggling another platform


### PR DESCRIPTION
# Fix: Patreon as only enabled platform causing re-login on app restart

## Issues
When a user has Patreon as their only enabled platform in the Go Live window and closes the app, the next app launch forces them to log in again.

The root cause is in `switchPlatforms()`: when exactly one platform remains enabled, the code unconditionally promotes it to `primaryPlatform` via `setPrimaryChat()`. This writes Patreon into `auth.primaryPlatform`. On the next app launch, `autoLogin()` calls `getPlatformService(auth.primaryPlatform)` to re-authenticate — but Patreon is a merge-only platform with no authentication capability, so the login silently fails and the user is prompted to log in again.

The same issue applies to Instagram, which is also a merge-only platform.

## Fixes
Skip promoting merge-only platforms (Patreon, Instagram) to `primaryPlatform` when they are the last remaining enabled platform. This preserves whichever streaming platform (Twitch, YouTube, etc.) the user originally logged in with.