### PR TITLE
Fix highlighter recording broken by twitch game_id instead of game_name

### DIFF
--- a/app/services/highlighter/index.ts
+++ b/app/services/highlighter/index.ts
@@ -416,14 +416,14 @@ export class HighlighterService extends PersistentStatefulService<IHighlighterSt
         this.usageStatisticsService.recordAnalyticsEvent('AIHighlighter', {
           type: 'AiRecordingGoinglive',
           streamId,
-          game: this.streamingService.views.game,
+          game: this.streamingService.views.gameName,
         });
 
         if (!this.aiHighlighterFeatureEnabled) {
           this.usageStatisticsService.recordAnalyticsEvent('AIHighlighter', {
             type: 'AiHighlighterFeatureNotEnabled',
             streamId,
-            game: this.streamingService.views.game,
+            game: this.streamingService.views.gameName,
           });
           return;
         }
@@ -435,15 +435,15 @@ export class HighlighterService extends PersistentStatefulService<IHighlighterSt
         this.usageStatisticsService.recordAnalyticsEvent('AIHighlighter', {
           type: 'AiRecordingHighlighterIsActive',
           streamId,
-          game: this.streamingService.views.game,
+          game: this.streamingService.views.gameName,
         });
 
-        if (!isGameSupported(this.streamingService.views.game)) {
+        if (!isGameSupported(this.streamingService.views.gameName)) {
           return;
         }
 
         let game;
-        const normalizedGameName = isGameSupported(this.streamingService.views.game);
+        const normalizedGameName = isGameSupported(this.streamingService.views.gameName);
         if (normalizedGameName) {
           game = normalizedGameName as EGame;
         } else {
@@ -505,7 +505,7 @@ export class HighlighterService extends PersistentStatefulService<IHighlighterSt
         this.usageStatisticsService.recordAnalyticsEvent('AIHighlighter', {
           type: 'AiRecordingFinished',
           streamId: streamInfo?.id,
-          game: this.streamingService.views.game,
+          game: this.streamingService.views.gameName,
         });
         this.streamingService.actions.toggleRecording();
 
@@ -528,7 +528,7 @@ export class HighlighterService extends PersistentStatefulService<IHighlighterSt
             type: 'AiRecordingExists',
             duration,
             streamId: streamInfo?.id,
-            game: this.streamingService.views.game,
+            game: this.streamingService.views.gameName,
           });
         })
         .catch(error => {

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -110,6 +110,15 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     );
   }
 
+  get gameName() {
+    return (
+      (this.platforms.twitch?.enabled && this.platforms.twitch.gameName) ||
+      (this.platforms.facebook?.enabled && this.platforms.facebook.game) ||
+      (this.platforms.trovo?.enabled && this.platforms.trovo.game) ||
+      ''
+    );
+  }
+
   getPlatformDisplayName(platform: TPlatform): string {
     return getPlatformService(platform).displayName;
   }


### PR DESCRIPTION
With a previous change the `this.streamingService.views.game ` now passes a _game_id_ instead of the _game_name_. 
I now added the game_name as an additional views variable to the _streamingService_, which is only used in the _highlighterService_ now. 