### PR TITLE
osn 0.26.28 + #5941 + #5943 

### DIFF
--- a/app/services/guest-cam/index.ts
+++ b/app/services/guest-cam/index.ts
@@ -82,6 +82,7 @@ export interface IObsReturnTypes {
   func_stop_sender: {};
   func_stop_receiver: {};
   func_stop_producer: {};
+  func_reset_device: {};
 }
 
 interface IRoomResponse {
@@ -898,11 +899,19 @@ export class GuestCamService extends StatefulService<IGuestCamServiceState> {
       this.producer = null;
     }
 
-    // TODO: AFAIK there is no way to cleanly recreate the producer without
-    // entirely disconnecting destroying all state on the server. For now, we
-    // disconnect from the socket and start listening to guests again.
+    // Disconnect the socket and reset the native mediasoup transceiver so the
+    // next session starts from a clean device. Without the reset, the singleton
+    // transceiver in mediasoup-connector retains m_device across sessions and
+    // every subsequent func_load_device call hits the "Device already exists"
+    // early-return path, leaving stale WebRTC state in place.
     this.socket.disconnect();
     this.socket = null;
+
+    const sourceForReset = this.views.sources[0];
+    if (sourceForReset) {
+      this.makeObsRequest(sourceForReset.sourceId, 'func_reset_device');
+    }
+
     this.CLEAR_GUESTS();
   }
 

--- a/app/services/settings-v2/default-settings-data.ts
+++ b/app/services/settings-v2/default-settings-data.ts
@@ -3,8 +3,8 @@ import { EVideoFormat, EColorSpace, ERangeType, EScaleType, EFPSType } from 'obs
 export const horizontalDisplayData = {
   fpsNum: 30,
   fpsDen: 1,
-  baseWidth: 1920,
-  baseHeight: 1080,
+  baseWidth: 1280,
+  baseHeight: 720,
   outputWidth: 1280,
   outputHeight: 720,
   outputFormat: EVideoFormat.I420,

--- a/app/services/settings-v2/default-settings-data.ts
+++ b/app/services/settings-v2/default-settings-data.ts
@@ -1,5 +1,19 @@
 import { EVideoFormat, EColorSpace, ERangeType, EScaleType, EFPSType } from 'obs-studio-node';
 
+export const horizontalDisplayData = {
+  fpsNum: 30,
+  fpsDen: 1,
+  baseWidth: 1920,
+  baseHeight: 1080,
+  outputWidth: 1280,
+  outputHeight: 720,
+  outputFormat: EVideoFormat.I420,
+  colorspace: EColorSpace.CS709,
+  range: ERangeType.Full,
+  scaleType: EScaleType.Bilinear,
+  fpsType: EFPSType.Integer,
+};
+
 export const verticalDisplayData = {
   fpsNum: 30,
   fpsDen: 1,

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -16,6 +16,7 @@ import { DualOutputService } from 'services/dual-output';
 import { SettingsService } from 'services/settings';
 import { OutputSettingsService } from 'services/settings/output';
 import { Subject } from 'rxjs';
+import { horizontalDisplayData } from './default-settings-data';
 
 /**
  * Display Types
@@ -290,7 +291,19 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
      */
     if (display === 'horizontal' && !this.dualOutputService.views.videoSettings?.horizontal) {
       this.loadLegacySettings();
-      this.contexts.horizontal.video = this.contexts.horizontal.legacySettings;
+      // Fresh canvas reads back 0x0 for both legacySettings and video. osn 0.26.28
+      // now throws on SetVideoContext(0x0) where it previously dropped the error.
+      // Seed with defaults so the first push validates; autoconfig overwrites later.
+      const legacy = this.contexts.horizontal.legacySettings;
+      if (!legacy.baseWidth || !legacy.baseHeight) {
+        Object.keys(horizontalDisplayData).forEach((key: keyof IVideoInfo) => {
+          this.SET_VIDEO_SETTING(key, horizontalDisplayData[key], 'horizontal');
+          this.dualOutputService.setVideoSetting({ [key]: horizontalDisplayData[key] }, 'horizontal');
+        });
+        this.contexts.horizontal.video = horizontalDisplayData;
+      } else {
+        this.contexts.horizontal.video = legacy;
+      }
     } else {
       // otherwise, load them from the dual output service
       const settings = this.dualOutputService.views.videoSettings[display];

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -96,6 +96,13 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
 
   establishedContext = new Subject<TDisplayType>();
 
+  /**
+   * Emitted when a video context fails to establish (e.g. graphics device lost
+   * during startup, leaving the libobs canvas mix as NULL). Consumers should
+   * gate streaming/recording start on this and surface a user-facing error.
+   */
+  videoContextError = new Subject<{ display: TDisplayType; error: string }>();
+
   init() {
     this.establishVideoContext();
     this.establishVideoContext('vertical');
@@ -315,12 +322,27 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
     if (this.contexts[display]) return;
     this.SET_VIDEO_CONTEXT(display);
     this.contexts[display] = VideoFactory.create();
-    this.migrateSettings(display);
 
-    this.contexts[display].video = this.state[display];
-    this.contexts[display].legacySettings = this.state[display];
-    Video.video = this.state.horizontal;
-    Video.legacySettings = this.state.horizontal;
+    try {
+      this.migrateSettings(display);
+
+      this.contexts[display].video = this.state[display];
+      this.contexts[display].legacySettings = this.state[display];
+      Video.video = this.state.horizontal;
+      Video.legacySettings = this.state.horizontal;
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(
+        `[VideoSettingsService] Failed to establish ${display} video context: ${message}`,
+      );
+      if (this.contexts[display]) {
+        this.contexts[display].destroy();
+        this.contexts[display] = null as IVideo;
+      }
+      this.DESTROY_VIDEO_CONTEXT(display);
+      this.videoContextError.next({ display, error: message });
+      return false;
+    }
 
     if (display === 'vertical') {
       // ensure vertical context as the same fps settings as the horizontal context

--- a/app/services/settings-v2/video.ts
+++ b/app/services/settings-v2/video.ts
@@ -298,7 +298,10 @@ export class VideoSettingsService extends StatefulService<IVideoSetting> {
       if (!legacy.baseWidth || !legacy.baseHeight) {
         Object.keys(horizontalDisplayData).forEach((key: keyof IVideoInfo) => {
           this.SET_VIDEO_SETTING(key, horizontalDisplayData[key], 'horizontal');
-          this.dualOutputService.setVideoSetting({ [key]: horizontalDisplayData[key] }, 'horizontal');
+          this.dualOutputService.setVideoSetting(
+            { [key]: horizontalDisplayData[key] },
+            'horizontal',
+          );
         });
         this.contexts.horizontal.video = horizontalDisplayData;
       } else {

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.26",
+      "version": "0.26.28",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
**Draft — not for review/merge. Pushed to see how the three changes behave together on CI.**

Bundles three open PRs onto a single branch so we can run CI once and see how they interact, particularly around the IPC-error-propagation behavior change in osn 0.26.28.

## Cherry-picks (in this order)

1. **#5941** — `surface video-context init failures from establishVideoContext`
   Desktop-side handling for the new osn behavior: wraps the now-throwing `IVideo` setters in try/catch, tears down the partial context, and emits a `videoContextError` subject so UI consumers can gate streaming/recording start.

2. **#5943** — `Collab Cam: reset native transceiver on feature teardown`
   Calls `func_reset_device` on Collab Cam teardown so the singleton `MediaSoupTransceiver` in mediasoup-connector is fully rebuilt between sessions instead of accumulating stale state.

3. **#5951** — `Update obs-studio-node to v0.26.28`
   Pulls in osn 0.26.28, which includes the canvas-video-pipeline streaming-crash fix **and** the `osn::Video::set` `ValidateResponse` change that propagates previously-swallowed `SetVideoContext` errors to the JS layer.

## Why bundle

PR #5951 alone reproduces a cascade in webdriver CI: a previously-silent `SetVideoContext` failure during `VideoSettingsService.establishVideoContext` now throws `IPC received error code 1`, leaving the horizontal video context half-initialized, after which `PerformanceService.skippedFrames` throws `code 4` (NotFound), recording stops with code -4, etc. #5941 is the desktop-side fix for exactly that scenario, so running it together with #5951 is the meaningful CI signal. #5943 is along for the ride to validate the Collab Cam reset path on the same osn bump.

## Source PRs

- https://github.com/streamlabs/desktop/pull/5941
- https://github.com/streamlabs/desktop/pull/5943
- https://github.com/streamlabs/desktop/pull/5951