### PR TITLE
Fix YT Broadcasts to past schedules being rejected

### DIFF
--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -733,6 +733,11 @@ export class YoutubeService
       'scheduledStartTime',
     ]);
 
+    // Ensure scheduled start time is in the future
+    if (snippet.scheduledStartTime && !(new Date(snippet.scheduledStartTime) > new Date())) {
+      snippet.scheduledStartTime = new Date().toISOString();
+    }
+
     // `zxx` is a `Not applicable` language code
     // YouTube API doesn't allow us to set this code
     if (snippet.defaultAudioLanguage === 'zxx') delete snippet.defaultAudioLanguage;

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -500,7 +500,11 @@ export class YoutubeService
       return;
     }
 
+    // Make sure the scheduled stream exists and is in the future
     const streamToScheduledBroadcast = !!ytSettings.broadcastId;
+    if (ytSettings.scheduledStartTime && !(ytSettings.scheduledStartTime > new Date().getTime())) {
+      ytSettings.scheduledStartTime = new Date().getTime();
+    }
     // update selected LiveBroadcast with new title and description
     // or create a new LiveBroadcast if there are no broadcasts selected
     let broadcast: IYoutubeLiveBroadcast;


### PR DESCRIPTION
Adds a guard to ensure we aren't sending scheduled start times from the past so users won't get rejected by the YT API