### PR TITLE
Fix incorrect bitrate performance metric.

### DIFF
--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -3525,9 +3525,9 @@ export class StreamingService
       dataOutput += instance.dataOutput;
     }
 
-    // TODO: Add UI to show bitrate by display but for now average the two displays, which is more accurate
+    // TODO: Add UI to show bitrate by display but for now average the all instances, which is more accurate
     // than only showing the horizontal display's bitrate in dual output mode
-    kbitsPerSec = Math.round(kbitsPerSec / 2);
+    kbitsPerSec = Math.round(kbitsPerSec / Object.keys(this.contexts).length);
 
     return { droppedFrames, totalFrames, kbitsPerSec, dataOutput };
   }

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -3525,6 +3525,10 @@ export class StreamingService
       dataOutput += instance.dataOutput;
     }
 
+    // TODO: Add UI to show bitrate by display but for now average the two displays, which is more accurate
+    // than only showing the horizontal display's bitrate in dual output mode
+    kbitsPerSec = Math.round(kbitsPerSec / 2);
+
     return { droppedFrames, totalFrames, kbitsPerSec, dataOutput };
   }
 


### PR DESCRIPTION
## Fix incorrect bitrate performance metric in dual output mode

### Issue
In dual output mode, `streamingPerformanceStats` sums `kbitsPerSec` across all streaming instances, causing the displayed bitrate not show actual per-stream value.

### Fix
Average `kbitsPerSec` across all instances until a UI is implemented to show the per-display bitrate.