### PR TITLE
Fix YouTube disabled notification styling.

### DIFF
--- a/app/components-react/root/NotificationsArea.m.less
+++ b/app/components-react/root/NotificationsArea.m.less
@@ -41,6 +41,10 @@
   margin: 5px 0px 5px 5px !important;
   line-height: 20px !important;
   font-size: 12px;
+
+  &.refresh {
+    width: 80px;
+  }
 }
 
 :global(.ant-message-notice).notification {

--- a/app/components-react/root/NotificationsArea.m.less
+++ b/app/components-react/root/NotificationsArea.m.less
@@ -35,10 +35,11 @@
 }
 
 .alert-button {
-  min-height: 30px !important;
-  height: 30px;
+  min-height: 20px !important;
+  height: 20px !important;
   background-color: rgba(251, 72, 76, 0.36) !important;
-  margin: 0 4px !important;
+  margin: 5px 0px 5px 5px !important;
+  line-height: 20px !important;
   font-size: 12px;
 }
 
@@ -71,6 +72,10 @@
   &.warning {
     background-color: var(--warning-bg);
     color: var(--warning);
+
+    i {
+      margin-right: 5px !important;
+    }
   }
 
   &.success {

--- a/app/components-react/root/NotificationsArea.tsx
+++ b/app/components-react/root/NotificationsArea.tsx
@@ -106,7 +106,7 @@ class NotificationsModule {
     Services.YoutubeService.actions.openYoutubeEnable();
   }
 
-  confirmYoutubeEnabled() {
+  async confirmYoutubeEnabled() {
     if (this.platform === 'youtube') {
       Services.YoutubeService.actions.prepopulateInfo();
     }
@@ -224,6 +224,22 @@ function MessageNode(p: { notif: INotification }) {
 
 function YTError() {
   const { confirmYoutubeEnabled, openYoutubeEnable } = useModule(NotificationsModule);
+  const [loading, setLoading] = useState(false);
+  const [refreshText, setRefreshText] = useState($t("I'm set up"));
+
+  async function handleConfirm() {
+    setLoading(true);
+    await new Promise(resolve => setTimeout(resolve, 500));
+    await confirmYoutubeEnabled();
+    if (!Services.YoutubeService.state.liveStreamingEnabled) {
+      setRefreshText($t('Not enabled'));
+      setLoading(false);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      setRefreshText($t("I'm set up"));
+    } else {
+      setLoading(false);
+    }
+  }
 
   return (
     <div className={cx('ant-message-notice', styles.notification, styles.warning, styles.ytError)}>
@@ -232,8 +248,12 @@ function YTError() {
       <button className={cx('button', styles.alertButton)} onClick={openYoutubeEnable}>
         {$t('Fix')}
       </button>
-      <button className={cx('button', styles.alertButton)} onClick={confirmYoutubeEnabled}>
-        {$t("I'm set up")}
+      <button
+        className={cx('button', styles.alertButton, styles.refresh)}
+        onClick={handleConfirm}
+        disabled={loading || refreshText === $t('Not enabled')}
+      >
+        {loading ? <i className="fa fa-spinner fa-spin" /> : refreshText}
       </button>
     </div>
   );

--- a/app/i18n/en-US/common.json
+++ b/app/i18n/en-US/common.json
@@ -176,5 +176,6 @@
   "Upgrade": "Upgrade",
   "Edit Data": "Edit Data",
   "Edit Reactive Data": "Edit Reactive Data",
-  "Reactive Data Editor": "Reactive Data Editor"
+  "Reactive Data Editor": "Reactive Data Editor",
+  "Not enabled": "Not enabled"
 }

--- a/app/services/platforms/youtube.ts
+++ b/app/services/platforms/youtube.ts
@@ -319,6 +319,7 @@ export class YoutubeService
 
       // Log specific Youtube API errors if they exist
       if (error?.result && error.result?.error) {
+        console.log('Youtube API Error Reason: ', error.result.error.errors[0].reason);
         console.log('Youtube API Error: ', JSON.stringify(error.result.error, null, 2));
       }
 
@@ -670,6 +671,9 @@ export class YoutubeService
       return EPlatformCallResult.Success;
     } catch (e: unknown) {
       const error = e as any;
+
+      console.log('Youtube API Error Reason: ', error?.result?.error?.errors[0]?.reason);
+      console.log('Youtube API Error: ', JSON.stringify(error?.result?.error, null, 2));
 
       // Check if this is a YouTube live stream API error response
       if (error?.errors && error?.status) {


### PR DESCRIPTION
# Fix YouTube disabled notification styling and add logging

## Issue
Notification buttons styling was off and refresh button had no confirmation UI.
<img width="566" height="50" alt="Screenshot 2026-06-24 143121" src="https://github.com/user-attachments/assets/04672827-f25a-4a03-ab1f-e0acdcb9fb39" />

## Fix
- Fixed buttons margin/padding
<img width="582" height="50" alt="Screenshot 2026-06-24 142953" src="https://github.com/user-attachments/assets/6c802f69-c720-4caf-b464-666cfdc92508" />

- Added confirmation UI to the refresh button
<img width="591" height="49" alt="Screenshot 2026-06-24 143236" src="https://github.com/user-attachments/assets/babec38b-12a0-4458-8b2a-eed8bda43ffb" />
<img width="583" height="51" alt="Screenshot 2026-06-24 143006" src="https://github.com/user-attachments/assets/356a71bf-fa6f-4fd5-85e2-1a37ada9977a" />


## Other
- Added additional logging for YouTube api requests