### PR TITLE
Fix YouTube monetization state update before mount error

### DIFF
--- a/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
@@ -64,11 +64,8 @@ export const YoutubeEditStreamInfo = InputComponent((p: IPlatformComponentParams
 
   // re-fill form when the broadcastId selected
   useEffect(() => {
-    if (!broadcastId) {
-      // Cannot have monetization enabled before the broadcast is checked
-      updateSettings({ monetizationEnabled: false, eligibleForMonetization: false });
-      return;
-    }
+    if (!broadcastId) return;
+
     Services.YoutubeService.actions.return
       .fetchStartStreamOptionsForBroadcast(broadcastId)
       .then(newYtSettings => {

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -10,7 +10,7 @@ import {
 import { StreamSettingsService, ICustomStreamDestination } from '../settings/streaming';
 import { UserService } from '../user';
 import { RestreamService, TStreamShiftStatus } from '../restream';
-import { DualOutputService, TDisplayPlatforms, TDisplayDestinations } from '../dual-output';
+import { TDisplayPlatforms, TDisplayDestinations, DualOutputService } from '../dual-output';
 import { getPlatformService, TPlatform, TPlatformCapability, platformList } from '../platforms';
 import { TwitchService, TwitterService } from '../../app-services';
 import { EAvailableFeatures, IncrementalRolloutService } from 'services/incremental-rollout';
@@ -779,7 +779,21 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     // don't reuse broadcastId and thumbnail for Youtube
     // TODO: index
     // @ts-ignore
-    if (settings && settings['broadcastId']) settings['broadcastId'] = '';
+    if (settings && settings['broadcastId']) {
+      // TODO: index
+      // @ts-ignore
+      settings['broadcastId'] = '';
+
+      if (platform === 'youtube') {
+        // Cannot have monetization enabled before the broadcast is checked
+        // TODO: index
+        // @ts-ignore
+        settings['monetizationEnabled'] = false;
+        // TODO: index
+        // @ts-ignore
+        settings['eligibleForMonetization'] = false;
+      }
+    }
     // TODO: index
     // @ts-ignore
     if (settings && settings['thumbnail']) settings['thumbnail'] = '';


### PR DESCRIPTION
# Fix YouTube form state update before mount error

## Issue
YouTube monetization values should be reset when there is no broadcast id. This was happening in the component instead of when setting default values on load, causing the component to attempt to update state before mount.
<img width="606" height="37" alt="Screenshot 2026-06-25 115523" src="https://github.com/user-attachments/assets/20a733e2-ad59-4289-b0f2-e675520b2685" />
## Fix
Move default value reset to service level where all other default form values are set