### PR TITLE
Update OSN 0.26.29b17: Allow Enhanced Broadcasting streams as recording parents

### DIFF
--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.29b10",
+      "version": "0.26.29b17",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
* update to 0.26.29b17- from hotfix branch. Last ver was 0.26.29b10.