### PR TITLE
powerups,recentevents: update recent events power-ups format

### DIFF
--- a/app/components-react/editor/elements/RecentEvents.tsx
+++ b/app/components-react/editor/elements/RecentEvents.tsx
@@ -173,6 +173,7 @@ function EventCell(p: { event: IRecentEvent }) {
   function getName(event: IRecentEvent) {
     if (event.gifter) return event.gifter;
     if (event.from) return event.from;
+    if (event.redeemer_display_name) return event.redeemer_display_name;
     return event.name;
   }
 

--- a/app/services/recent-events.ts
+++ b/app/services/recent-events.ts
@@ -62,6 +62,7 @@ export interface IRecentEvent {
   skill_currency?: string;
   skill_name?: string;
   recurring_donation?: { id: string; months?: number };
+  redeemer_display_name?: string;
   power_up_name?: string;
   power_up_prompt?: string;
 }
@@ -230,8 +231,8 @@ function getHashForRecentEvent(event: IRecentEvent) {
     case 'share':
     case 'support':
       return [event.type, event.name, event._id].join(':');
-    case 'power_up':
-      return [event.type, event.name, event.power_up_name].join(':');
+    case 'powerUp':
+      return [event.type, event.redeemer_display_name, event.power_up_name].join(':');
     case 'prime_sub_gift':
       return [event.type, event.name, event.streamer, event.giftType].join(':');
     case 'sticker':


### PR DESCRIPTION
Fix missing redeemer name in power-up recent events

<img width="739" height="78" alt="image" src="https://github.com/user-attachments/assets/a08e908c-f264-485a-87e9-02e8148f1ff8" />
