### PR TITLE
Fix recording size split settings mapping

### DIFF
--- a/app/services/settings/output/output-settings.ts
+++ b/app/services/settings/output/output-settings.ts
@@ -3,7 +3,13 @@ import { ISettingsSubCategory, SettingsService } from 'services/settings';
 import { TDisplayType, VideoSettingsService } from 'services/settings-v2/video';
 import { Inject } from 'services/core/injector';
 import { Dictionary } from 'vuex';
-import { ERecordingQuality, ERecordingFormat, EScaleType, ISettings } from 'obs-studio-node';
+import {
+  ERecordingQuality,
+  ERecordingFormat,
+  EScaleType,
+  ERecSplitType,
+  ISettings,
+} from 'obs-studio-node';
 
 /**
  * list of encoders for simple mode
@@ -149,8 +155,8 @@ interface IAdvancedRecordingOutputSettings extends IRecordingOutputSettings {
   enableFileSplit: boolean;
   splitTime: number;
   splitSize: number;
-  splitType: string;
-  resetTimestamps: boolean;
+  splitType: ERecSplitType;
+  fileResetTimestamps: boolean;
 }
 
 interface IStreamingOutputSettings {
@@ -479,23 +485,31 @@ export class OutputSettingsService extends Service {
         'Recording',
         'RecSplitFile',
       );
-      const splitTime =
-        this.settingsService.findSettingValue(output, 'Recording', 'RecSplitFileTime') * 60; // convert seconds to minutes
-      const splitSize = this.settingsService.findSettingValue(
-        output,
-        'Recording',
-        'RecSplitFileSize',
+      const splitTimeMinutes = Number(
+        this.settingsService.findSettingValue(output, 'Recording', 'RecSplitFileTime') ?? 0,
       );
-      const splitType = this.settingsService.findSettingValue(
+      const splitTime = Number.isFinite(splitTimeMinutes) ? splitTimeMinutes * 60 : 0;
+      const splitSizeValue = Number(
+        this.settingsService.findSettingValue(output, 'Recording', 'RecSplitFileSize') ?? 0,
+      );
+      const splitSize = Number.isFinite(splitSizeValue) ? splitSizeValue : 0;
+      const splitTypeValue = this.settingsService.findSettingValue(
         output,
         'Recording',
         'RecSplitFileType',
       );
-      const resetTimestamps = this.settingsService.findSettingValue(
-        output,
-        'Recording',
-        'RecSplitFileResetTimestamps',
-      );
+      const splitType =
+        splitTypeValue === 'Size'
+          ? ERecSplitType.Size
+          : splitTypeValue === 'Manual'
+            ? ERecSplitType.Manual
+            : ERecSplitType.Time;
+      const fileResetTimestamps =
+        this.settingsService.findSettingValue(
+          output,
+          'Recording',
+          'RecSplitFileResetTimestamps',
+        ) ?? true;
 
       // advanced settings
       return {
@@ -517,7 +531,7 @@ export class OutputSettingsService extends Service {
         splitTime,
         splitSize,
         splitType,
-        resetTimestamps,
+        fileResetTimestamps,
       };
     } else {
       // simple settings

--- a/test/regular/api/streaming.ts
+++ b/test/regular/api/streaming.ts
@@ -1,5 +1,7 @@
 import { TExecutionContext, useWebdriver, test } from '../../helpers/webdriver';
 import { getApiClient } from '../../helpers/api-client';
+import * as fs from 'fs-extra';
+import { sleep } from '../../helpers/sleep';
 import {
   IStreamingServiceApi,
   EStreamingState,
@@ -85,6 +87,56 @@ test('Recording via API', async (t: TExecutionContext) => {
 
   recordingStatus = (await client.fetchNextEvent()).data;
   t.is(recordingStatus, ERecordingState.Offline, 'Recording status should be Offline');
+});
+
+test('Advanced recording splits files by size via API', async (t: TExecutionContext) => {
+  t.timeout(2 * 60 * 1000, 'Advanced recording size split test timed out');
+
+  const client = await getApiClient();
+  const streamingService = client.getResource<IStreamingServiceApi>('StreamingService');
+  const settingsService = client.getResource<SettingsService>('SettingsService');
+
+  settingsService.setSettingValue('Output', 'Mode', 'Advanced');
+  settingsService.setSettingValue('Output', 'RecFilePath', t.context.cacheDir);
+  settingsService.setSettingValue('Output', 'RecFormat', 'mkv');
+  settingsService.setSettingValue('Output', 'RecEncoder', 'obs_x264');
+  settingsService.setSettingValue('Output', 'Recrate_control', 'CBR');
+  settingsService.setSettingValue('Output', 'Recbitrate', 60000);
+  settingsService.setSettingValue('Output', 'RecSplitFile', true);
+  settingsService.setSettingValue('Output', 'RecSplitFileType', 'Size');
+  settingsService.setSettingValue('Output', 'RecSplitFileSize', 2);
+
+  let recordingStatus = streamingService.getModel().recordingStatus;
+
+  streamingService.recordingStatusChange.subscribe(() => void 0);
+
+  t.is(recordingStatus, ERecordingState.Offline, 'Recording status should be Offline');
+
+  streamingService.toggleRecording();
+
+  recordingStatus = (await client.fetchNextEvent()).data;
+  t.is(recordingStatus, ERecordingState.Recording, 'Recording status should be Recording');
+
+  await sleep(12000);
+
+  streamingService.toggleRecording();
+
+  recordingStatus = (await client.fetchNextEvent()).data;
+  t.is(recordingStatus, ERecordingState.Stopping, 'Recording status should be Stopping');
+
+  recordingStatus = (await client.fetchNextEvent()).data;
+  t.is(recordingStatus, ERecordingState.Writing, 'Recording status should be Writing');
+
+  recordingStatus = (await client.fetchNextEvent()).data;
+  t.is(recordingStatus, ERecordingState.Offline, 'Recording status should be Offline');
+
+  const files = await fs.readdir(t.context.cacheDir);
+  const recordingFiles = files.filter(file => file.endsWith('.mkv'));
+
+  t.true(
+    recordingFiles.length > 1,
+    `Expected size-split recording to create multiple files, got:\n${files.join('\n')}`,
+  );
 });
 
 test('Recording filename formatting is read from advanced recording settings', async t => {


### PR DESCRIPTION
### Summary

Fixes Advanced recording file splitting by size when using the recording factory API.

### Root Cause

The Output settings UI stores `RecSplitFileType` as a string value: `"Time"`, `"Size"`, or `"Manual"`.

Desktop was passing that string directly through `migrateSettings()` to the `obs-studio-node` recording object as `recording.splitType`. However, the native recording API expects `splitType` to be the numeric `ERecSplitType` enum:

- `Time = 0`
- `Size = 1`
- `Manual = 2`

The native setter converts the JS value with `ToNumber().Uint32Value()`. For `"Size"`, that conversion does not produce `1`; it collapses to `0`, so the backend configures the recording as Time mode instead of Size mode.

There was a second issue in Size mode: `nodeobs_settings.cpp` only emits the currently relevant split threshold field. So when Size mode is selected, `RecSplitFileTime` is not present in the settings model. Desktop still read it unconditionally, producing `NaN`, which then became `0` at the native boundary. That left OBS with splitting enabled but no valid automatic threshold.

As a result, selecting “Split by Size” with a value like `100 MB` could produce a single large recording file instead of multiple split files.

### Fix

Desktop now normalizes the recording split settings before they are assigned to the native recording factory object:

- `"Size"` maps to `ERecSplitType.Size`
- `"Manual"` maps to `ERecSplitType.Manual`
- everything else defaults to `ERecSplitType.Time`
- missing/hidden split size or time fields fall back to `0` instead of `NaN`
- `RecSplitFileResetTimestamps` is returned as `fileResetTimestamps`, matching the native recording contract
