### PR TITLE
Add new source filters

### DIFF
--- a/app/i18n/en-US/filters.json
+++ b/app/i18n/en-US/filters.json
@@ -27,6 +27,7 @@
   "Shader": "Shader",
   "HDR Tone Mapping (Override)": "HDR Tone Mapping (Override)",
   "NVIDIA Background Removal": "NVIDIA Background Removal",
+  "Luma Key": "Luma Key",
   "No settings are available for this filter": "No settings are available for this filter",
   "Visual Presets": "Visual Presets",
   "None": "None",
@@ -81,5 +82,7 @@
   "Open Threshold": "Open Threshold",
   "Close Threshold": "Close Threshold",
   "Presets": "Presets",
-  "Detection": "Detection"
+  "Detection": "Detection",
+  "Upward Compressor": "Upward Compressor",
+  "3-Band Equalizer": "3-Band Equalizer"
 }

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -27,18 +27,24 @@ import uuid from 'uuid/v4';
 
 export type TSourceFilterType =
   | 'mask_filter'
+  | 'mask_filter_v2'
   | 'crop_filter'
   | 'gain_filter'
   | 'color_filter'
+  | 'color_filter_v2'
   | 'scale_filter'
   | 'scroll_filter'
   | 'gpu_delay'
   | 'color_key_filter'
+  | 'color_key_filter_v2'
   | 'clut_filter'
   | 'sharpness_filter'
+  | 'sharpness_filter_v2'
   | 'chroma_key_filter'
+  | 'chroma_key_filter_v2'
   | 'async_delay_filter'
   | 'noise_suppress_filter'
+  | 'noise_suppress_filter_v2'
   | 'noise_gate_filter'
   | 'compressor_filter'
   | 'vst_filter'
@@ -51,7 +57,11 @@ export type TSourceFilterType =
   | 'mediasoupconnector_vfilter'
   | 'mediasoupconnector_vsfilter'
   | 'hdr_tonemap_filter'
-  | 'nv_greenscreen_filter';
+  | 'nv_greenscreen_filter'
+  | 'luma_key_filter'
+  | 'luma_key_filter_v2'
+  | 'upward_compressor_filter'
+  | 'basic_eq_filter';
 
 interface ISourceFilterType {
   type: TSourceFilterType;
@@ -221,18 +231,24 @@ export class SourceFiltersService extends StatefulService<IFiltersServiceState> 
     const obsAvailableTypes = obs.FilterFactory.types();
     const allowlistedTypes: IObsListOption<TSourceFilterType>[] = [
       { description: $t('Image Mask/Blend'), value: 'mask_filter' },
+      { description: $t('Image Mask/Blend'), value: 'mask_filter_v2' },
       { description: $t('Crop/Pad'), value: 'crop_filter' },
       { description: $t('Gain'), value: 'gain_filter' },
       { description: $t('Color Correction'), value: 'color_filter' },
+      { description: $t('Color Correction'), value: 'color_filter_v2' },
       { description: $t('Scaling/Aspect Ratio'), value: 'scale_filter' },
       { description: $t('Scroll'), value: 'scroll_filter' },
       { description: $t('Render Delay'), value: 'gpu_delay' },
       { description: $t('Color Key'), value: 'color_key_filter' },
+      { description: $t('Color Key'), value: 'color_key_filter_v2' },
       { description: $t('Apply LUT'), value: 'clut_filter' },
       { description: $t('Sharpen'), value: 'sharpness_filter' },
+      { description: $t('Sharpen'), value: 'sharpness_filter_v2' },
       { description: $t('Chroma Key'), value: 'chroma_key_filter' },
+      { description: $t('Chroma Key'), value: 'chroma_key_filter_v2' },
       { description: $t('Video Delay (Async)'), value: 'async_delay_filter' },
       { description: $t('Noise Suppression'), value: 'noise_suppress_filter' },
+      { description: $t('Noise Suppression'), value: 'noise_suppress_filter_v2' },
       { description: $t('Noise Gate'), value: 'noise_gate_filter' },
       { description: $t('Compressor'), value: 'compressor_filter' },
       { description: $t('VST 2.x Plugin'), value: 'vst_filter' },
@@ -243,6 +259,9 @@ export class SourceFiltersService extends StatefulService<IFiltersServiceState> 
       { description: $t('Shader'), value: 'shader_filter' },
       { description: $t('HDR Tone Mapping (Override)'), value: 'hdr_tonemap_filter' },
       { description: $t('NVIDIA Background Removal'), value: 'nv_greenscreen_filter' },
+      { description: $t('Luma Key'), value: 'luma_key_filter_v2' },
+      { description: $t('Upward Compressor'), value: 'upward_compressor_filter' },
+      { description: $t('3-Band Equalizer'), value: 'basic_eq_filter' },
     ];
     const allowedAvailableTypes = allowlistedTypes.filter(type =>
       obsAvailableTypes.includes(type.value),

--- a/app/services/source-filters.ts
+++ b/app/services/source-filters.ts
@@ -58,7 +58,6 @@ export type TSourceFilterType =
   | 'mediasoupconnector_vsfilter'
   | 'hdr_tonemap_filter'
   | 'nv_greenscreen_filter'
-  | 'luma_key_filter'
   | 'luma_key_filter_v2'
   | 'upward_compressor_filter'
   | 'basic_eq_filter';

--- a/scripts/repositories.json
+++ b/scripts/repositories.json
@@ -4,7 +4,7 @@
       "name": "obs-studio-node",
       "url": "https://s3-us-west-2.amazonaws.com/obsstudionodes3.streamlabs.com/",
       "archive": "osn-[VERSION]-release-[OS][ARCH].tar.gz",
-      "version": "0.26.29b18",
+      "version": "0.26.32-rno-filters1",
       "win64": true,
       "osx": true
     },


### PR DESCRIPTION
* Add missing filters: Luma Key, 3-Band Eq, and Upward Compressor.
* Add version 2 of all known filters that were updated.
* User's scene collection remains unaffected. They will keep using version 1 unless they delete their filter and create a new one matching OBS behavior.

# Dependencies
This change depends on this OSN [update](https://github.com/streamlabs/obs-studio-node/pull/1743) which filters out disabled/obsolete filters. 

# Regression test cases for QA
This PR updates the following filters to their version 2 counterparts: Image Mask/Blend, Color Correction, Color Key, Sharpen, Chroma Key, Noise Suppression.

This PR adds Upward Compressor (Audio filter), Luma Key Filter (Video), and 3-Band Equalizer (Audio filter)

# What changed from version 1 to version 2?
*Color Correction* - v2 adds proper color space negotiation so the filter works correctly in SDR/WCG pipelines without mangling HDR content, whereas v1 blindly assumed GS_RGBA for everything.

*Image Mask/Blend*- v2 is a precision and color-pipeline upgrade — higher-resolution opacity and proper sRGB/color space awareness

*Color Key Filter*- v2 is a substantial rework: opacity is redesigned from an alpha-packed color hack into a proper float parameter, brightness scaling is removed, the contrast/brightness ranges are expanded, and the whole render path gains proper color space awareness. 

*Sharpness* - only adds SRGB capability flag
*Chroma Key* - the chroma key v2 changes are a mirror of the color key v2 changes — opacity redesigned from an alpha-packed color hack to a proper float, brightness scaling removed, expanded ranges, and full color space pipeline awareness added.   

*Noise Suppression (Audio)* - The change is essentially: v2 promotes RNN noise suppression as the preferred default when available, rather than only falling back to it when Speex isn't present. RNN = Recurrent Neural Network. It refers to a neural network-based noise suppression approach (specifically the https://jmvalin.ca/demo/rnnoise/ library), as opposed to the classic DSP-based Speex noise suppression.

# New filters that this PR exposes
*Luma Key Filer*:
The luma key filter makes pixels transparent based on their brightness (luminance) rather than a specific color. It exposes four parameters:                                                                                                                               
                                                                                                                                                                                                                                                                             
  - Luma Min / Luma Max (0.0–1.0): defines the brightness range to key out. Pixels whose luminance falls within this range become transparent.                                                                                                                               
  - Luma Min Smooth / Luma Max Smooth: softens the edges of the key at the min/max thresholds, so the transparency transition isn't a hard cut.                                                                                                                              
                                                                                                                                                                                                                                                                             
  For example, with default settings (luma_min=0.0, luma_max=1.0, no smoothing), nothing is keyed. If you set luma_min=0.5, pixels darker than 50% brightness become transparent — useful for removing black backgrounds or applying overlays that blend based on brightness 
  rather than color.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                             
  It's commonly used with white/black backgrounds or as a way to composite elements where a color-based chroma key wouldn't work.

*Upwards Compressor*: The upward compressor is an audio dynamics filter that boosts quiet sounds up toward a threshold, as opposed to a traditional (downward) compressor which turns loud sounds down.                                                                                          
                                                                                                                                                                                                                                                                             
  How it works:                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                             
  1. Detection — measures the signal level using an RMS envelope follower (10ms window)                                                                                                                                                                                      
  2. Gain stage — for signals below the threshold, applies positive gain proportional to slope * (threshold - signal_level). Signals above the threshold get 0 gain (left untouched). The slope is 1.0 - ratio, where ratio is 0.0–1.0                                       
  3. Knee — a soft knee (0–20 dB wide) smooths the transition around the threshold so the boost doesn't kick in abruptly                                                                                                                                                     
  4. Ballistics — attack and release times control how fast the gain responds                                                                                                                                                                                                
  5. Output gain — a final makeup gain stage                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  Parameters:                                                                                                                                                                                                                                                                
  - Ratio (0.0–1.0): how aggressively to boost quiet sounds — higher ratio = more boost                                                                                                                                                                                      
  - Threshold (-60–0 dB): the level below which boosting begins                                                                                                                                                                                                              
  - Attack / Release (1–100ms / 1–1000ms): how fast the gain reacts
  - Knee width (0–20 dB): softness of the threshold transition                                                                                                                                                                                                               
  - Output gain (-32–+32 dB): makeup gain applied after compression                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                             
  Practical use: leveling out a quiet speaker or microphone so soft parts of speech become more audible without turning up the overall volume — the opposite problem from what a downward compressor solves. It shares the same underlying code as the expander filter, just 
  with is_upwcomp = true which flips the gain direction.    

*3 Band Equalizer*: It's a simple 3-band equalizer audio filter. It splits the audio signal into three frequency bands and lets you boost or cut each by ±20 dB:                                                                                                                               
                 
  - Low — below 800 Hz (bass)                                                                                                                                                                                                                                                
  - Mid — 800 Hz to 5000 Hz (vocals, presence)                                                                                                                                                                                                                               
  - High — above 5000 Hz (air, sibilance)                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                             
  How it works under the hood:                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  The crossover frequencies are hardcoded at 800 Hz and 5000 Hz. For each audio sample it runs two 4-pole lowpass filters in series (one tuned to 800 Hz, one to 5000 Hz) using a simple first-order IIR structure. The three bands are then derived by subtraction:         
  - low = output of the 800 Hz lowpass                                                                                                                                                                                                                                     
  - high = delayed input minus the 5000 Hz lowpass output                                                                                                                                                                                                                    
  - mid = delayed input minus high minus low                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                             
  Each band is scaled by its gain multiplier and the three are summed back together. The EQ_EPSILON added each step prevents denormal floating-point values from causing performance issues.                                                                               
                                                                                                                                                                                                                                                                             
  It's intentionally simple — no adjustable crossover frequencies, no shelf or peak filters, just three fixed bands with gain controls.
