### PR TITLE
[3] Go Live Window UI - Changes to shared inputs

### DIFF
--- a/app/components-react/highlighter/Export/ExportModal.tsx
+++ b/app/components-react/highlighter/Export/ExportModal.tsx
@@ -442,7 +442,7 @@ function ExportFlow({
                       { value: '1080', label: '1080p' },
                     ]}
                     onChange={setResolution}
-                    buttons={true}
+                    optionType="button"
                   />
                 </div>
 
@@ -456,7 +456,7 @@ function ExportFlow({
                       { value: '60', label: '60 FPS' },
                     ]}
                     onChange={setFps}
-                    buttons={true}
+                    optionType="button"
                   />
                 </div>
 
@@ -471,7 +471,7 @@ function ExportFlow({
                       { value: 'slow', label: $t('Smaller File') },
                     ]}
                     onChange={setPreset}
-                    buttons={true}
+                    optionType="button"
                   />
                 </div>
               </div>

--- a/app/components-react/shared/inputs/CheckboxInput.tsx
+++ b/app/components-react/shared/inputs/CheckboxInput.tsx
@@ -1,11 +1,11 @@
-import React, { CSSProperties } from 'react';
+import React, { CSSProperties, ReactNode } from 'react';
 import { Checkbox, Tooltip } from 'antd';
 import { InputComponent, TSlobsInputProps, useInput } from './inputs';
 import { CheckboxProps } from 'antd/lib/checkbox';
 import { QuestionCircleOutlined } from '@ant-design/icons';
 
 export type TCheckboxInputProps = TSlobsInputProps<
-  { nolabel?: boolean; className?: string; style?: CSSProperties },
+  { nolabel?: boolean; className?: string; style?: CSSProperties; tooltipIcon?: ReactNode },
   boolean,
   CheckboxProps
 >;
@@ -22,7 +22,7 @@ export const CheckboxInput = InputComponent((p: TCheckboxInputProps) => {
         {p.label}
         {p.tooltip && (
           <Tooltip title={p.tooltip}>
-            <QuestionCircleOutlined style={{ marginLeft: '7px' }} />
+            {p.tooltipIcon ?? <QuestionCircleOutlined style={{ marginLeft: '7px' }} />}
           </Tooltip>
         )}
       </Checkbox>

--- a/app/components-react/shared/inputs/ListInput.tsx
+++ b/app/components-react/shared/inputs/ListInput.tsx
@@ -24,6 +24,7 @@ const ANT_SELECT_FEATURES = [
   'suffixIcon',
   'size',
   'dropdownMatchSelectWidth',
+  'bordered',
 ] as const;
 
 export interface IListGroup<TValue> {
@@ -39,7 +40,7 @@ export interface ICustomListProps<TValue> {
   labelRender?: (opt: IListOption<TValue>) => ReactNode;
   onBeforeSearch?: (searchStr: string) => unknown;
   options?: IListOption<TValue>[] | IListGroup<TValue>[];
-  description?: string;
+  description?: string | ReactNode;
   nolabel?: boolean;
   filter?: string;
 }

--- a/app/components-react/shared/inputs/RadioInput.m.less
+++ b/app/components-react/shared/inputs/RadioInput.m.less
@@ -1,20 +1,17 @@
 @import '../../../styles/index.less';
 
 .icon-radio {
-  flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
+  i.icon-toggle {
+    padding: 0px 1px;
+  }
 
   :global(.ant-row.ant-form-item) {
     margin-right: 0px !important;
   }
 
-  :global(.ant-radio-wrapper::after) {
-    width: inherit;
-  }
-
   :global(.ant-radio-wrapper) {
+    margin: 0px !important;
+
     i {
       color: var(--icon-toggle);
       transition: color 0.3s ease-in-out;
@@ -31,33 +28,77 @@
   }
 
   :global(.ant-radio) {
-    position: absolute;
-    left: -9999px;
-    overflow: hidden;
-  }
-
-  :global(.ant-radio) + * {
-    padding: 0px;
-    overflow: hidden;
+    display: none;
   }
 }
 
-.icon-radio {
+.icon-default:extend(.icon-radio) {
   flex: 1;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
 
-  :global(.ant-row.ant-form-item) {
-    margin-right: 0px !important;
+  &:global(.ant-radio-group.ant-radio-group-outline) {
+    display: flex;
+    align-items: center;
+    margin: 0px 6px !important;
   }
+
+  :global(.ant-radio-wrapper > span) {
+    padding: 0px 3px;
+  }
+
+  :global(.ant-radio-wrapper-checked) {
+    i {
+      transition: unset;
+    }
+  }
+}
+
+.icon-button:extend(.icon-default) {
+  background-color: var(--dark-background) !important;
+  border-radius: 4px;
+  padding: 4px;
 
   :global(.ant-radio-wrapper) {
-    margin: 0px !important;
+    padding: 5px 0px !important;
   }
 
-  i.icon-toggle {
-    padding: 0px 1px;
+  :global(.ant-radio-wrapper):first-child {
+    border-top-left-radius: 4px;
+    border-bottom-left-radius: 4px;
+    border-top-right-radius: unset;
+    border-bottom-right-radius: unset;
+  }
+
+  :global(.ant-radio-wrapper):last-child {
+    border-top-left-radius: unset;
+    border-bottom-left-radius: unset;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+  }
+
+  :global(.ant-radio-wrapper-checked) {
+    background-color: var(--button);
+
+    i {
+      transition: unset;
+    }
+  }
+}
+
+.icons-left {
+  text-align: left;
+}
+
+.icons-center {
+  text-align: center;
+}
+
+.icons-right {
+  text-align: right;
+}
+
+.nomargin {
+  &:global(.ant-form-item) {
+    margin: 0 !important;
   }
 }
 

--- a/app/components-react/shared/inputs/RadioInput.tsx
+++ b/app/components-react/shared/inputs/RadioInput.tsx
@@ -20,8 +20,8 @@ interface ICustomRadioGroupProps {
   label?: string;
   nolabel?: boolean;
   nowrap?: boolean;
+  nomargin?: boolean;
   options: ICustomRadioOption[];
-  buttons?: boolean;
   icons?: boolean;
   style?: CSSProperties;
   value?: string;
@@ -29,6 +29,9 @@ interface ICustomRadioGroupProps {
   disabled?: boolean;
   className?: string;
   gapsize?: number;
+  alignIcons?: 'left' | 'center' | 'right';
+  optionType?: 'default' | 'button';
+  filled?: boolean;
 }
 
 type TRadioInputProps = TSlobsInputProps<ICustomRadioGroupProps, string, {}>;
@@ -41,13 +44,22 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
     ...pick(p, 'name'),
   };
 
+  const optionType = p.optionType ?? 'default';
+
   return (
     <InputWrapper
       {...wrapperAttrs}
       data-title={p.label}
-      className={cx({ [styles.defaultRadio]: !p.buttons && !p.icons })}
+      nolabel={p.nolabel}
+      className={cx({
+        [styles.defaultRadio]: optionType === 'default' && !p.icons,
+        [styles.iconsLeft]: p.alignIcons === 'left',
+        [styles.iconsCenter]: p.alignIcons === 'center',
+        [styles.iconsRight]: p.alignIcons === 'right',
+        [styles.nomargin]: p.nomargin,
+      })}
     >
-      {p.buttons && (
+      {optionType === 'button' && !p.icons && (
         <Radio.Group
           {...inputProps}
           data-title={p.label}
@@ -56,7 +68,6 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           onChange={e => p.onChange && p.onChange(e.target.value)}
           options={p.options}
           optionType="button"
-          buttonStyle="solid"
           disabled={p.disabled}
           className={p.className}
           style={p?.style}
@@ -70,9 +81,14 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           value={p.value}
           defaultValue={p.defaultValue}
           onChange={e => p.onChange && p.onChange(e.target.value)}
-          className={cx(p.className, styles.iconRadio)}
+          className={cx(p.className, styles.iconRadio, {
+            [styles.iconDefault]: optionType === 'default',
+            [styles.iconButton]: optionType === 'button',
+            [styles.filled]: p.filled,
+          })}
           style={p?.style}
           disabled={p.disabled}
+          optionType={p.optionType}
         >
           {p.options.map((option: ICustomRadioOption) => {
             return (
@@ -94,7 +110,7 @@ export const RadioInput = InputComponent((p: TRadioInputProps) => {
           })}
         </Radio.Group>
       )}
-      {!p.icons && !p.buttons && (
+      {!p.icons && optionType === 'default' && (
         <Radio.Group
           {...inputProps}
           data-title={p.label}

--- a/app/components-react/shared/inputs/SwitchInput.tsx
+++ b/app/components-react/shared/inputs/SwitchInput.tsx
@@ -17,6 +17,7 @@ export type TSwitchInputProps = TSlobsInputProps<
     size?: 'small' | 'default';
     color?: 'primary' | 'secondary';
     nolabel?: boolean;
+    nomargin?: boolean;
     checkmark?: boolean;
     skipWrapperAttrs?: boolean;
   },
@@ -49,7 +50,8 @@ export const SwitchInput = InputComponent((p: TSwitchInputProps) => {
           size={size}
           {...inputAttrs}
           ref={p.inputRef}
-          className={cx(styles.horizontal, styles.horizontalItem, {
+          className={cx({
+            [styles.horizontal]: !p?.nomargin,
             [styles.checkmark]: p?.checkmark,
             [styles.secondarySwitch]: p?.color === 'secondary',
             [styles.noLabel]: p?.nolabel,

--- a/app/components-react/shared/inputs/inputs.ts
+++ b/app/components-react/shared/inputs/inputs.ts
@@ -51,6 +51,7 @@ export interface IInputCommonProps<TValue> {
   onInput?: (val: TValue, ev?: ChangeEvent | CheckboxChangeEvent) => unknown;
   required?: boolean;
   max?: number;
+  min?: number;
   placeholder?: string;
   disabled?: boolean;
   readOnly?: boolean;
@@ -397,11 +398,20 @@ function createValidationRules(type: TInputType, inputProps: IInputCommonProps<u
   if (inputProps.required) {
     rules.push({ required: true, message: $t('The field is required') });
   }
-  if (type === 'text' && inputProps.max) {
+  if ((type === 'text' || type === 'textarea') && inputProps.max) {
     rules.push({
       max: inputProps.max,
       message: $t('This field may not be greater than %{value} characters.', {
         value: inputProps.max,
+      }),
+    });
+  }
+  if ((type === 'text' || type === 'textarea') && inputProps.min) {
+    rules.push({
+      type: 'string',
+      min: inputProps.min,
+      message: $t('This field must be at least %{value} characters.', {
+        value: inputProps.min,
       }),
     });
   }


### PR DESCRIPTION
# Go Live Window Shared Input Components

## Summary

- Update RadioInput with filled variant and new styling options
- Add props to CheckboxInput, SwitchInput, and ListInput
- Add input utility types to `inputs.ts`

## Source Commits

| Commit      | Message                                  | What it touched                          |
| ----------- | ---------------------------------------- | ---------------------------------------- |
| `179516838` | Update shared components.                | CheckboxInput, ListInput, RadioInput (tsx + less), SwitchInput |
| `48683ca4c` | Update components.                       | RadioInput.m.less, RadioInput.tsx        |
| `97d23a967` | Recording Switcher styling.              | RadioInput.m.less                        |
| `b7c68b8ea` | Remove patreon stream shift limitation.  | inputs.ts                                |

## Files Changed

| File                                               | Change                                          |
| -------------------------------------------------- | ----------------------------------------------- |
| `app/components-react/shared/inputs/RadioInput.tsx` | Add filled variant, new props                   |
| `app/components-react/shared/inputs/RadioInput.m.less` | Filled variant styling, theme-aware colors   |
| `app/components-react/shared/inputs/CheckboxInput.tsx` | Add styling props                            |
| `app/components-react/shared/inputs/ListInput.tsx` | Add props                                       |
| `app/components-react/shared/inputs/SwitchInput.tsx` | Add styling props                              |
| `app/components-react/shared/inputs/inputs.ts`     | Add input utility types                          |

## Performance Implications

None. Component prop additions and styling changes only.
