### PR TITLE
[5] Go Live Window UI - Service Changes (UI Independent)

### DIFF
--- a/app/components-react/root/StartStreamingButton.tsx
+++ b/app/components-react/root/StartStreamingButton.tsx
@@ -227,7 +227,7 @@ function StartStreamingButton(p: { disabled?: boolean }) {
               secondaryActionText: $t('Force Start'),
               secondaryActionFn: async () => {
                 // FIXME: this should actually do something server-side
-                RestreamService.actions.return.forceStreamShiftGoLive(true);
+                RestreamService.actions.return.forceStreamShiftGoLive();
                 shouldForceGoLive = true;
               },
             });

--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -49,7 +49,13 @@ export function DestinationSwitchers() {
     return unlinkedAlwaysShownPlatforms.length
       ? linkedPlatforms.concat(unlinkedAlwaysShownPlatforms)
       : linkedPlatforms;
-  }, [linkedPlatforms, enabledPlatformsRef.current, isDualOutputMode, isPrime]);
+  }, [
+    linkedPlatforms,
+    enabledPlatformsRef.current,
+    isDualOutputMode,
+    isPrime,
+    alwaysShownPlatforms,
+  ]);
 
   // Disable custom destination switchers when restream is not available
   // or for a non-ultra user is in single output mode. The one exception

--- a/app/components-react/windows/go-live/GoLiveWindow.tsx
+++ b/app/components-react/windows/go-live/GoLiveWindow.tsx
@@ -95,7 +95,7 @@ function ModalFooter() {
     },
 
     async forceStreamShiftGoLive() {
-      this.restreamService.actions.forceStreamShiftGoLive(true);
+      this.restreamService.actions.forceStreamShiftGoLive();
     },
 
     get hasIncompatibleCodec() {

--- a/app/services/incremental-rollout.ts
+++ b/app/services/incremental-rollout.ts
@@ -26,7 +26,7 @@ export enum EAvailableFeatures {
   streamShift = 'slobs--stream-shift',
   twitchDualStream = 'slobs--twitch-dual-stream',
   twitchDualStreamPreview = 'slobs--twitch-dual-stream-preview',
-  patreon = 'slobs--patreon',
+  liveOutputEditing = 'slobs--live-output-editing',
 
   /**
    * There are two flags because one is used for beta access and

--- a/app/services/platforms/kick.ts
+++ b/app/services/platforms/kick.ts
@@ -212,6 +212,10 @@ export class KickService
   }
 
   async afterStopStream(): Promise<void> {
+    if (this.state.platformId) {
+      await this.endStream(this.state.platformId);
+    }
+
     // clear server url and stream key
     this.SET_INGEST('');
     this.SET_STREAM_KEY('');
@@ -380,7 +384,7 @@ export class KickService
         console.warn('Error fetching Kick info: ', e);
 
         if (e.result && e.result.data.code === 401) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
+          const message = e.statusText || e.result.data.message;
           throwStreamError(
             'KICK_SCOPE_OUTDATED',
             {
@@ -391,6 +395,22 @@ export class KickService
             e.result.data.message,
           );
         }
+
+        let message = e.message ?? 'Unknown error fetching Kick info';
+        if (e.result) {
+          message = e.statusText || e.result.data.message;
+        }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'kick',
+          },
+          details,
+        );
       });
   }
 
@@ -480,6 +500,23 @@ export class KickService
       })
       .catch((e: unknown) => {
         console.warn('Error updating Kick channel info', e);
+
+        const err = e as any;
+        let message = err?.message ?? 'Unknown error updating Kick channel info';
+        if (err?.result) {
+          message = err.statusText || err.result.data.message;
+        }
+        const details = err?.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: err?.status,
+            statusText: message,
+            platform: 'kick',
+          },
+          details,
+        );
       });
   }
 

--- a/app/services/platforms/patreon.ts
+++ b/app/services/platforms/patreon.ts
@@ -22,6 +22,7 @@ export interface IPatreonStartStreamOptions {
   title: string;
   description: string;
   accessRules: string[];
+  campaignId: string;
 }
 
 interface IPatreonStartStreamSettings {
@@ -94,7 +95,6 @@ interface IPatreonError {
 interface IPatreonServiceState extends IPlatformState {
   settings: IPatreonStartStreamSettings;
   ingest: string;
-  campaignId: string;
   accessRules: { key: string; value: string }[];
   broadcastId: string;
   platformId: string;
@@ -109,7 +109,6 @@ export class PatreonService
     ...BasePlatformService.initialState,
     settings: { title: '', description: '', campaignId: '', accessRules: [], mode: 'landscape' },
     ingest: '',
-    campaignId: '',
     accessRules: [],
     broadcastId: '',
     platformId: '',
@@ -172,7 +171,7 @@ export class PatreonService
     }
 
     const streamInfo = (await this.startStream(
-      goLiveSettings.platforms.patreon ?? this.state.settings,
+      patreonSettings ?? this.state.settings,
     )) as IPatreonStartStreamResponse;
 
     this.SET_INGEST(streamInfo.rtmp);
@@ -247,13 +246,22 @@ export class PatreonService
         const info = res as IPatreonStreamInfoResponse;
 
         if (info.campaigns.length) {
-          this.SET_CAMPAIGN_ID(info.campaigns[0].key.toString());
-          this.SET_CHANNEL_NAME(info.campaigns[0].value);
+          const campaigns = await Promise.all(info.campaigns.map(campaign => campaign));
+
+          // Set campaign id in stream settings and channel name in state
+          const streamSettings = {
+            ...this.state.settings,
+            campaignId: campaigns[0].key.toString(),
+          };
+          this.SET_STREAM_SETTINGS(streamSettings);
+          this.SET_CHANNEL_NAME(campaigns[0].value);
         }
 
         if (info.accessRules.length) {
-          this.SET_ACCESS_RULES(info.accessRules);
+          const accessRules = await Promise.all(info.accessRules.map(rule => rule));
+          this.SET_ACCESS_RULES(accessRules);
         }
+
         return EPlatformCallResult.Success;
       })
       .catch((e: unknown) => {
@@ -272,29 +280,34 @@ export class PatreonService
     const body = new FormData();
     body.append('title', opts.title);
     body.append('description', opts.description);
-    body.append('campaign_id', this.state.campaignId);
+    body.append('campaign_id', opts.campaignId);
     opts.accessRules.forEach(rule => body.append('access_rules[]', rule));
     body.append('state', 'live');
 
     const request = new Request(url, { headers, method: 'POST', body });
 
     return jfetch<IPatreonStartStreamResponse | IPatreonError>(request)
-      .then(async res => res)
+      .then(async res => {
+        return res;
+      })
       .catch(e => {
         console.warn('Error starting Patreon stream: ', e);
 
+        let message = e.message ?? 'Unknown error starting Patreon stream';
         if (e.result) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
-          throwStreamError(
-            'PLATFORM_REQUEST_FAILED',
-            {
-              status: e.status,
-              statusText: message,
-              platform: 'patreon',
-            },
-            e.result.data.message,
-          );
+          message = e.statusText || e.result.data.message;
         }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'patreon',
+          },
+          details,
+        );
       });
   }
 
@@ -311,22 +324,27 @@ export class PatreonService
     const request = new Request(url, { method: 'POST', headers });
 
     return jfetch<IPatreonEndStreamResponse | IPatreonError>(request)
-      .then(async res => res)
+      .then(async res => {
+        return res;
+      })
       .catch(e => {
         console.warn('Error ending Patreon stream: ', e);
 
+        let message = e.message ?? 'Unknown error ending Patreon stream';
         if (e.result) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
-          throwStreamError(
-            'PLATFORM_REQUEST_FAILED',
-            {
-              status: e.status,
-              statusText: message,
-              platform: 'patreon',
-            },
-            e.result.data.message,
-          );
+          message = e.statusText || e.result.data.message;
         }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'patreon',
+          },
+          details,
+        );
       });
   }
 
@@ -381,11 +399,6 @@ export class PatreonService
   @mutation()
   SET_INGEST(ingest: string) {
     this.state.ingest = ingest;
-  }
-
-  @mutation()
-  SET_CAMPAIGN_ID(campaignId: string) {
-    this.state.campaignId = campaignId;
   }
 
   @mutation()

--- a/app/services/platforms/tiktok.ts
+++ b/app/services/platforms/tiktok.ts
@@ -741,7 +741,7 @@ export class TikTokService
     const isFrequentUser = this.diagnosticsService.isFrequentUser;
     if (isOldAccount && !isTikTokLinked && isFrequentUser) return true;
 
-    return false;
+    return this.getHasScope('never-applied') || this.getHasScope('denied');
   }
 
   get promptReapply(): boolean {

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -4,7 +4,11 @@ import { HostsService } from 'services/hosts';
 import { getPlatformService, TPlatform } from 'services/platforms';
 import { StreamSettingsService } from 'services/settings/streaming';
 import { UserService } from 'services/user';
-import { CustomizationService, ICustomizationServiceState } from 'services/customization';
+import {
+  CustomizationService,
+  CustomizationState,
+  ICustomizationServiceState,
+} from 'services/customization';
 import { authorizedHeaders, jfetch } from 'util/requests';
 import electron from 'electron';
 import { StreamingService } from './streaming';
@@ -20,6 +24,7 @@ import { PlatformAppsService } from './platform-apps';
 import { DualOutputService } from 'services/dual-output';
 import { SettingsService } from 'services/settings';
 import { throwStreamError } from './streaming/stream-error';
+import { Subject } from 'rxjs';
 import uuid from 'uuid';
 import Utils from './utils';
 import { $t } from './i18n';
@@ -143,6 +148,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
   settings: IUserSettingsResponse;
 
   preferences = RestreamPreferences.inject();
+
+  isLive = new Subject<boolean>();
 
   static initialState: IRestreamState = {
     enabled: true,
@@ -630,6 +637,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
       this.SET_STREAM_SWITCHER_TARGETS([]);
     }
 
+    this.isLive.next(status.isLive);
     return status.isLive;
   }
 
@@ -656,8 +664,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
 
     const request = new Request(url, { headers, method: 'GET' });
 
-    return jfetch(request)
-      .then((res: { [key: string]: ITargetLiveData[] }) => {
+    return jfetch<{ [key: string]: ITargetLiveData[] }>(request)
+      .then(res => {
         const targets = this.state.streamShiftTargets.reduce((targetData: ITargetLiveData[], t) => {
           const platform = t.platform as string;
           if (t.platform !== 'relay') {
@@ -754,6 +762,12 @@ export class RestreamService extends StatefulService<IRestreamState> {
     return fetch(request).then(res => res.json());
   }
 
+  async deleteTargets() {
+    const targets = await this.fetchTargets();
+    const promises = targets.map(t => this.deleteTarget(t.id));
+    await Promise.all(promises);
+  }
+
   /**
    * Stream Shift
    */
@@ -766,6 +780,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     this.SET_STREAM_SWITCHER_STATUS('inactive');
     this.SET_STREAM_SWITCHER_STREAM_ID();
     this.SET_STREAM_SWITCHER_TARGETS([]);
+    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(false);
   }
 
   async confirmStreamShift(action: TStreamShiftAction) {
@@ -823,13 +838,32 @@ export class RestreamService extends StatefulService<IRestreamState> {
     }
   }
 
-  forceStreamShiftGoLive(shouldForce: boolean) {
-    if (shouldForce) {
+  async forceStreamShiftGoLive() {
+    this.streamSettingsService.setGoLiveSettings({ streamShift: false });
+    await this.deleteTargets();
+    this.SET_STREAM_SWITCHER_STATUS('inactive');
+    this.SET_STREAM_SWITCHER_STREAM_ID();
+    this.SET_STREAM_SWITCHER_TARGETS([]);
+    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(true);
+  }
+
+  /**
+   * Test helper to emit isLive for testing purposes
+   * @param isLive - Whether the stream is live or not
+   * @remarks This is only used for testing purposes. It should not be used in production code.
+   */
+  emitIsLiveForTest(isLive: boolean): void {
+    if (!Utils.isTestMode()) return;
+
+    if (isLive) {
+      this.streamSettingsService.setGoLiveSettings({ streamShift: true });
+      this.SET_STREAM_SWITCHER_STATUS('pending');
+    } else {
       this.streamSettingsService.setGoLiveSettings({ streamShift: false });
       this.SET_STREAM_SWITCHER_STATUS('inactive');
     }
 
-    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(shouldForce);
+    this.isLive.next(isLive);
   }
 
   /* Chat Handling
@@ -890,7 +924,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     });
 
     this.customizationService.settingsChanged.subscribe(
-      (changed: Partial<ICustomizationServiceState>) => {
+      (changed: DeepPartial<CustomizationState>) => {
         this.handleSettingsChanged(changed);
       },
     );
@@ -908,7 +942,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     this.chatView = null;
   }
 
-  private handleSettingsChanged(changed: Partial<ICustomizationServiceState>) {
+  private handleSettingsChanged(changed: DeepPartial<ICustomizationServiceState>) {
     if (!this.chatView) return;
     if (changed.chatZoomFactor) {
       this.chatView.webContents.setZoomFactor(changed.chatZoomFactor);
@@ -953,7 +987,7 @@ class RestreamView extends ViewHandler<IRestreamState> {
     return this.state.streamShiftTargets.length > 0;
   }
 
-  get shouldForceGoLive() {
+  get streamShiftForceGoLive() {
     return this.state.streamShiftForceGoLive;
   }
 }

--- a/app/services/settings/streaming/stream-settings.ts
+++ b/app/services/settings/streaming/stream-settings.ts
@@ -25,6 +25,7 @@ export interface ISavedGoLiveSettings {
   advancedMode: boolean;
   recording?: TDisplayOutput;
   streamShift?: boolean;
+  liveOutputEditing?: boolean;
 }
 
 export interface ICustomStreamDestination {
@@ -212,6 +213,8 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
   }
 
   setGoLiveSettings(settingsPatch: Partial<IGoLiveSettings>) {
+    if (!settingsPatch) return;
+
     // transform IGoLiveSettings to ISavedGoLiveSettings
     const patch: Partial<ISavedGoLiveSettings> = settingsPatch;
     if (settingsPatch.platforms) {
@@ -223,11 +226,10 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
         const platformSettings = pick(settingsPatch.platforms![platform], pickedFields);
 
         if (this.streamingService.views.isDualOutputMode) {
-          this.videoSettingsService.validateVideoContext();
           const display = this.streamingService.views.getPlatformDisplayType(platform as TPlatform);
           platformSettings.video = this.videoSettingsService.contexts[display];
         }
-        return (platforms[platform] = platformSettings);
+        platforms[platform] = platformSettings;
       });
       patch.platforms = platforms as ISavedGoLiveSettings['platforms'];
     }

--- a/app/services/streaming/streaming-api.ts
+++ b/app/services/streaming/streaming-api.ts
@@ -86,6 +86,7 @@ export interface IStreamSettings {
   recording: TDisplayOutput;
   streamShift?: boolean;
   enhancedBroadcasting?: boolean;
+  liveOutputEditing?: boolean;
 }
 
 export interface IGoLiveSettings extends IStreamSettings {

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -130,11 +130,7 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
    * Returns a sorted list of all platforms (linked and unlinked)
    */
   get allPlatforms(): TPlatform[] {
-    const platforms = !this.incrementalRolloutService.featureIsEnabled(EAvailableFeatures.patreon)
-      ? platformList.filter(p => p !== 'patreon')
-      : platformList;
-
-    return this.getSortedPlatforms(platforms);
+    return this.getSortedPlatforms(platformList);
   }
 
   /**

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -667,7 +667,7 @@ export class StreamingService
      * SET MULTISTREAM SETTINGS
      */
     // TODO: remove after server-side impl
-    this.restreamService.actions.forceStreamShiftGoLive(false);
+    this.restreamService.actions.forceStreamShiftGoLive();
     if (this.views.shouldSetupRestream) {
       // In single output mode, this sets up multistreaming
       // In dual output mode, this sets up streaming displays to multiple targets
@@ -1616,7 +1616,7 @@ export class StreamingService
       }
     } else {
       // In dual output mode without enhanced broadcasting, create the horizontal streaming instance after the vertical stream
-      // has started. The start streaming promise resolves when the vertical stream starts because the vertical stream is the
+      // has started. The start streaming promise resolves when the horizontal stream starts because the horizontal stream is the
       // last streaming instance created
       if (context === 'vertical') {
         await this.validateOrCreateOutputInstance({
@@ -1633,6 +1633,13 @@ export class StreamingService
         // Only resolve the start streaming promise after the horizontal stream has started to prevent unintended side effects of duplicate
         // actions taken after starting the stream
         await this.handleStartStreaming(code, context);
+
+        if (this.state.status.vertical.streaming === EStreamingState.Starting) {
+          // The horizontal stream has started but the vertical stream status is still `Starting`. Update the vertical streaming status here,
+          // instead of when the vertical stream actually starts, to prevent a race condition where the UI might show all streams as `Live`
+          // when some streams may be still in the process of starting.
+          this.SET_STREAMING_STATUS(EStreamingState.Live, 'vertical', time);
+        }
       }
     }
   }

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -60,7 +60,8 @@ export type TAnalyticsEvent =
   | 'Onboarding'
   | 'WidgetAdded'
   | 'WidgetRemoved'
-  | 'GamePulse';
+  | 'GamePulse'
+  | 'LiveOutputEditing';
 
 // Refls are used as uuids for ultra components and should be updated for new ulta components.
 export type TUltraRefl =
@@ -78,6 +79,7 @@ export type TUltraRefl =
   | 'slobs-multistream-settings'
   | 'slobs-multistream'
   | 'slobs-stream-settings'
+  | 'slobs-live-output-editing'
   | string;
 
 interface IAnalyticsEvent {

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -624,6 +624,15 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     return EPlatformCallResult.Success;
   }
 
+  /**
+   * Remove a dummy account that was previously added via addDummyAccount.
+   * @remark Use for tests to unlink a platform from the local state.
+   */
+  removeDummyAccount(platform: TPlatform): void {
+    if (!Utils.isTestMode()) return;
+    this.UNLINK_PLATFORM(platform);
+  }
+
   async autoLogin() {
     if (!this.state.auth) return;
 

--- a/app/services/websocket.ts
+++ b/app/services/websocket.ts
@@ -9,6 +9,7 @@ import { IRecentEvent, ISafeModeServerSettings } from 'services/recent-events';
 import { importSocketIOClient } from '../util/slow-imports';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { TPlatform } from './platforms';
+import Utils from './utils';
 
 export type TSocketEvent =
   | IStreamlabelsSocketEvent
@@ -243,6 +244,11 @@ export class WebsocketService extends Service {
           this.socketEvent.next(e);
         });
       });
+  }
+
+  sendSocketEventForTest(event: TSocketEvent): void {
+    if (!Utils.isTestMode()) return;
+    this.socketEvent.next(event);
   }
 
   disconnect() {


### PR DESCRIPTION
# Go Live Window Service Layer Updates

## Summary

- Update restream service with stream shift toggling consolidation and event support
- Fix swallowed errors in Patreon and Kick platform services
- Add live output editing flag and stream shift event support
- Update callers of `forceStreamShiftGoLive` to match new signature

## Source Commits

### Full file changes from original commits

| File | Source commits |
| ---- | -------------- |
| `app/services/platforms/kick.ts` | `647a35f14` Fix swallowed errors for patreon and kick, `4e4f899d6` Fix for strictnulls |
| `app/services/platforms/patreon.ts` | `647a35f14` Fix swallowed errors for patreon and kick, `b7c68b8ea` Remove patreon stream shift limitation |
| `app/services/platforms/tiktok.ts` | `0476f507f` Fix TikTok test and apply prompt showing twice |
| `app/services/streaming/streaming-api.ts` | `9d717c276` Add toggling live output editing |
| `app/services/settings/streaming/stream-settings.ts` | `e634c78a8` Add custom destinations to tests, `9d717c276` Add toggling live output editing, `f47911137` Fix toggle multiple platforms, `89fba840b` Fix dual output mode |
| `app/services/incremental-rollout.ts` | `021b69334` Update services |
| `app/services/usage-statistics.ts` | `24c0796e1` Consolidate getters in go live module and fix styling |
| `app/services/user/index.ts` | `23cd21ce6` WIP: Go Live window tests |
| `app/services/websocket.ts` | `b420be0f0` Add events and live status to Stream Shift test |

### Partial file changes (subset of original commits, rest deferred to later PRs)

| File | Included from | Deferred |
| ---- | ------------- | -------- |
| `app/services/restream.ts` | `318c70bc4` `89fba840b` `fcbb968f1` `b420be0f0` `5d01c81f2` | Minor diff — 1 removed arg from `forceStreamShiftGoLive` call |
| `app/services/streaming/streaming.ts` | `021b69334` `318c70bc4` `db3f7de7d` `501db2818` `850f2a406` | Larger streaming refactor deferred to Go Live UI PRs |
| `app/services/streaming/streaming-view.ts` | `850f2a406` | Larger streaming-view refactor deferred to Go Live UI PRs |
| `app/components-react/root/StartStreamingButton.tsx` | `318c70bc4` `b420be0f0` `b7c68b8ea` `0a950b886` | Larger refactor deferred to Go Live UI PRs |
| `app/components-react/windows/go-live/DestinationSwitchers.tsx` | `48683ca4c` `a90829c2c` `f47911137` `bafb4f0e7` `24c0796e1` `bcc210401` `10715b3cf` `a0bf4ae0c` `b7c68b8ea` `55adeaccc` `85a53d745` `44ba46186` `e634c78a8` | Larger refactor deferred to Go Live UI PRs |
| `app/components-react/windows/go-live/GoLiveWindow.tsx` | `48683ca4c` `318c70bc4` `89fba840b` `fcbb968f1` `10715b3cf` `55adeaccc` `e0962e3bd` `44ba46186` | Larger refactor deferred to Go Live UI PRs |

### New code (not from original commits)

| File | Change |
| ---- | ------ |
| `app/components-react/root/StartStreamingButton.tsx` | Remove `true` arg from `forceStreamShiftGoLive(true)` to match new restream signature |
| `app/components-react/windows/go-live/GoLiveWindow.tsx` | Remove `true` arg from `forceStreamShiftGoLive(true)` to match new restream signature |
| `app/components-react/windows/go-live/DestinationSwitchers.tsx` | Add `alwaysShownPlatforms` to useMemo deps |

## Files Changed

| File                                                             | Change                                               |
| ---------------------------------------------------------------- | ---------------------------------------------------- |
| `app/services/restream.ts`                                       | Stream shift toggling consolidation, event support (partial) |
| `app/services/platforms/kick.ts`                                 | Fix swallowed errors, strictnull fix                 |
| `app/services/platforms/patreon.ts`                              | Fix swallowed errors, stream shift limitation changes |
| `app/services/platforms/tiktok.ts`                               | Fix apply prompt showing twice                       |
| `app/services/streaming/streaming-api.ts`                        | Add live output editing flag                         |
| `app/services/streaming/streaming.ts`                            | Minor streaming fixes (partial)                      |
| `app/services/streaming/streaming-view.ts`                       | Minor view fixes (partial)                           |
| `app/services/settings/streaming/stream-settings.ts`             | Stream shift settings, custom destinations           |
| `app/services/incremental-rollout.ts`                            | Minor update                                         |
| `app/services/usage-statistics.ts`                               | Consolidate getters                                  |
| `app/services/user/index.ts`                                     | Add test support methods                             |
| `app/services/websocket.ts`                                      | Add stream shift event support                       |
| `app/components-react/root/StartStreamingButton.tsx`             | Update `forceStreamShiftGoLive` call signature (partial) |
| `app/components-react/windows/go-live/DestinationSwitchers.tsx`  | Add missing useMemo dependency (partial)             |
| `app/components-react/windows/go-live/GoLiveWindow.tsx`          | Update `forceStreamShiftGoLive` call signature (partial) |

## Performance Implications

None. Service logic refactoring with no added overhead.
