### PR TITLE
[6] Go Live Window UI - Stream shift toggle changes

### DIFF
--- a/app/components-react/modals.tsx
+++ b/app/components-react/modals.tsx
@@ -1,5 +1,5 @@
 import { Services } from './service-provider';
-import { Modal, Button } from 'antd';
+import { Modal, Button, message } from 'antd';
 import Utils from '../services/utils';
 import { ModalFuncProps } from 'antd/lib/modal';
 import { $t } from '../services/i18n';
@@ -172,6 +172,33 @@ export function promptAction(p: {
     ),
     width: 600,
   });
+}
+
+export function alertInfo({
+  name,
+  text,
+  duration,
+}: {
+  name: string;
+  text: string;
+  duration?: number;
+}) {
+  message.info({
+    key: name,
+    content: <AlertContent name={name} message={text} />,
+    className: styles.infoAlert,
+    onClick: () => message.destroy(name),
+    duration,
+  });
+}
+
+export function AlertContent(p: { name: string; message: string }) {
+  return (
+    <div className={styles.alertContent} data-name={p.name}>
+      <div>{p.message}</div>
+      <i className="icon-close" />
+    </div>
+  );
 }
 
 export function DefaultPromptForm(

--- a/app/components-react/root/StartStreamingButton.tsx
+++ b/app/components-react/root/StartStreamingButton.tsx
@@ -227,7 +227,7 @@ function StartStreamingButton(p: { disabled?: boolean }) {
               secondaryActionText: $t('Force Start'),
               secondaryActionFn: async () => {
                 // FIXME: this should actually do something server-side
-                RestreamService.actions.return.forceStreamShiftGoLive(true);
+                RestreamService.actions.return.forceStreamShiftGoLive();
                 shouldForceGoLive = true;
               },
             });

--- a/app/components-react/shared/StreamShiftToggle.m.less
+++ b/app/components-react/shared/StreamShiftToggle.m.less
@@ -1,18 +1,12 @@
 .stream-shift-wrapper {
   display: inline-flex;
   align-items: center;
+  width: 100%;
 }
 
 .stream-shift-toggle {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  font-size: 14px;
-  color: var(--title);
-
-  :global(.ant-checkbox-wrapper) {
-    align-items: flex-start;
-  }
+  color: var(--title) !important;
 }
 
 .label-ultra-badge {
@@ -20,6 +14,25 @@
   align-items: center;
 }
 
+.label-checkbox {
+  width: 100%;
+  text-wrap: nowrap;
+
+  &.ultra {
+    align-self: baseline;
+  }
+}
+
+.tooltip {
+  display: flex;
+  align-items: center;
+}
+
 .beta-badge {
-  margin: 1px 0 0 8px !important;
+  margin-left: 10px;
+}
+
+.ultra-icon {
+  margin-right: 5px;
+  overflow: visible;
 }

--- a/app/components-react/shared/StreamShiftToggle.tsx
+++ b/app/components-react/shared/StreamShiftToggle.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useEffect } from 'react';
+import React, { CSSProperties, useEffect, useMemo } from 'react';
 import { shell } from '@electron/remote';
 import styles from './StreamShiftToggle.m.less';
 import Tooltip from 'components-react/shared/Tooltip';
@@ -17,7 +17,15 @@ interface IStreamShiftToggle {
 }
 
 export default function StreamShiftToggle(p: IStreamShiftToggle) {
-  const { isPrime, isStreamShiftMode, setStreamShift } = useGoLiveSettings();
+  const {
+    isPrime,
+    isStreamShiftMode,
+    setStreamShift,
+    isDualOutputMode,
+    isPatreonEnabled,
+    isStreamShiftDisabled,
+    forceStreamShiftToggleEnabled,
+  } = useGoLiveSettings();
 
   useEffect(() => {
     // Ensure that non-ultra users have the stream switcher disabled
@@ -26,14 +34,35 @@ export default function StreamShiftToggle(p: IStreamShiftToggle) {
     }
   }, [isPrime, isStreamShiftMode]);
 
-  const value = p?.disabled ? false : isStreamShiftMode;
   const label = $t('Stream Shift');
 
-  function handleTooltipClick() {
-    shell.openExternal(
-      'https://streamlabs.com/content-hub/post/how-to-use-streamlabs-stream-shift',
-    );
+  function handleToggleStreamShift(status?: boolean) {
+    if (disableToggle) return;
+    const newStatus = status ?? !isStreamShiftMode;
+    setStreamShift(newStatus);
+    Services.UsageStatisticsService.actions.recordAnalyticsEvent('StreamShift', {
+      toggle: newStatus,
+    });
   }
+
+  const isStreamShiftEnabled = useMemo(() => {
+    return isPatreonEnabled ? false : isStreamShiftMode;
+  }, [isPatreonEnabled, isStreamShiftMode]);
+
+  const disableToggle = useMemo(() => {
+    if (p?.disabled) return true;
+    if (!isPrime) return true;
+    if (isPatreonEnabled) return true;
+    if (isDualOutputMode && !forceStreamShiftToggleEnabled) return true;
+    return isStreamShiftDisabled;
+  }, [
+    p?.disabled,
+    isPatreonEnabled,
+    isDualOutputMode,
+    forceStreamShiftToggleEnabled,
+    isPrime,
+    isStreamShiftDisabled,
+  ]);
 
   return (
     <div className={styles.streamShiftWrapper}>
@@ -43,6 +72,7 @@ export default function StreamShiftToggle(p: IStreamShiftToggle) {
           label={
             !isPrime ? (
               <div
+                data-name="shift-ultra-icon"
                 className={styles.labelUltraBadge}
                 onClick={() => {
                   Services.MagicLinkService.actions.linkToPrime('slobs-streamswitcher', {
@@ -50,41 +80,80 @@ export default function StreamShiftToggle(p: IStreamShiftToggle) {
                   });
                 }}
               >
-                <UltraIcon type="badge" style={{ marginRight: '5px' }} />
-                {label}
+                <UltraIcon type="badge" className={styles.ultraIcon} />
+                <div className={cx(styles.labelCheckbox, styles.ultra)}>{label}</div>
               </div>
             ) : (
-              <>{label}</>
+              <div className={styles.labelCheckbox} onClick={() => handleToggleStreamShift()}>
+                {label}
+              </div>
             )
           }
           name="streamShift"
-          value={value}
-          onChange={(status: boolean) => {
-            setStreamShift(status);
-            Services.UsageStatisticsService.actions.recordAnalyticsEvent('StreamShift', {
-              toggle: status,
-            });
-          }}
-          disabled={p?.disabled}
+          value={isStreamShiftEnabled}
+          onChange={handleToggleStreamShift}
+          disabled={disableToggle}
         />
 
         <Tooltip
-          title={
-            <span onClick={handleTooltipClick}>
-              {$t(
-                'Stay uninterrupted by switching between devices mid stream. Works between Desktop and Mobile App.',
-              )}
-              <a style={{ marginLeft: 4 }}>{$t('Learn More')}</a>
-            </span>
-          }
+          title={<StreamShiftTooltip />}
           placement="top"
           lightShadow={true}
-          disabled={p?.disabled}
+          className={styles.tooltip}
         >
-          <i className="icon-information" style={{ marginLeft: '10px' }} />
+          <i className="icon-information" />
         </Tooltip>
       </div>
       <Badge className={styles.betaBadge} content={'Beta'} />
     </div>
+  );
+}
+
+function StreamShiftTooltip() {
+  const {
+    isPrime,
+    isDualOutputMode,
+    isPatreonEnabled,
+    forceStreamShiftToggleEnabled,
+  } = useGoLiveSettings();
+
+  const tooltipText = useMemo(() => {
+    if (!isPrime) {
+      return { name: 'not-ultra', text: $t('Upgrade to Ultra to switch streams between devices.') };
+    }
+
+    if (isPatreonEnabled) {
+      return { name: 'patreon', text: $t('Stream Shift cannot be used with Patreon') };
+    }
+
+    if (isDualOutputMode && !forceStreamShiftToggleEnabled) {
+      return { name: 'dual-output', text: $t('Stream Shift cannot be used with Dual Output') };
+    }
+
+    return { name: 'default', text: '' };
+  }, [isPrime, isPatreonEnabled, isDualOutputMode, forceStreamShiftToggleEnabled]);
+
+  const showTextTooltip = useMemo(() => {
+    if (isPatreonEnabled) return true;
+    if (!isPrime) return true;
+    if (isDualOutputMode && !forceStreamShiftToggleEnabled) return true;
+    return false;
+  }, [isPrime, isPatreonEnabled, isDualOutputMode, forceStreamShiftToggleEnabled]);
+
+  function handleTooltipClick() {
+    shell.openExternal(
+      'https://streamlabs.com/content-hub/post/how-to-use-streamlabs-stream-shift',
+    );
+  }
+
+  return showTextTooltip ? (
+    <span data-name={tooltipText.name}>{tooltipText.text}</span>
+  ) : (
+    <span data-name="explanation" onClick={handleTooltipClick}>
+      {$t(
+        'Stay uninterrupted by switching between devices mid stream. Works between Desktop and Mobile App.',
+      )}
+      <a style={{ marginLeft: 4 }}>{$t('Learn More')}</a>
+    </span>
   );
 }

--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -49,7 +49,13 @@ export function DestinationSwitchers() {
     return unlinkedAlwaysShownPlatforms.length
       ? linkedPlatforms.concat(unlinkedAlwaysShownPlatforms)
       : linkedPlatforms;
-  }, [linkedPlatforms, enabledPlatformsRef.current, isDualOutputMode, isPrime]);
+  }, [
+    linkedPlatforms,
+    enabledPlatformsRef.current,
+    isDualOutputMode,
+    isPrime,
+    alwaysShownPlatforms,
+  ]);
 
   // Disable custom destination switchers when restream is not available
   // or for a non-ultra user is in single output mode. The one exception

--- a/app/components-react/windows/go-live/GoLiveWindow.tsx
+++ b/app/components-react/windows/go-live/GoLiveWindow.tsx
@@ -95,7 +95,7 @@ function ModalFooter() {
     },
 
     async forceStreamShiftGoLive() {
-      this.restreamService.actions.forceStreamShiftGoLive(true);
+      this.restreamService.actions.forceStreamShiftGoLive();
     },
 
     get hasIncompatibleCodec() {

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -1,5 +1,5 @@
 import { IGoLiveSettings, StreamInfoView, TDisplayOutput } from '../../../services/streaming';
-import { platformList, TPlatform } from '../../../services/platforms';
+import { maxNumPlatforms, platformList, TPlatform } from '../../../services/platforms';
 import { ICustomStreamDestination } from 'services/settings/streaming';
 import { Services } from '../../service-provider';
 import cloneDeep from 'lodash/cloneDeep';
@@ -8,6 +8,7 @@ import { message } from 'antd';
 import { $t } from '../../../services/i18n';
 import { injectState, useModule } from 'slap';
 import { useForm } from '../../shared/inputs/Form';
+import { alertInfo } from '../../modals';
 import { getDefined } from '../../../util/properties-type-guards';
 import isEqual from 'lodash/isEqual';
 import { TDisplayType } from 'services/settings-v2';
@@ -28,7 +29,7 @@ class GoLiveSettingsState extends StreamInfoView<IGoLiveSettingsState> {
     ...this.savedSettings,
   };
 
-  isUpdating: boolean;
+  isUpdating: boolean = false;
 
   get settings(): IGoLiveSettingsState {
     return this.state;
@@ -142,13 +143,20 @@ class GoLiveSettingsState extends StreamInfoView<IGoLiveSettingsState> {
   }
 
   /**
+   * Enable/Disable Live Output Editing
+   */
+  toggleLiveOutputEditing(status: boolean) {
+    this.updateSettings({ liveOutputEditing: status });
+  }
+
+  /**
    * Set a common field like title or description for all eligible platforms
    **/
   updateCommonFields(
     fields: { title: string; description: string },
     shouldChangeAllPlatforms = false,
   ) {
-    Object.keys(fields).forEach((fieldName: TCommonFieldName) => {
+    (Object.keys(fields) as TCommonFieldName[]).forEach((fieldName: TCommonFieldName) => {
       const view = this.getView();
       const value = fields[fieldName];
       const platforms = shouldChangeAllPlatforms
@@ -227,14 +235,16 @@ export class GoLiveSettingsModule {
     };
 
     if (this.state.isUpdateMode && !view.isMidStreamMode) {
-      Object.keys(settings.platforms).forEach((platform: TPlatform) => {
-        // In multi-platform mode, allow deleting all platform settings, including primary
-        if (!isMultiplatformMode && this.state.isPrimaryPlatform(platform)) {
-          return;
-        }
+      (Object.keys(settings.platforms) as (keyof typeof settings.platforms)[]).forEach(
+        (platform: TPlatform) => {
+          // In multi-platform mode, allow deleting all platform settings, including primary
+          if (!isMultiplatformMode && this.state.isPrimaryPlatform(platform)) {
+            return;
+          }
 
-        delete settings.platforms[platform];
-      });
+          delete settings.platforms[platform];
+        },
+      );
     }
 
     // prefill the form if `prepopulateOptions` provided
@@ -302,6 +312,10 @@ export class GoLiveSettingsModule {
    * If platform is enabled then prepopulate its settings
    */
   switchPlatforms(enabledPlatforms: TPlatform[], skipPrepopulate?: boolean) {
+    // Guard against debounced calls arriving after the module state is destroyed
+    // (e.g. the go-live window closed before the debounce timer fired)
+    if (!this.state?.settings) return;
+
     // If Patreon or Instagram is the current primary (merge-only / no chat),
     // promote any other enabled platform to primary so chat & stream-info
     // routing don't resolve to a non-streaming platform.
@@ -366,6 +380,16 @@ export class GoLiveSettingsModule {
     this.save(this.state.settings);
   }
 
+  setPlatformEnabled(platform: TPlatform, enabled: boolean) {
+    this.state.updatePlatform(platform, { enabled });
+    this.save(this.state.settings);
+  }
+
+  setCustomDestinationEnabled(index: number, enabled: boolean) {
+    this.state.switchCustomDestination(index, enabled);
+    this.save(this.state.settings);
+  }
+
   updateCustomDestinationDisplayAndSaveSettings(destId: number, display: TDisplayType) {
     this.state.updateCustomDestinationDisplay(destId, display);
     this.save(this.state.settings);
@@ -427,6 +451,11 @@ export class GoLiveSettingsModule {
     return this.state.getCanStreamDualOutput(this.state);
   }
 
+  setLiveOutputEditingEnabled(status: boolean) {
+    this.state.toggleLiveOutputEditing(status);
+    this.save(this.state.settings);
+  }
+
   getIsInvalidDualStream(): boolean {
     if (this.isPrime) {
       return false;
@@ -453,22 +482,41 @@ export class GoLiveSettingsModule {
    * Validate the form and show an error message
    */
   async validate() {
-    // tiktok live authorization error
-    if (
-      this.state.isEnabled('tiktok') &&
-      (Services.TikTokService.neverApplied || Services.TikTokService.denied)
-    ) {
-      // Show this allow users to attempt to go live with rtmp regardless of tiktok status
-      message.info(
-        $t("Couldn't confirm TikTok Live Access. Apply for Live Permissions below"),
-        2,
-        () => true,
-      );
+    if (this.getIsInvalidDualStream()) {
+      alertInfo({
+        name: 'ultra-required-alert',
+        text: $t('Upgrade to Ultra to allow more than two outputs'),
+        duration: 2,
+      });
+      return;
     }
 
-    if (this.getIsInvalidDualStream()) {
-      message.info($t('Upgrade to Ultra to allow more than two outputs'), 2, () => true);
-      return;
+    if (!this.isPrime && this.state.isDualOutputMode) {
+      const totalEnabled =
+        this.state.enabledPlatforms.length +
+        this.state.customDestinations.filter(d => d.enabled).length;
+      if (totalEnabled >= 2) {
+        const hasHorizontal = this.state.horizontalStream.length > 0;
+        const hasVertical = this.state.verticalStream.length > 0;
+        if (!hasHorizontal || !hasVertical) {
+          alertInfo({
+            name: 'display-assignment-alert',
+            text: $t(
+              'Assign one destination to Horizontal and one to Vertical to go live, or upgrade to Ultra to enable multistreaming.',
+            ),
+            duration: 2,
+          });
+          return;
+        }
+      }
+    }
+
+    // Disable AI Highlighter if Twitch is not enabled, because it's a Twitch-only feature
+    if (
+      Services.HighlighterService.aiHighlighterFeatureEnabled &&
+      !this.state.isEnabled('twitch')
+    ) {
+      Services.HighlighterService.actions.setAiHighlighter(false);
     }
 
     try {
@@ -521,6 +569,82 @@ export class GoLiveSettingsModule {
 
   get codec() {
     return Services.SettingsService.views.values.Output.Encoder;
+  }
+
+  get isPatreonEnabled() {
+    return this.state.enabledPlatforms.some((p: TPlatform) => p === 'patreon');
+  }
+
+  get isStreamShiftDisabled() {
+    if (!this.isPrime) return true;
+    return this.isPatreonEnabled;
+  }
+
+  /**
+   * Override the default behavior of toggling stream shift so that the user is still
+   * able to toggle stream shift on/off when they have a single platform enabled and
+   * that platform has its display set to 'both'. Otherwise, the isDualOutputMode check
+   * would prevent the user from toggling stream shift on/off.
+   * Note: This should never happen but is a failsafe in case something goes wrong with
+   * the Go Live window's state.
+   */
+  get forceStreamShiftToggleEnabled() {
+    return (
+      this.state.isStreamShiftMode &&
+      this.state.enabledPlatforms.length === 1 &&
+      this.state.settings.platforms[this.state.enabledPlatforms[0]]?.display === 'both'
+    );
+  }
+
+  get isLiveOutputEditingDisabled() {
+    if (!this.isPrime) return true;
+    return this.state.isStreamShiftMode;
+  }
+
+  get enabledPlatformsCount() {
+    return this.state.enabledPlatforms.length;
+  }
+
+  get canAddDestinations() {
+    return (
+      this.state.linkedPlatforms.length + this.state.customDestinations.length < maxNumPlatforms + 5
+    );
+  }
+
+  get showTopAddDestination() {
+    return this.canAddDestinations && this.state.linkedPlatforms.length > 1;
+  }
+
+  get showBottomAddDestination() {
+    return this.state.linkedPlatforms.length < 2;
+  }
+
+  get disableCustomDestinationSwitchers() {
+    return (
+      !this.isRestreamEnabled &&
+      !this.state.enabledPlatforms.includes('tiktok') &&
+      this.state.enabledPlatforms.length > 1
+    );
+  }
+
+  get disableNonUltraSwitchers() {
+    return (
+      !this.isPrime && this.state.enabledPlatforms.length + this.enabledDestinations.length >= 2
+    );
+  }
+
+  // Returns the label of the enabled platform with 'both' display selected, if any, for non-prime users.
+  get nonPrimeBothDisplayPlatform(): TPlatform | null {
+    if (this.isPrime) return null;
+    return (
+      this.state.enabledPlatforms.find(
+        platform => this.state.settings.platforms[platform]?.display === 'both',
+      ) ?? null
+    );
+  }
+
+  get isAiHighlighterEnabled() {
+    return Services.HighlighterService.aiHighlighterFeatureEnabled;
   }
 }
 

--- a/app/services/incremental-rollout.ts
+++ b/app/services/incremental-rollout.ts
@@ -26,7 +26,7 @@ export enum EAvailableFeatures {
   streamShift = 'slobs--stream-shift',
   twitchDualStream = 'slobs--twitch-dual-stream',
   twitchDualStreamPreview = 'slobs--twitch-dual-stream-preview',
-  patreon = 'slobs--patreon',
+  liveOutputEditing = 'slobs--live-output-editing',
 
   /**
    * There are two flags because one is used for beta access and

--- a/app/services/platforms/kick.ts
+++ b/app/services/platforms/kick.ts
@@ -212,6 +212,10 @@ export class KickService
   }
 
   async afterStopStream(): Promise<void> {
+    if (this.state.platformId) {
+      await this.endStream(this.state.platformId);
+    }
+
     // clear server url and stream key
     this.SET_INGEST('');
     this.SET_STREAM_KEY('');
@@ -380,7 +384,7 @@ export class KickService
         console.warn('Error fetching Kick info: ', e);
 
         if (e.result && e.result.data.code === 401) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
+          const message = e.statusText || e.result.data.message;
           throwStreamError(
             'KICK_SCOPE_OUTDATED',
             {
@@ -391,6 +395,22 @@ export class KickService
             e.result.data.message,
           );
         }
+
+        let message = e.message ?? 'Unknown error fetching Kick info';
+        if (e.result) {
+          message = e.statusText || e.result.data.message;
+        }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'kick',
+          },
+          details,
+        );
       });
   }
 
@@ -480,6 +500,23 @@ export class KickService
       })
       .catch((e: unknown) => {
         console.warn('Error updating Kick channel info', e);
+
+        const err = e as any;
+        let message = err?.message ?? 'Unknown error updating Kick channel info';
+        if (err?.result) {
+          message = err.statusText || err.result.data.message;
+        }
+        const details = err?.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: err?.status,
+            statusText: message,
+            platform: 'kick',
+          },
+          details,
+        );
       });
   }
 

--- a/app/services/platforms/patreon.ts
+++ b/app/services/platforms/patreon.ts
@@ -22,6 +22,7 @@ export interface IPatreonStartStreamOptions {
   title: string;
   description: string;
   accessRules: string[];
+  campaignId: string;
 }
 
 interface IPatreonStartStreamSettings {
@@ -94,7 +95,6 @@ interface IPatreonError {
 interface IPatreonServiceState extends IPlatformState {
   settings: IPatreonStartStreamSettings;
   ingest: string;
-  campaignId: string;
   accessRules: { key: string; value: string }[];
   broadcastId: string;
   platformId: string;
@@ -109,7 +109,6 @@ export class PatreonService
     ...BasePlatformService.initialState,
     settings: { title: '', description: '', campaignId: '', accessRules: [], mode: 'landscape' },
     ingest: '',
-    campaignId: '',
     accessRules: [],
     broadcastId: '',
     platformId: '',
@@ -172,7 +171,7 @@ export class PatreonService
     }
 
     const streamInfo = (await this.startStream(
-      goLiveSettings.platforms.patreon ?? this.state.settings,
+      patreonSettings ?? this.state.settings,
     )) as IPatreonStartStreamResponse;
 
     this.SET_INGEST(streamInfo.rtmp);
@@ -247,13 +246,22 @@ export class PatreonService
         const info = res as IPatreonStreamInfoResponse;
 
         if (info.campaigns.length) {
-          this.SET_CAMPAIGN_ID(info.campaigns[0].key.toString());
-          this.SET_CHANNEL_NAME(info.campaigns[0].value);
+          const campaigns = await Promise.all(info.campaigns.map(campaign => campaign));
+
+          // Set campaign id in stream settings and channel name in state
+          const streamSettings = {
+            ...this.state.settings,
+            campaignId: campaigns[0].key.toString(),
+          };
+          this.SET_STREAM_SETTINGS(streamSettings);
+          this.SET_CHANNEL_NAME(campaigns[0].value);
         }
 
         if (info.accessRules.length) {
-          this.SET_ACCESS_RULES(info.accessRules);
+          const accessRules = await Promise.all(info.accessRules.map(rule => rule));
+          this.SET_ACCESS_RULES(accessRules);
         }
+
         return EPlatformCallResult.Success;
       })
       .catch((e: unknown) => {
@@ -272,29 +280,34 @@ export class PatreonService
     const body = new FormData();
     body.append('title', opts.title);
     body.append('description', opts.description);
-    body.append('campaign_id', this.state.campaignId);
+    body.append('campaign_id', opts.campaignId);
     opts.accessRules.forEach(rule => body.append('access_rules[]', rule));
     body.append('state', 'live');
 
     const request = new Request(url, { headers, method: 'POST', body });
 
     return jfetch<IPatreonStartStreamResponse | IPatreonError>(request)
-      .then(async res => res)
+      .then(async res => {
+        return res;
+      })
       .catch(e => {
         console.warn('Error starting Patreon stream: ', e);
 
+        let message = e.message ?? 'Unknown error starting Patreon stream';
         if (e.result) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
-          throwStreamError(
-            'PLATFORM_REQUEST_FAILED',
-            {
-              status: e.status,
-              statusText: message,
-              platform: 'patreon',
-            },
-            e.result.data.message,
-          );
+          message = e.statusText || e.result.data.message;
         }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'patreon',
+          },
+          details,
+        );
       });
   }
 
@@ -311,22 +324,27 @@ export class PatreonService
     const request = new Request(url, { method: 'POST', headers });
 
     return jfetch<IPatreonEndStreamResponse | IPatreonError>(request)
-      .then(async res => res)
+      .then(async res => {
+        return res;
+      })
       .catch(e => {
         console.warn('Error ending Patreon stream: ', e);
 
+        let message = e.message ?? 'Unknown error ending Patreon stream';
         if (e.result) {
-          const message = e.statusText !== '' ? e.statusText : e.result.data.message;
-          throwStreamError(
-            'PLATFORM_REQUEST_FAILED',
-            {
-              status: e.status,
-              statusText: message,
-              platform: 'patreon',
-            },
-            e.result.data.message,
-          );
+          message = e.statusText || e.result.data.message;
         }
+        const details = e.result?.data?.message ?? message;
+
+        throwStreamError(
+          'PLATFORM_REQUEST_FAILED',
+          {
+            status: e.status,
+            statusText: message,
+            platform: 'patreon',
+          },
+          details,
+        );
       });
   }
 
@@ -381,11 +399,6 @@ export class PatreonService
   @mutation()
   SET_INGEST(ingest: string) {
     this.state.ingest = ingest;
-  }
-
-  @mutation()
-  SET_CAMPAIGN_ID(campaignId: string) {
-    this.state.campaignId = campaignId;
   }
 
   @mutation()

--- a/app/services/platforms/tiktok.ts
+++ b/app/services/platforms/tiktok.ts
@@ -741,7 +741,7 @@ export class TikTokService
     const isFrequentUser = this.diagnosticsService.isFrequentUser;
     if (isOldAccount && !isTikTokLinked && isFrequentUser) return true;
 
-    return false;
+    return this.getHasScope('never-applied') || this.getHasScope('denied');
   }
 
   get promptReapply(): boolean {

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -4,7 +4,11 @@ import { HostsService } from 'services/hosts';
 import { getPlatformService, TPlatform } from 'services/platforms';
 import { StreamSettingsService } from 'services/settings/streaming';
 import { UserService } from 'services/user';
-import { CustomizationService, ICustomizationServiceState } from 'services/customization';
+import {
+  CustomizationService,
+  CustomizationState,
+  ICustomizationServiceState,
+} from 'services/customization';
 import { authorizedHeaders, jfetch } from 'util/requests';
 import electron from 'electron';
 import { StreamingService } from './streaming';
@@ -20,6 +24,7 @@ import { PlatformAppsService } from './platform-apps';
 import { DualOutputService } from 'services/dual-output';
 import { SettingsService } from 'services/settings';
 import { throwStreamError } from './streaming/stream-error';
+import { Subject } from 'rxjs';
 import uuid from 'uuid';
 import Utils from './utils';
 import { $t } from './i18n';
@@ -143,6 +148,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
   settings: IUserSettingsResponse;
 
   preferences = RestreamPreferences.inject();
+
+  isLive = new Subject<boolean>();
 
   static initialState: IRestreamState = {
     enabled: true,
@@ -630,6 +637,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
       this.SET_STREAM_SWITCHER_TARGETS([]);
     }
 
+    this.isLive.next(status.isLive);
     return status.isLive;
   }
 
@@ -656,8 +664,8 @@ export class RestreamService extends StatefulService<IRestreamState> {
 
     const request = new Request(url, { headers, method: 'GET' });
 
-    return jfetch(request)
-      .then((res: { [key: string]: ITargetLiveData[] }) => {
+    return jfetch<{ [key: string]: ITargetLiveData[] }>(request)
+      .then(res => {
         const targets = this.state.streamShiftTargets.reduce((targetData: ITargetLiveData[], t) => {
           const platform = t.platform as string;
           if (t.platform !== 'relay') {
@@ -754,6 +762,12 @@ export class RestreamService extends StatefulService<IRestreamState> {
     return fetch(request).then(res => res.json());
   }
 
+  async deleteTargets() {
+    const targets = await this.fetchTargets();
+    const promises = targets.map(t => this.deleteTarget(t.id));
+    await Promise.all(promises);
+  }
+
   /**
    * Stream Shift
    */
@@ -766,6 +780,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     this.SET_STREAM_SWITCHER_STATUS('inactive');
     this.SET_STREAM_SWITCHER_STREAM_ID();
     this.SET_STREAM_SWITCHER_TARGETS([]);
+    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(false);
   }
 
   async confirmStreamShift(action: TStreamShiftAction) {
@@ -823,13 +838,32 @@ export class RestreamService extends StatefulService<IRestreamState> {
     }
   }
 
-  forceStreamShiftGoLive(shouldForce: boolean) {
-    if (shouldForce) {
+  async forceStreamShiftGoLive() {
+    this.streamSettingsService.setGoLiveSettings({ streamShift: false });
+    await this.deleteTargets();
+    this.SET_STREAM_SWITCHER_STATUS('inactive');
+    this.SET_STREAM_SWITCHER_STREAM_ID();
+    this.SET_STREAM_SWITCHER_TARGETS([]);
+    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(true);
+  }
+
+  /**
+   * Test helper to emit isLive for testing purposes
+   * @param isLive - Whether the stream is live or not
+   * @remarks This is only used for testing purposes. It should not be used in production code.
+   */
+  emitIsLiveForTest(isLive: boolean): void {
+    if (!Utils.isTestMode()) return;
+
+    if (isLive) {
+      this.streamSettingsService.setGoLiveSettings({ streamShift: true });
+      this.SET_STREAM_SWITCHER_STATUS('pending');
+    } else {
       this.streamSettingsService.setGoLiveSettings({ streamShift: false });
       this.SET_STREAM_SWITCHER_STATUS('inactive');
     }
 
-    this.SET_STREAM_SWITCHER_FORCE_GO_LIVE(shouldForce);
+    this.isLive.next(isLive);
   }
 
   /* Chat Handling
@@ -890,7 +924,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     });
 
     this.customizationService.settingsChanged.subscribe(
-      (changed: Partial<ICustomizationServiceState>) => {
+      (changed: DeepPartial<CustomizationState>) => {
         this.handleSettingsChanged(changed);
       },
     );
@@ -908,7 +942,7 @@ export class RestreamService extends StatefulService<IRestreamState> {
     this.chatView = null;
   }
 
-  private handleSettingsChanged(changed: Partial<ICustomizationServiceState>) {
+  private handleSettingsChanged(changed: DeepPartial<ICustomizationServiceState>) {
     if (!this.chatView) return;
     if (changed.chatZoomFactor) {
       this.chatView.webContents.setZoomFactor(changed.chatZoomFactor);
@@ -953,7 +987,7 @@ class RestreamView extends ViewHandler<IRestreamState> {
     return this.state.streamShiftTargets.length > 0;
   }
 
-  get shouldForceGoLive() {
+  get streamShiftForceGoLive() {
     return this.state.streamShiftForceGoLive;
   }
 }

--- a/app/services/settings/streaming/stream-settings.ts
+++ b/app/services/settings/streaming/stream-settings.ts
@@ -25,6 +25,7 @@ export interface ISavedGoLiveSettings {
   advancedMode: boolean;
   recording?: TDisplayOutput;
   streamShift?: boolean;
+  liveOutputEditing?: boolean;
 }
 
 export interface ICustomStreamDestination {
@@ -212,6 +213,8 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
   }
 
   setGoLiveSettings(settingsPatch: Partial<IGoLiveSettings>) {
+    if (!settingsPatch) return;
+
     // transform IGoLiveSettings to ISavedGoLiveSettings
     const patch: Partial<ISavedGoLiveSettings> = settingsPatch;
     if (settingsPatch.platforms) {
@@ -223,11 +226,10 @@ export class StreamSettingsService extends PersistentStatefulService<IStreamSett
         const platformSettings = pick(settingsPatch.platforms![platform], pickedFields);
 
         if (this.streamingService.views.isDualOutputMode) {
-          this.videoSettingsService.validateVideoContext();
           const display = this.streamingService.views.getPlatformDisplayType(platform as TPlatform);
           platformSettings.video = this.videoSettingsService.contexts[display];
         }
-        return (platforms[platform] = platformSettings);
+        platforms[platform] = platformSettings;
       });
       patch.platforms = platforms as ISavedGoLiveSettings['platforms'];
     }

--- a/app/services/streaming/streaming-api.ts
+++ b/app/services/streaming/streaming-api.ts
@@ -86,6 +86,7 @@ export interface IStreamSettings {
   recording: TDisplayOutput;
   streamShift?: boolean;
   enhancedBroadcasting?: boolean;
+  liveOutputEditing?: boolean;
 }
 
 export interface IGoLiveSettings extends IStreamSettings {

--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -130,11 +130,7 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
    * Returns a sorted list of all platforms (linked and unlinked)
    */
   get allPlatforms(): TPlatform[] {
-    const platforms = !this.incrementalRolloutService.featureIsEnabled(EAvailableFeatures.patreon)
-      ? platformList.filter(p => p !== 'patreon')
-      : platformList;
-
-    return this.getSortedPlatforms(platforms);
+    return this.getSortedPlatforms(platformList);
   }
 
   /**

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -667,7 +667,7 @@ export class StreamingService
      * SET MULTISTREAM SETTINGS
      */
     // TODO: remove after server-side impl
-    this.restreamService.actions.forceStreamShiftGoLive(false);
+    this.restreamService.actions.forceStreamShiftGoLive();
     if (this.views.shouldSetupRestream) {
       // In single output mode, this sets up multistreaming
       // In dual output mode, this sets up streaming displays to multiple targets
@@ -1616,7 +1616,7 @@ export class StreamingService
       }
     } else {
       // In dual output mode without enhanced broadcasting, create the horizontal streaming instance after the vertical stream
-      // has started. The start streaming promise resolves when the vertical stream starts because the vertical stream is the
+      // has started. The start streaming promise resolves when the horizontal stream starts because the horizontal stream is the
       // last streaming instance created
       if (context === 'vertical') {
         await this.validateOrCreateOutputInstance({
@@ -1633,6 +1633,13 @@ export class StreamingService
         // Only resolve the start streaming promise after the horizontal stream has started to prevent unintended side effects of duplicate
         // actions taken after starting the stream
         await this.handleStartStreaming(code, context);
+
+        if (this.state.status.vertical.streaming === EStreamingState.Starting) {
+          // The horizontal stream has started but the vertical stream status is still `Starting`. Update the vertical streaming status here,
+          // instead of when the vertical stream actually starts, to prevent a race condition where the UI might show all streams as `Live`
+          // when some streams may be still in the process of starting.
+          this.SET_STREAMING_STATUS(EStreamingState.Live, 'vertical', time);
+        }
       }
     }
   }

--- a/app/services/usage-statistics.ts
+++ b/app/services/usage-statistics.ts
@@ -60,7 +60,8 @@ export type TAnalyticsEvent =
   | 'Onboarding'
   | 'WidgetAdded'
   | 'WidgetRemoved'
-  | 'GamePulse';
+  | 'GamePulse'
+  | 'LiveOutputEditing';
 
 // Refls are used as uuids for ultra components and should be updated for new ulta components.
 export type TUltraRefl =
@@ -78,6 +79,7 @@ export type TUltraRefl =
   | 'slobs-multistream-settings'
   | 'slobs-multistream'
   | 'slobs-stream-settings'
+  | 'slobs-live-output-editing'
   | string;
 
 interface IAnalyticsEvent {

--- a/app/services/user/index.ts
+++ b/app/services/user/index.ts
@@ -624,6 +624,15 @@ export class UserService extends PersistentStatefulService<IUserServiceState> {
     return EPlatformCallResult.Success;
   }
 
+  /**
+   * Remove a dummy account that was previously added via addDummyAccount.
+   * @remark Use for tests to unlink a platform from the local state.
+   */
+  removeDummyAccount(platform: TPlatform): void {
+    if (!Utils.isTestMode()) return;
+    this.UNLINK_PLATFORM(platform);
+  }
+
   async autoLogin() {
     if (!this.state.auth) return;
 

--- a/app/services/websocket.ts
+++ b/app/services/websocket.ts
@@ -9,6 +9,7 @@ import { IRecentEvent, ISafeModeServerSettings } from 'services/recent-events';
 import { importSocketIOClient } from '../util/slow-imports';
 import { SceneCollectionsService } from 'services/scene-collections';
 import { TPlatform } from './platforms';
+import Utils from './utils';
 
 export type TSocketEvent =
   | IStreamlabelsSocketEvent
@@ -243,6 +244,11 @@ export class WebsocketService extends Service {
           this.socketEvent.next(e);
         });
       });
+  }
+
+  sendSocketEventForTest(event: TSocketEvent): void {
+    if (!Utils.isTestMode()) return;
+    this.socketEvent.next(event);
   }
 
   disconnect() {


### PR DESCRIPTION
# Go Live Window StreamShiftToggle & useGoLiveSettings Hook

> [!NOTE]
> Target branch is [mw_gl_ui_3_services](https://github.com/streamlabs/desktop/tree/mw_gl_ui_3_services)
> PR [[5] Go Live Window UI - Service Changes (UI Independent) #6027](https://github.com/streamlabs/desktop/pull/6027)

## Summary

- Refactor StreamShiftToggle with consolidated toggling logic, error handling, and Patreon/stream shift limitations
- Update useGoLiveSettings hook with live output toggling, platform enable/disable logic, and stream shift race condition fixes
- Add `alertInfo` helper and `AlertContent` component to modals (used by useGoLiveSettings)

## Source Commits

| Commit      | Message                                                                   | What it touched                    |
| ----------- | ------------------------------------------------------------------------- | ---------------------------------- |
| `179516838` | Update shared components.                                                 | StreamShiftToggle (tsx + less)      |
| `48683ca4c` | Update components.                                                        | useGoLiveSettings                  |
| `89fba840b` | Fix dual output mode and move stream shift check into Go Live window.     | useGoLiveSettings                  |
| `9d717c276` | Add toggling live output editing.                                         | useGoLiveSettings                  |
| `bafb4f0e7` | Styling fixes.                                                            | useGoLiveSettings                  |
| `9e74e367e` | Fix Stream Shift non-ultra toggle alignment.                              | StreamShiftToggle (tsx + less)      |
| `45c5eeb35` | Consolidate Stream Shift toggling.                                        | StreamShiftToggle.tsx              |
| `10715b3cf` | Add error handling for toggling.                                          | useGoLiveSettings                  |
| `b7c68b8ea` | Remove patreon stream shift limitation.                                   | StreamShiftToggle, useGoLiveSettings |
| `e63d129ed` | Fix Twitch dual stream enhanced broadcasting state.                       | useGoLiveSettings                  |
| `55adeaccc` | Refactor Go Live window stream shift is live handling to remove race condition. | StreamShiftToggle, useGoLiveSettings |
| `85a53d745` | Restore patreon/stream shift limitation.                                  | StreamShiftToggle, useGoLiveSettings |
| `23cd21ce6` | WIP: Go Live window tests.                                                | useGoLiveSettings                  |
| `0a950b886` | Fixes from code review.                                                   | StreamShiftToggle.tsx              |
| `e0962e3bd` | More fixes from code review.                                              | StreamShiftToggle.tsx              |
| `44ba46186` | New info modal hook and expand go live and dual output tests.              | StreamShiftToggle, useGoLiveSettings, modals.tsx (alertInfo) |
| `0476f507f` | Fix TikTok test and apply prompt showing twice.                           | useGoLiveSettings                  |

## Files Changed

| File                                                        | Change                                                  |
| ----------------------------------------------------------- | ------------------------------------------------------- |
| `app/components-react/shared/StreamShiftToggle.tsx`         | Consolidated toggling, error handling, Patreon limits    |
| `app/components-react/shared/StreamShiftToggle.m.less`      | Non-ultra toggle alignment, styling updates              |
| `app/components-react/windows/go-live/useGoLiveSettings.ts` | Live output toggling, platform logic, race condition fix |
| `app/components-react/modals.tsx`                           | Add `alertInfo` helper and `AlertContent` component      |

## Performance Implications

None. Component and hook logic refactoring.
