### PR TITLE
[7a] Go Live Window UI - Instagram test changes.

### DIFF
--- a/app/components-react/windows/go-live/platforms/InstagramEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/InstagramEditStreamInfo.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Alert, Button } from 'antd';
 import { clipboard } from 'electron';
 import { IPlatformComponentParams } from './PlatformSettingsLayout';
-import { TextInput, createBinding } from '../../../shared/inputs';
+import { TextInput, createBinding, InputComponent } from '../../../shared/inputs';
 import Form from '../../../shared/inputs/Form';
 import { $t } from 'services/i18n';
 
@@ -10,7 +10,7 @@ type Props = IPlatformComponentParams<'instagram'> & {
   isStreamSettingsWindow?: boolean;
 };
 
-export function InstagramEditStreamInfo(p: Props) {
+export const InstagramEditStreamInfo = InputComponent((p: Props) => {
   const bind = createBinding(p.value, updatedSettings =>
     p.onChange({ ...p.value, ...updatedSettings }),
   );
@@ -23,6 +23,7 @@ export function InstagramEditStreamInfo(p: Props) {
     <Form name="instagram-settings">
       <TextInput
         {...bind.streamUrl}
+        name="instagramStreamUrl"
         required
         label={streamUrlLabel}
         addonAfter={<PasteButton onPaste={bind.streamUrl.onChange} />}
@@ -32,6 +33,7 @@ export function InstagramEditStreamInfo(p: Props) {
 
       <TextInput
         {...bind.streamKey}
+        name="instagramStreamKey"
         required
         label={streamKeyLabel}
         isPassword
@@ -42,7 +44,7 @@ export function InstagramEditStreamInfo(p: Props) {
       />
       {!isStreamSettingsWindow && (
         <Alert
-          style={{ marginBottom: 8 }}
+          style={{ marginTop: '16px' }}
           message={$t(
             'Remember to open Instagram in browser and click "Go Live" to start streaming!',
           )}
@@ -53,7 +55,7 @@ export function InstagramEditStreamInfo(p: Props) {
       )}
     </Form>
   );
-}
+});
 
 function PasteButton({ onPaste }: { onPaste: (text: string) => void }) {
   return (

--- a/app/components-react/windows/settings/Stream.tsx
+++ b/app/components-react/windows/settings/Stream.tsx
@@ -565,7 +565,6 @@ function CustomDestinationList() {
     isPrime: Services.UserService.isPrime,
     customDestinations: Services.StreamingService.views.savedSettings.customDestinations,
   }));
-
   const destinations = customDestinations;
   const isEditMode = editCustomDestMode !== false;
   const shouldShowAddForm = editCustomDestMode === true;
@@ -590,6 +589,7 @@ function CustomDestinationList() {
               filled
               text={$t('Ultra')}
               icon={<UltraIcon type="simple" />}
+              className={styles.ultraText}
             />
           ) : (
             <div className={styles.ultra} />

--- a/test/regular/streaming/instagram.ts
+++ b/test/regular/streaming/instagram.ts
@@ -31,8 +31,8 @@ test('Streaming to Instagram', withUser('twitch', { prime: true, multistream: fa
   await fillForm({
     title: 'Test stream',
     twitchGame: 'Fortnite',
-    streamUrl: dummy.streamUrl,
-    streamKey: dummy.streamKey,
+    instagramStreamUrl: dummy.streamUrl,
+    instagramStreamKey: dummy.streamKey,
   });
   await submit();
   await waitForDisplayed('span=Update settings for Instagram', { timeout: 10000 });


### PR DESCRIPTION
# Go Live UI 7a: Instagram & Stream Settings

**Stack:** `master` ← 7a ← 7b ← 7c ← 7d ← 7e ← 7f ← 8

## Summary
- Wrap `InstagramEditStreamInfo` in `InputComponent` for consistent form handling
- Add `name` attributes to Instagram stream URL/key inputs for test targeting
- Update instagram test to use new input names (`instagramStreamUrl`, `instagramStreamKey`)

## Files Changed

| File | Change |
|------|--------|
| `app/components-react/windows/go-live/platforms/InstagramEditStreamInfo.tsx` | Wrap in `InputComponent`, add `name` props, update alert margin |
| `test/regular/streaming/instagram.ts` | Update form field names to `instagramStreamUrl`/`instagramStreamKey` |

## Performance Implications
None. Minor component wrapper changes.