### PR TITLE
[7b] Go Live Window UI - Test Helper Improvements

### DIFF
--- a/test/helpers/modules/core.ts
+++ b/test/helpers/modules/core.ts
@@ -64,8 +64,32 @@ export async function clickButton(buttonText: string) {
   await click($button);
 }
 
-export async function clickTab(tabText: string) {
-  await click(`div[role="tab"]=${tabText}`);
+export async function clickTab(tabText: string, dataName?: string) {
+  const selector = dataName ? `[data-name="${dataName}"]` : `div[role="tab"]=${tabText}`;
+  await click(selector);
+}
+
+/**
+ * Check whether a tab with the given text is currently active
+ * @remark Note: to throw an error if the tab is not active, must be used with `t.true`
+ * @param tabText The text of the tab to check
+ * @param dataName Optional data-name attribute of the tab to check, use if the tab text is not unique
+ * or if the tab contents contain elements other than text
+ * @returns A promise that resolves to true if the tab is active, false otherwise
+ */
+export async function isTabActive(tabText: string, dataName?: string): Promise<boolean> {
+  // Test for active tab with data-name as selector
+  if (dataName) {
+    const $span = await select(`[data-name="${dataName}"]`);
+    const $tabBtn = await $span.parentElement();
+    const ariaSelected = await $tabBtn.getAttribute('aria-selected');
+    return ariaSelected === 'true';
+  }
+
+  // Test for active tab with text as selector
+  const $tab = await select(`div[role="tab"]=${tabText}`);
+  const ariaSelected = await $tab.getAttribute('aria-selected');
+  return ariaSelected === 'true';
 }
 
 export async function clickCheckbox(dataName: string) {
@@ -88,12 +112,21 @@ export async function selectAsyncAlert(title: string) {
 
 // OTHER SHORTCUTS
 
-export async function hoverElement(selector: string, duration?: number) {
+export async function hoverElement(selector: string, waitForOptions?: WaitForOptions) {
   const element = await select(`${selector}`);
   await element.moveTo();
-  if (duration) {
-    await getClient().pause(duration);
+  if (waitForOptions?.timeout) {
+    await getClient().pause(waitForOptions.timeout);
   }
+}
+
+export async function isTooltipDisplayed(
+  hoverSelector: string,
+  tooltipSelector: string,
+  waitForOptions?: WaitForOptions,
+): Promise<void> {
+  await hoverElement(hoverSelector, waitForOptions);
+  await isDisplayed(tooltipSelector, waitForOptions);
 }
 
 export async function isDisplayed(selectorOrEl: TSelectorOrEl, waitForOptions?: WaitForOptions) {
@@ -122,6 +155,31 @@ export function waitForText(text: string) {
 
 export async function waitForEnabled(selectorOrEl: TSelectorOrEl, options?: WaitForOptions) {
   await (await select(selectorOrEl)).waitForEnabled(options);
+}
+
+/**
+ * Wait for an antd message alert identified by its data-name attribute
+ */
+export async function waitForAlert(name: string, options?: WaitForOptions) {
+  await waitForDisplayed(`[data-name="${name}"]`, options);
+}
+
+/**
+ * Click an antd message alert identified by its data-name attribute, if displayed
+ */
+export async function clickAlert(name: string) {
+  const selector = `[data-name="${name}"]`;
+  if (await isDisplayed(selector)) {
+    await click(selector);
+  }
+}
+
+/**
+ * Wait for an antd message alert by data-name, then click it to dismiss
+ */
+export async function dismissAlert(name: string, options?: WaitForOptions) {
+  await waitForAlert(name, options);
+  await clickAlert(name);
 }
 
 /**

--- a/test/helpers/modules/forms/radio.ts
+++ b/test/helpers/modules/forms/radio.ts
@@ -3,7 +3,12 @@ import { BaseInputController } from './base';
 export class RadioInputController extends BaseInputController<string> {
   async setValue(value: string) {
     const $el = await this.getElement();
-    const $labels = await $el.$$('label.ant-radio-wrapper');
+    // Handle both standard radio (ant-radio-wrapper)
+    // and button-style radio (ant-radio-button-wrapper)
+    let $labels = await $el.$$('label.ant-radio-wrapper');
+    if ($labels.length === 0) {
+      $labels = await $el.$$('label.ant-radio-button-wrapper');
+    }
 
     for (const $label of $labels) {
       const $input = await $label.$('input[type="radio"]');
@@ -18,7 +23,11 @@ export class RadioInputController extends BaseInputController<string> {
 
   async getValue() {
     const $el = await this.getElement();
-    const $inputs = await $el.$$('.ant-radio-input');
+    // Handle both standard radio and button-style radio inputs
+    let $inputs = await $el.$$('.ant-radio-input');
+    if ($inputs.length === 0) {
+      $inputs = await $el.$$('.ant-radio-button-input');
+    }
 
     for (const $input of $inputs) {
       const isChecked = await $input.isSelected();
@@ -34,7 +43,11 @@ export class RadioInputController extends BaseInputController<string> {
 
   async getOptions() {
     const $el = await this.getElement();
-    const $inputs = await $el.$$('.ant-radio-input');
+    // Handle both standard radio and button-style radio inputs
+    let $inputs = await $el.$$('.ant-radio-input');
+    if ($inputs.length === 0) {
+      $inputs = await $el.$$('.ant-radio-button-input');
+    }
     const result: { label: string; value: string }[] = [];
     for (const $input of $inputs) {
       const value = await $input.getValue();

--- a/test/helpers/modules/user.ts
+++ b/test/helpers/modules/user.ts
@@ -1,6 +1,9 @@
-import { getContext } from '../webdriver';
+import { getContext, TExecutionContext } from '../webdriver';
 import { TPlatform } from '../../../app/services/platforms';
-import { ITestUserFeatures, logIn as userLogin } from '../webdriver/user';
+import { ITestUserFeatures, reserveUserFromPool, logIn as userLogin } from '../webdriver/user';
+import { click, clickButton } from './core';
+import { fillForm } from './forms';
+import { showSettingsWindow } from './settings/settings';
 
 export function logIn(
   platform: TPlatform = 'twitch',
@@ -9,4 +12,22 @@ export function logIn(
   isOnboardingTest = false,
 ) {
   return userLogin(getContext(), platform, features, waitForUI, isOnboardingTest);
+}
+
+export async function addCustomDestination(t: TExecutionContext) {
+  const user = await reserveUserFromPool(t, 'twitch');
+  const name = 'MyCustomDest';
+
+  // add new destination
+  await showSettingsWindow('Stream');
+  await click('span=Add Custom Destination');
+
+  await fillForm({
+    name,
+    url: 'rtmp://live.twitch.tv/app/',
+    streamKey: user.streamKey,
+  });
+  await clickButton('Save');
+
+  return { user, name };
 }

--- a/test/helpers/webdriver/user.ts
+++ b/test/helpers/webdriver/user.ts
@@ -33,6 +33,10 @@ export interface ITestUserFeatures {
    */
   streamingIsDisabled?: boolean;
   /**
+   * Has multiple platforms that can dual stream
+   */
+  dualStream?: boolean;
+  /**
    * This account doesn't have facebook pages
    */
   noFacebookPages?: boolean;
@@ -158,6 +162,15 @@ export async function addDummyAccount(
   await api.getResource<UserService>('UserService').addDummyAccount(userInfo, settings);
 
   return user;
+}
+
+/**
+ * Remove a dummy account that was previously added
+ * @param platform - platform to unlink
+ */
+export async function removeDummyAccount(platform: TTestDummyUserPlatforms): Promise<void> {
+  const api = await getApiClient();
+  await api.getResource<UserService>('UserService').removeDummyAccount(platform);
 }
 
 export async function loginWithAuthInfo(

--- a/test/regular/streaming/instagram.ts
+++ b/test/regular/streaming/instagram.ts
@@ -31,8 +31,8 @@ test('Streaming to Instagram', withUser('twitch', { prime: true, multistream: fa
   await fillForm({
     title: 'Test stream',
     twitchGame: 'Fortnite',
-    streamUrl: dummy.streamUrl,
-    streamKey: dummy.streamKey,
+    instagramStreamUrl: dummy.streamUrl,
+    instagramStreamKey: dummy.streamKey,
   });
   await submit();
   await waitForDisplayed('span=Update settings for Instagram', { timeout: 10000 });


### PR DESCRIPTION
# Go Live UI 7b: Test Helper Improvements

**Stack:** `master` ← 7a ← **7b** ← 7c ← 7d ← 7e ← 7f ← 8

## Summary
- Add new test helper functions for tabs, tooltips, and alerts
- Add button-style radio input support in test RadioInputController
- Add `dualStream` feature flag and `removeDummyAccount` to webdriver user helpers
- Add `addCustomDestination` helper to user module

## Files Changed

| File | Change |
|------|--------|
| `test/helpers/modules/core.ts` | Add `clickTab` data-name support, `isTabActive`, `isTooltipDisplayed`, `waitForAlert`, `clickAlert`, `dismissAlert`; update `hoverElement` to accept `WaitForOptions` |
| `test/helpers/modules/forms/radio.ts` | Support `ant-radio-button-wrapper` in `setValue`, `getValue`, `getOptions` |
| `test/helpers/modules/user.ts` | Add `addCustomDestination` helper |
| `test/helpers/webdriver/user.ts` | Add `dualStream` feature flag, add `removeDummyAccount` function |

## Performance Implications
None. Test-only changes with no runtime impact.