### PR TITLE
[7c] Go Live Window UI - Add Destination Button

### DIFF
--- a/app/components-react/shared/AddDestinationButton.m.less
+++ b/app/components-react/shared/AddDestinationButton.m.less
@@ -28,7 +28,6 @@ button.add-destination-btn {
   position: relative;
   margin: auto;
   margin-bottom: 15px;
-  background-color: var(--background);
 
   &:hover {
     transition: 0.3s !important;
@@ -59,7 +58,7 @@ button.add-destination-btn {
 button.info-banner {
   width: unset !important;
   padding: 5px !important;
-  margin: 0px 15px 12px;
+  margin: 0px 15px;
   height: fit-content;
   align-items: flex-start;
   border-radius: 6px;
@@ -117,7 +116,6 @@ button.add-destination-header {
     #ffab48 96.52%,
     #ff5151 100%
   );
-
   background-clip: text;
   color: transparent;
 }
@@ -142,7 +140,6 @@ button.add-destination-header {
     #ffab48 79.52%,
     #ff5151 96.69%
   );
-
   background-clip: text;
   color: transparent;
 }
@@ -161,7 +158,6 @@ button.add-destination-header {
     #ffab48 79.52%,
     #ff5151 96.69%
   );
-
   background-clip: text;
   color: transparent;
 
@@ -170,7 +166,7 @@ button.add-destination-header {
     width: 12px;
     height: 14px;
     float: inline-end;
-    margin-right: 50px;
+    margin-right: 10px;
     margin-top: 1px;
   }
 }
@@ -192,6 +188,7 @@ button.add-destination-header {
 .ultra-btn:extend(button.add-destination-btn) {
   margin: 0px 15px !important;
   width: calc(100% - 30px) !important;
+  background-color: var(--background);
   font-weight: 500;
 
   .ultra-icon {
@@ -201,29 +198,19 @@ button.add-destination-header {
 }
 
 .small-btn-group {
-  padding: 0px !important;
+  margin: 0px !important;
 }
 
-.small-btn:extend(button.add-destination-btn) {
-  height: 40px !important;
-  font-weight: 500;
+button.small-btn {
   color: var(--title) !important;
-  text-align: left !important;
-  font-size: 14px;
-  border: 0px !important;
-  background-color: var(--section-alt) !important;
-  margin: 0px 15px !important;
-  width: calc(100% - 30px) !important;
 
-  :global(.anticon.anticon-plus) {
-    font-size: 14px !important;
+  span.anticon.anticon-plus {
     color: var(--title) !important;
-    padding-left: 65px !important;
   }
 
   &:hover {
     transition: 0.3s;
-    background-color: var(--button);
+    background-color: var(--button) !important;
   }
 }
 

--- a/app/components-react/shared/AddDestinationButton.tsx
+++ b/app/components-react/shared/AddDestinationButton.tsx
@@ -12,15 +12,23 @@ import cx from 'classnames';
 import { useRealmObject } from 'components-react/hooks/realm';
 
 const PlusIcon = PlusOutlined as Function;
-interface IAddDestinationButtonProps {
+interface IAddDestinationGroupProps {
   type?: 'default' | 'ultra' | 'small' | 'banner' | 'header';
   text?: string;
+  name?: string;
   className?: string;
   style?: CSSProperties;
   onClick?: () => void;
 }
 
-export default function AddDestinationButton(p: IAddDestinationButtonProps) {
+interface IAddDestinationButtonProps {
+  name?: string;
+  className?: string;
+  isDualOutputMode?: boolean;
+  onClick: () => void;
+}
+
+export default function AddDestinationButton(p: IAddDestinationGroupProps) {
   const { addDestination, btnType, isDualOutputMode } = useGoLiveSettings().extend(module => {
     const { RestreamService, SettingsService, MagicLinkService } = Services;
 
@@ -66,6 +74,7 @@ export default function AddDestinationButton(p: IAddDestinationButtonProps) {
     >
       {type === 'default' && (
         <DefaultAddDestinationButton
+          name={p?.name}
           className={p?.className}
           onClick={p?.onClick ?? addDestination}
         />
@@ -73,6 +82,7 @@ export default function AddDestinationButton(p: IAddDestinationButtonProps) {
 
       {type === 'ultra' && (
         <UltraAddDestinationButton
+          name={p?.name}
           className={p?.className}
           isDualOutputMode={isDualOutputMode}
           onClick={p?.onClick ?? addDestination}
@@ -81,26 +91,35 @@ export default function AddDestinationButton(p: IAddDestinationButtonProps) {
 
       {type === 'small' && (
         <SmallAddDestinationButton
+          name={p?.name}
           className={p?.className}
           onClick={p?.onClick ?? addDestination}
         />
       )}
 
       {type === 'banner' && (
-        <AddDestinationBanner className={p?.className} onClick={p?.onClick ?? addDestination} />
+        <AddDestinationBanner
+          name={p?.name}
+          className={p?.className}
+          onClick={p?.onClick ?? addDestination}
+        />
       )}
 
       {type === 'header' && (
-        <AddDestinationHeader className={p?.className} onClick={p?.onClick ?? addDestination} />
+        <AddDestinationHeader
+          name={p?.name}
+          className={p?.className}
+          onClick={p?.onClick ?? addDestination}
+        />
       )}
     </ButtonGroup>
   );
 }
 
-function DefaultAddDestinationButton(p: { className?: string; onClick: () => void }) {
+function DefaultAddDestinationButton(p: IAddDestinationButtonProps) {
   return (
     <Button
-      data-name="default-add-destination"
+      name={p?.name ?? 'default-add-destination'}
       className={cx(styles.addDestinationBtn, styles.defaultOutputBtn, p.className)}
       onClick={p.onClick}
       block
@@ -111,28 +130,24 @@ function DefaultAddDestinationButton(p: { className?: string; onClick: () => voi
   );
 }
 
-function SmallAddDestinationButton(p: { className?: string; onClick: () => void }) {
+function SmallAddDestinationButton(p: IAddDestinationButtonProps) {
   return (
     <Button
-      data-name="default-add-destination"
-      className={cx(styles.addDestinationBtn, styles.smallBtn, p.className)}
+      name={p?.name ?? 'default-add-destination'}
+      className={cx(styles.smallBtn, p.className)}
       onClick={p.onClick}
       block
     >
-      <PlusIcon style={{ paddingLeft: '17px', fontSize: '24px' }} />
-      <span style={{ flex: 1 }}>{$t('Add Destination')}</span>
+      <PlusIcon style={{ color: 'var(--title)' }} />
+      <span>{$t('Add Destination')}</span>
     </Button>
   );
 }
 
-function UltraAddDestinationButton(p: {
-  className?: string;
-  isDualOutputMode: boolean;
-  onClick: () => void;
-}) {
+function UltraAddDestinationButton(p: IAddDestinationButtonProps) {
   return (
     <ButtonHighlighted
-      data-name="ultra-add-destination"
+      name={p?.name ?? 'ultra-add-destination'}
       faded
       className={cx(
         styles.addDestinationBtn,
@@ -151,17 +166,18 @@ function UltraAddDestinationButton(p: {
   );
 }
 
-function AddDestinationBanner(p: { className?: string; onClick: () => void }) {
+function AddDestinationBanner(p: IAddDestinationButtonProps) {
   const isDarkTheme = useRealmObject(Services.CustomizationService.state).isDarkTheme;
 
   const text = $t('Unlock unlimited multistreaming with Ultra and grow your audience faster');
 
   return (
     <ButtonHighlighted
-      data-name="banner-add-destination"
-      faded
-      className={cx(styles.infoBanner, { [styles.night]: isDarkTheme }, p?.className)}
+      name={p?.name ?? 'banner-add-destination'}
+      faded={isDarkTheme}
+      className={cx(styles.infoBanner, p?.className)}
       onClick={p.onClick}
+      filledLight={!isDarkTheme}
     >
       <UltraIcon type="badge" className={styles.ultraIcon} />
       <div className={styles.ultraText}>
@@ -174,7 +190,7 @@ function AddDestinationBanner(p: { className?: string; onClick: () => void }) {
   );
 }
 
-function AddDestinationHeader(p: { className?: string; onClick: () => void }) {
+function AddDestinationHeader(p: IAddDestinationButtonProps) {
   const isDarkTheme = useRealmObject(Services.CustomizationService.state).isDarkTheme;
 
   const text = $t(
@@ -183,10 +199,11 @@ function AddDestinationHeader(p: { className?: string; onClick: () => void }) {
 
   return (
     <ButtonHighlighted
-      data-name="header-add-destination"
-      faded
+      name={p?.name ?? 'header-add-destination'}
+      faded={isDarkTheme}
+      filledLight={!isDarkTheme}
       noMargin
-      className={cx(styles.addDestinationHeader, { [styles.night]: isDarkTheme }, p?.className)}
+      className={cx(styles.addDestinationHeader, p?.className)}
       onClick={p.onClick}
     >
       <UltraIcon type="badge" className={styles.ultraIconLg} />


### PR DESCRIPTION
# Go Live UI 7c: AddDestinationButton Refactor

**Stack:** `master` ← 7a ← 7b ← **7c** ← 7d ← 7e ← 7f ← 8

## Summary
- Add `name` prop passthrough to all `AddDestinationButton` variants
- Replace `data-name` with `name` attributes for consistent test targeting
- Refactor internal component interfaces to use shared `IAddDestinationButtonProps`
- Update banner `faded`/`filledLight` logic based on dark theme
- Simplify `SmallAddDestinationButton` layout and move `background-color` to ultra variant only

## Files Changed

| File | Change |
|------|--------|
| `app/components-react/shared/AddDestinationButton.tsx` | Add `name` prop, refactor interfaces, update banner theme logic |
| `app/components-react/shared/AddDestinationButton.m.less` | Move `background-color` to `.ultra-btn`, simplify `.small-btn`, adjust margins |

## Performance Implications
None. Component prop refactoring and CSS adjustments.