### PR TITLE
[7d] Go Live Window UI - AI Highlighter Banner + Test Tagging

### DIFF
--- a/app/components-react/highlighter/ImportStream.tsx
+++ b/app/components-react/highlighter/ImportStream.tsx
@@ -1,6 +1,7 @@
-import { Button, Form, Select } from 'antd';
+import { Button, Select } from 'antd';
 import { Services } from 'components-react/service-provider';
 import { ListInput, TextInput } from 'components-react/shared/inputs';
+import Form from 'components-react/shared/inputs/Form';
 import * as remote from '@electron/remote';
 import { SUPPORTED_FILE_TYPES } from 'services/highlighter/constants';
 import { EGame } from 'services/highlighter/models/ai-highlighter.models';

--- a/app/components-react/highlighter/SettingsView.tsx
+++ b/app/components-react/highlighter/SettingsView.tsx
@@ -263,7 +263,26 @@ export default function SettingsView({
                   )}
                 </p>
 
-                {renderInstallSection()}
+                {v.highlighterVersion !== '' ? (
+                  <SwitchInput
+                    name="useHighlighter"
+                    style={{ margin: 0, marginLeft: '-10px' }}
+                    size="default"
+                    value={disableAIHighlighter ? false : v.useAiHighlighter}
+                    onChange={handleToggleHighlighter}
+                  />
+                ) : (
+                  <Button
+                    name="installHighlighter"
+                    style={{ width: 'fit-content' }}
+                    type="primary"
+                    onClick={() => {
+                      HighlighterService.actions.installAiHighlighter(true, 'Highlighter-tab');
+                    }}
+                  >
+                    {$t('Install AI Highlighter App')}
+                  </Button>
+                )}
                 <div className={styles.recommendedCorner}>{$t('Recommended')}</div>
               </div>
             )}

--- a/app/components-react/highlighter/migration/PageInstallationFlow.tsx
+++ b/app/components-react/highlighter/migration/PageInstallationFlow.tsx
@@ -42,6 +42,7 @@ export default function PageInstallationFlow(props: IPageInstallationFlowProps) 
         features={CAROUSEL_FEATURES}
       >
         <div
+          data-name="streamlabs-highlighter"
           style={{ height: 82, display: 'flex', flexDirection: 'column', justifyContent: 'end' }}
         >
           <PageInstallCta

--- a/app/components-react/windows/go-live/AiHighlighterToggle.m.less
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.m.less
@@ -5,6 +5,55 @@
 @paddingRight: 24px;
 @paddingBottom: 20px;
 
+.highlighter-banner {
+  display: flex;
+  align-items: center;
+  background-color: var(--callout);
+  border-radius: 4px;
+
+  :global(.ant-alert-message) {
+    color: var(--section);
+    font-weight: 500;
+
+    span {
+      vertical-align: text-top;
+    }
+
+    a {
+      color: var(--section);
+    }
+  }
+
+  :global(.ant-alert-info) {
+    background-color: unset;
+    border: 0px;
+  }
+
+  :global(.ant-row.ant-form-item) {
+    margin-top: 0px;
+    margin-left: 8px;
+  }
+
+  :global(.ant-switch:not(.ant-switch-checked)) {
+    background-color: var(--icon-toggle);
+  }
+
+  // :global(.ant-switch-checked) {
+  //   background-color: unset !important;
+  // }
+
+  //   background-color: var(--button);
+  // }
+
+  // :global(.ant-switch-handle::before) {
+  //   background-color: var(--title);
+  // }
+
+  // :global(.ant-switch-checked) {
+  //   background-color: var(--button-hover) !important;
+  // }
+}
+
 .ai-highlighter-box {
   position: relative;
   overflow: hidden;
@@ -178,3 +227,15 @@
   align-items: center;
   justify-content: space-between;
 }
+
+.highlighter-card {
+  margin: 16px 0px;
+  display: flex;
+  justify-content: flex-end;
+  flex-flow: row-wrap;
+  width: 100%;
+  background-color: var(--dark-background);
+  border-radius: 8px;
+}
+
+// .highlighter-banner___36EFl .ant-switch-handle::before

--- a/app/components-react/windows/go-live/AiHighlighterToggle.tsx
+++ b/app/components-react/windows/go-live/AiHighlighterToggle.tsx
@@ -1,11 +1,11 @@
 import { SwitchInput } from 'components-react/shared/inputs/SwitchInput';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, memo } from 'react';
 import styles from './AiHighlighterToggle.m.less';
 import { Services } from 'components-react/service-provider';
 import * as remote from '@electron/remote';
 import { useDebounce, useVuex } from 'components-react/hooks';
 import { DownOutlined, UpOutlined } from '@ant-design/icons';
-import { Button } from 'antd';
+import { Alert, Button } from 'antd';
 import { getConfigByGame, isGameSupported } from 'services/highlighter/models/game-config.models';
 import { $t } from 'services/i18n';
 import { DiscordLogo } from 'components-react/highlighter/HypeWrapper';
@@ -13,6 +13,8 @@ import PlatformLogo from 'components-react/shared/PlatformLogo';
 import { REPLAY_APP_NAME } from 'services/highlighter/constants';
 import { EAvailableFeatures } from 'services/incremental-rollout';
 import { promptAction } from 'components-react/modals';
+import InputWrapper from 'components-react/shared/inputs/InputWrapper';
+import Translate from 'components-react/shared/Translate';
 
 export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded: boolean }) {
   //TODO M: Probably good way to integrate the highlighter in to GoLiveSettings
@@ -161,7 +163,9 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
       {gameIsSupported ? (
         <div
           key={'aiSelector'}
+          data-name="ai-highlighter-selector"
           style={{
+            marginTop: '12px',
             marginBottom: '24px',
             display: 'flex',
             justifyContent: 'flex-end',
@@ -191,6 +195,7 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
 
                   {highlighterVersion !== '' ? (
                     <SwitchInput
+                      name="replay"
                       style={{ width: '80px', margin: 0, marginTop: '-2px' }}
                       value={disableAIHighlighter ? false : useHighlighter}
                       label=""
@@ -365,3 +370,45 @@ export default function AiHighlighterToggle({ cardIsExpanded }: { cardIsExpanded
     </div>
   );
 }
+
+const AIHighlighterBanner = memo(
+  (p: { game: string | undefined; toggleHighlighter: () => void }) => {
+    const { HighlighterService } = Services;
+    const { useHighlighter } = useVuex(
+      () => ({
+        useHighlighter: HighlighterService.views.useAiHighlighter,
+      }),
+      false,
+    );
+
+    const installAiHighlighter = useDebounce(300, () => {
+      HighlighterService.actions.installAiHighlighter(false, 'Go-live-flow', p.game);
+    });
+
+    return (
+      <InputWrapper layout="vertical" nolabel className={styles.highlighterBannerWrapper}>
+        <div className={styles.highlighterBanner}>
+          <SwitchInput
+            value={useHighlighter}
+            label={$t('AI Highlighter')}
+            onChange={p.toggleHighlighter}
+            nolabel
+          />
+          <Alert
+            message={
+              <Translate
+                message={$t(
+                  'Automatically capture highlights of your game with <replay>Replay</replay>',
+                )}
+              >
+                <a slot="replay" onClick={installAiHighlighter}>
+                  <b>{'Replay'}</b>
+                </a>
+              </Translate>
+            }
+          />
+        </div>
+      </InputWrapper>
+    );
+  },
+);


### PR DESCRIPTION
# Go Live UI 7d: AI Highlighter & Highlighter UI

**Stack:** `master` ← 7a ← 7b ← 7c ← **7d** ← 7e ← 7f ← 8

## Summary
- Add `AIHighlighterBanner` component for compact go-live integration
- Add `.highlighter-banner` and `.highlighter-card` CSS classes
- Add `data-name` and `name` attributes to highlighter toggle elements
- Switch `ImportStream` to use internal `Form` component instead of antd `Form`
- Add `name` props to `SettingsView` switch/button for test targeting
- Add `data-name` to `PageInstallationFlow` for test targeting

## Files Changed

| File | Change |
|------|--------|
| `app/components-react/windows/go-live/AiHighlighterToggle.tsx` | Add `AIHighlighterBanner` memo component, add `data-name`/`name` attrs |
| `app/components-react/windows/go-live/AiHighlighterToggle.m.less` | Add `.highlighter-banner` and `.highlighter-card` styles |
| `app/components-react/highlighter/ImportStream.tsx` | Replace antd `Form` with internal `Form` component |
| `app/components-react/highlighter/SettingsView.tsx` | Add `name` props to `SwitchInput` and `Button` |
| `app/components-react/highlighter/migration/PageInstallationFlow.tsx` | Add `data-name="streamlabs-highlighter"` |

## Performance Implications
None. New component is memo-wrapped. All other changes are attribute additions.