### PR TITLE
[7e] Go Live Window UI - Changes for RecordingSwitcher, modals, ObsForm, TwitchTagsInput.

### DIFF
--- a/app/components-react/modals.tsx
+++ b/app/components-react/modals.tsx
@@ -135,6 +135,7 @@ export function promptAction(p: {
   icon?: React.ReactNode;
   secondaryActionText?: string;
   secondaryActionFn?: () => unknown;
+  maskClosable?: boolean;
 }) {
   return alertAsync({
     bodyStyle: { padding: '24px' },
@@ -144,7 +145,7 @@ export function promptAction(p: {
     content: p.message,
     icon: p?.icon,
     closable: true,
-    maskClosable: true,
+    maskClosable: p.maskClosable ?? true,
     cancelButtonProps: { style: { display: 'none' } },
     okButtonProps: { style: { display: 'none' } },
     modalRender: node => (

--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -115,7 +115,6 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
   };
 
   switch (type) {
-    case 'OBS_PROPERTY_FLOAT':
     case 'OBS_PROPERTY_DOUBLE':
       return <ObsNumberInput {...inputProps} ref={ref} data-name={p.value.name} />;
     case 'OBS_PROPERTY_INT':

--- a/app/components-react/windows/go-live/RecordingSwitcher.m.less
+++ b/app/components-react/windows/go-live/RecordingSwitcher.m.less
@@ -2,22 +2,29 @@
 
 .recording-tooltip {
   display: flex;
+  flex-direction: row;
   align-items: center;
 
   i.info {
     margin-left: 10px;
   }
 
-  :global(div.ant-form-item) {
+  :global(.ant-col.ant-form-item-label) {
+    display: none !important;
+  }
+
+  :global(.ant-row.ant-form-item) {
     margin-right: 0px !important;
-    margin-bottom: 0px !important;
+  }
+
+  :global(.ant-switch.ant-switch-small) {
+    margin-right: 0px !important;
   }
 }
 
 .recording-switcher {
-  display: flex;
-  justify-content: flex-start;
-  flex: 1;
+  color: var(--title);
+  margin-right: 16px;
 
   :global(.ant-switch-checked) {
     background-color: var(--title);

--- a/app/components-react/windows/go-live/RecordingSwitcher.tsx
+++ b/app/components-react/windows/go-live/RecordingSwitcher.tsx
@@ -10,6 +10,7 @@ import { RadioInput } from 'components-react/shared/inputs/RadioInput';
 import cx from 'classnames';
 import { EAvailableFeatures } from 'services/incremental-rollout';
 import { TDisplayType } from 'services/settings-v2/video';
+import { isGameSupported } from 'services/highlighter/models/game-config.models';
 
 interface IRecordingSettingsProps {
   showRecordingToggle?: boolean;
@@ -20,7 +21,7 @@ interface IRecordingSettingsProps {
 }
 
 export default function RecordingSwitcher(p: IRecordingSettingsProps) {
-  const { updateRecordingDisplayAndSaveSettings } = useGoLiveSettings();
+  const { updateRecordingDisplayAndSaveSettings, game } = useGoLiveSettings();
   const {
     DualOutputService,
     StreamSettingsService,
@@ -43,9 +44,14 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
       StreamSettingsService.views.settings?.goLiveSettings?.recording ?? 'horizontal',
   }));
 
-  const recordWhenStartStream = useMemo(() => v.recordWhenStreaming || v.useAiHighlighter, [
+  const shouldUseAiHighlighter = useMemo(() => {
+    return isGameSupported(game) && v.useAiHighlighter;
+  }, [game, v.useAiHighlighter]);
+
+  const recordWhenStartStream = useMemo(() => v.recordWhenStreaming || shouldUseAiHighlighter, [
     v.recordWhenStreaming,
-    v.useAiHighlighter,
+    shouldUseAiHighlighter,
+    game,
   ]);
 
   const showRecordingToggle = useMemo(() => p?.showRecordingToggle ?? false, [
@@ -60,14 +66,14 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
     return false;
   }, [v.isDualOutputMode, v.canRecordVertical]);
 
-  const disableToggle = useMemo(() => v.useAiHighlighter || v.isRecording, [
-    v.useAiHighlighter,
+  const disableToggle = useMemo(() => shouldUseAiHighlighter || v.isRecording, [
+    shouldUseAiHighlighter,
     v.isRecording,
   ]);
 
   const disableIcons = useMemo(
-    () => v.useAiHighlighter || v.isRecording || v.isReplayBufferActive,
-    [v.useAiHighlighter, v.isRecording, v.isReplayBufferActive],
+    () => shouldUseAiHighlighter || v.isRecording || v.isReplayBufferActive,
+    [shouldUseAiHighlighter, v.isRecording, v.isReplayBufferActive, game],
   );
 
   const options = useMemo(() => {
@@ -82,12 +88,17 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
       v.isRecording
         ? $t('Recording in progress. Stop recording to change the recording display.')
         : $t('AI Highlighter is enabled. Recording will start when stream starts.'),
-    [v.isRecording],
+    [v.isRecording, shouldUseAiHighlighter, game],
   );
 
   return (
-    <div style={p?.style} className={cx(p?.className, styles.recordingSwitcher)}>
+    <div
+      data-name="recording-switcher"
+      style={p?.style}
+      className={cx(p?.className, styles.recordingSwitcher)}
+    >
       <Tooltip
+        name="recording-toggle-tooltip"
         title={message}
         disabled={!disableToggle && !p?.showTooltip}
         placement="topRight"
@@ -96,13 +107,13 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
       >
         {showRecordingToggle && (
           <SwitchInput
-            name="recording-toggle"
+            name="recording"
             value={recordWhenStartStream}
             onChange={val => {
               SettingsService.actions.setSettingValue('General', 'RecordWhenStreaming', val);
             }}
             uncontrolled
-            label={showRecordingIcons ? $t('Record Stream in') : $t('Record Stream')}
+            label={$t('Record Stream')}
             layout="horizontal"
             checkmark
             disabled={disableToggle}
@@ -111,15 +122,15 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
         {showRecordingIcons && (
           <>
             <RadioInput
-              name="recording-display"
+              name="recordingDisplay"
               defaultValue="horizontal"
               value={v.recordingDisplay}
               label={p?.label}
               options={options}
               onChange={val => updateRecordingDisplayAndSaveSettings(val as TDisplayType)}
               icons={true}
-              className={styles.recordingDisplay}
               disabled={v.isRecording || disableIcons}
+              optionType="default"
             />
           </>
         )}

--- a/app/components-react/windows/go-live/platforms/TwitchTagsInput.tsx
+++ b/app/components-react/windows/go-live/platforms/TwitchTagsInput.tsx
@@ -58,6 +58,7 @@ export function TwitchTagsInput(p: TTwitchTagsInputProps) {
       dropdownStyle={{ display: 'none' }}
       layout={p.layout}
       size="large"
+      style={{ flex: 1 }}
     />
   );
 }


### PR DESCRIPTION
# Go Live UI 7e: RecordingSwitcher, Modals & Misc

**Stack:** `master` ← 7a ← 7b ← 7c ← 7d ← **7e** ← 7f ← 8

## Summary
- Make RecordingSwitcher AI Highlighter logic game-aware via `isGameSupported`
- Add `data-name` and `name` attributes to RecordingSwitcher for test targeting
- Update RecordingSwitcher CSS for row layout and theme-aware colors
- Add `maskClosable` option to `promptAction` modal helper
- Remove `OBS_PROPERTY_FLOAT` case fallthrough in ObsForm
- Add flex styling to `TwitchTagsInput`

## Files Changed

| File | Change |
|------|--------|
| `app/components-react/windows/go-live/RecordingSwitcher.tsx` | Game-aware AI Highlighter toggle, add `data-name`/`name` attrs, rename form fields |
| `app/components-react/windows/go-live/RecordingSwitcher.m.less` | Row layout, hide label, theme color updates |
| `app/components-react/modals.tsx` | Add `maskClosable` option to `promptAction` |
| `app/components-react/obs/ObsForm.tsx` | Remove `OBS_PROPERTY_FLOAT` case (handled by `OBS_PROPERTY_INT`) |
| `app/components-react/windows/go-live/platforms/TwitchTagsInput.tsx` | Add `style={{ flex: 1 }}` |

## Performance Implications
None. The `isGameSupported` check is a lightweight lookup.