### PR TITLE
Fix laggy OBS settings text/path inputs

### DIFF
--- a/app/components-react/obs/ObsForm.tsx
+++ b/app/components-react/obs/ObsForm.tsx
@@ -161,6 +161,7 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
         return (
           <ObsTextInput
             {...inputProps}
+            uncontrolled
             isPassword={inputProps.masked}
             ref={ref}
             data-name={p.value.name}
@@ -309,6 +310,7 @@ const ObsInput = forwardRef<{}, IObsInputProps>((p, ref) => {
       return (
         <ObsTextInput
           {...inputProps}
+          uncontrolled
           style={{ marginBottom: '8px' }}
           addonAfter={
             <Button onClick={() => showFileDialog({ ...inputProps, directory: true })}>


### PR DESCRIPTION
OBS settings text/path fields saved to the backend on every keystroke, making typing laggy and, on slow machines, missing characters (e.g. the drive colon in a recording path lead to failed recordings on the Win2025 CI runner).

Set these inputs to `uncontrolled` so they commit on unfocus instead of per keystroke.