### PR TITLE
[7g] Go Live UI Fixes for 7f

### DIFF
--- a/app/components-react/root/StudioEditor.tsx
+++ b/app/components-react/root/StudioEditor.tsx
@@ -406,12 +406,15 @@ function DualOutputControls(p: { stacked: boolean; isRecording: boolean }) {
   const v = useVuex(() => ({ toggleDisplay: Services.DualOutputService.actions.toggleDisplay }));
 
   const showRecordingIcons = useMemo(() => {
-    return (
-      p.isRecording &&
-      Services.IncrementalRolloutService.views.featureIsEnabled(
-        EAvailableFeatures.dualOutputRecording,
-      )
-    );
+    return false;
+    // TODO: Comment in when ready for testing
+
+    // return (
+    //   p.isRecording &&
+    //   Services.IncrementalRolloutService.views.featureIsEnabled(
+    //     EAvailableFeatures.dualOutputRecording,
+    //   )
+    // );
   }, [p.isRecording]);
 
   return (

--- a/app/components-react/root/StudioFooter.tsx
+++ b/app/components-react/root/StudioFooter.tsx
@@ -304,16 +304,17 @@ const RecordingTooltipTitle = memo(
     }, [p.isRecording, p.isDualOutputMode, p.useAiHighlighter]);
 
     const showRecordingSwitcher = useMemo(() => {
-      if (
-        Services.IncrementalRolloutService.views.featureIsEnabled(
-          EAvailableFeatures.verticalRecording,
-        ) ||
-        Services.IncrementalRolloutService.views.featureIsEnabled(
-          EAvailableFeatures.dualOutputRecording,
-        )
-      ) {
-        return p.isDualOutputMode && !p.isRecording && !p.useAiHighlighter;
-      }
+      // TODO: Comment in when ready for testing
+      // if (
+      //   Services.IncrementalRolloutService.views.featureIsEnabled(
+      //     EAvailableFeatures.verticalRecording,
+      //   ) ||
+      //   Services.IncrementalRolloutService.views.featureIsEnabled(
+      //     EAvailableFeatures.dualOutputRecording,
+      //   )
+      // ) {
+      //   return p.isDualOutputMode && !p.isRecording && !p.useAiHighlighter;
+      // }
 
       return false;
     }, [p.isDualOutputMode, p.isRecording, p.useAiHighlighter]);

--- a/app/components-react/shared/DisplaySelector.tsx
+++ b/app/components-react/shared/DisplaySelector.tsx
@@ -25,6 +25,7 @@ export default function DisplaySelector(p: IDisplaySelectorProps) {
     canDualStream,
     updateCustomDestinationDisplayAndSaveSettings,
     updatePlatformDisplayAndSaveSettings,
+    toggleVerticalDisplay,
   } = useGoLiveSettings().extend(module => ({
     get canDualStream() {
       if (!p.platform) return false;
@@ -89,6 +90,12 @@ export default function DisplaySelector(p: IDisplaySelectorProps) {
           throw new Error('Attempted to update custom display for dual stream, this is impossible');
         }
         updateCustomDestinationDisplayAndSaveSettings(p.index, updatedDisplay as TDisplayType);
+      }
+
+      // When the user selects either of these displays it indicates that they will stream in dual output mode,
+      // so if they do not already have the vertical display visible in the editor, show it
+      if (updatedDisplay === 'both' || updatedDisplay === 'vertical') {
+        toggleVerticalDisplay();
       }
     },
     [

--- a/app/components-react/shared/DisplaySelector.tsx
+++ b/app/components-react/shared/DisplaySelector.tsx
@@ -17,6 +17,7 @@ interface IDisplaySelectorProps {
   nolabel?: boolean;
   alignIcons?: 'left' | 'center' | 'right';
   visible?: boolean;
+  disabled?: boolean;
 }
 
 export default function DisplaySelector(p: IDisplaySelectorProps) {
@@ -134,6 +135,7 @@ export default function DisplaySelector(p: IDisplaySelectorProps) {
       gapsize={0}
       nowrap
       optionType="button"
+      disabled={p?.disabled}
     />
   );
 }

--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -38,6 +38,7 @@ export const DestinationSwitchers = memo(() => {
     disableNonUltraSwitchers,
     nonPrimeBothDisplayPlatform,
     getUsername,
+    isLoading,
   } = useGoLiveSettings().extend(module => ({
     get renderedPlatforms() {
       // Some platforms are always shown, even if not linked so add them to the list of platforms to display
@@ -201,6 +202,7 @@ export const DestinationSwitchers = memo(() => {
             isPrime={isPrime}
             username={getUsername(platform)}
             index={ind}
+            isLoading={isLoading}
           />
         );
       })}
@@ -227,6 +229,7 @@ export const DestinationSwitchers = memo(() => {
             showDisplaySelector={visible}
             isPrime={isPrime}
             index={ind}
+            isLoading={isLoading}
           />
         );
       })}
@@ -246,6 +249,8 @@ interface IDestinationSwitcherProps {
   isPrime: boolean;
   username?: string;
   isUnlinked?: boolean;
+  /** Disable the switch while the go live window is loading/refreshing settings */
+  isLoading?: boolean;
 }
 
 /**
@@ -289,6 +294,9 @@ const DestinationSwitcher = memo(
       (e: MouseEvent) => {
         const enabled = p.enabled;
 
+        // Ignore toggles while the go live window is loading/refreshing settings
+        if (p.isLoading) return enabled;
+
         if (!p.isPrime) {
           if (p.bothDisplayPlatformLabel) {
             alertInfo({
@@ -309,7 +317,7 @@ const DestinationSwitcher = memo(
         if (disabled) return enabled;
         return onChange(!enabled);
       },
-      [p.enabled, onChange, p.bothDisplayPlatformLabel, disabled],
+      [p.enabled, p.isLoading, onChange, p.bothDisplayPlatformLabel, disabled],
     );
 
     const { title, description } = useMemo(() => {
@@ -365,6 +373,7 @@ const DestinationSwitcher = memo(
         label={label}
         title={title}
         description={description}
+        switchDisabled={p.isLoading}
         className={cx({ [styles.disabled]: disabled })}
         tooltipClassName={styles.switcherTooltip}
       >

--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -393,6 +393,7 @@ const DestinationSwitcher = memo(
             index={p.index}
             alignIcons="left"
             visible={p.showDisplaySelector}
+            disabled={p.isLoading}
           />
         </AnimatedWrapper>
       </SwitcherCard>

--- a/app/components-react/windows/go-live/RecordingSwitcher.tsx
+++ b/app/components-react/windows/go-live/RecordingSwitcher.tsx
@@ -59,9 +59,10 @@ export default function RecordingSwitcher(p: IRecordingSettingsProps) {
   ]);
 
   const showRecordingIcons = useMemo(() => {
-    if (v.canRecordVertical) {
-      return v.isDualOutputMode;
-    }
+    // TODO: Comment in when ready for testing
+    // if (v.canRecordVertical) {
+    //   return v.isDualOutputMode;
+    // }
 
     return false;
   }, [v.isDualOutputMode, v.canRecordVertical]);

--- a/app/components-react/windows/go-live/SwitcherCard.tsx
+++ b/app/components-react/windows/go-live/SwitcherCard.tsx
@@ -34,6 +34,7 @@ interface ISwitcherCardProps {
   switchClassName?: string;
   tooltipClassName?: string;
   disabled?: boolean;
+  switchDisabled?: boolean;
 }
 
 interface ISwitcherCardContentsProps {
@@ -49,6 +50,7 @@ interface ISwitcherCardContentsProps {
   icon?: string | ReactNode;
   description: string;
   children?: ReactNode;
+  switchDisabled?: boolean;
 }
 
 /**
@@ -122,7 +124,7 @@ export const SwitcherCard = forwardRef<ISwitcherCardHandle, ISwitcherCardProps>(
         onTransitionEnd={handleTransitionEnd}
         value={displayValue}
         name={p.name}
-        disabled={p.disabled}
+        disabled={p.disabled || p.switchDisabled}
         label={p.label}
         title={p.title}
         icon={p.icon}

--- a/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
+++ b/app/components-react/windows/go-live/platforms/YoutubeEditStreamInfo.tsx
@@ -221,17 +221,19 @@ export const YoutubeEditStreamInfo = InputComponent((p: IPlatformComponentParams
               </InputWrapper>
               <InputWrapper label={$t('Made for kids')} layout="vertical" nolabel>
                 <CheckboxInput label={$t('Made for kids')} {...bind.selfDeclaredMadeForKids} />
-                {shouldShowSafeForKidsWarn && (
-                  <p>
-                    {$t(
-                      "Features like personalized ads and live chat won't be available on live streams made for kids.",
-                    )}
-                  </p>
-                )}
               </InputWrapper>
             </>
           )}
         </div>
+        {/* Render the warning below the checkbox row so checking "Made for kids" doesn't
+            reflow the wrapping flex row and push the field to the next line. */}
+        {!isMidStreamMode && shouldShowSafeForKidsWarn && (
+          <p>
+            {$t(
+              "Features like personalized ads and live chat won't be available on live streams made for kids.",
+            )}
+          </p>
+        )}
       </div>
     );
   }

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -499,6 +499,12 @@ export class GoLiveSettingsModule {
     this.save(this.state.settings);
   }
 
+  toggleVerticalDisplay() {
+    if (Services.DualOutputService.views.showVerticalDisplay) return;
+    Services.DualOutputService.actions.toggleDualOutputMode(true);
+    Services.DualOutputService.actions.toggleDisplay(true, 'vertical');
+  }
+
   get enabledDestinations() {
     return this.state.customDestinations.reduce(
       (enabled: number[], dest: ICustomStreamDestination, index: number) => {

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -1797,6 +1797,15 @@ export class StreamingService
    * @param force - boolean, whether to force stop the stream
    */
   private async handleStopStreaming(force?: boolean) {
+    // Twitch dual streaming uses the `enhancedBroadcasting` instance but most of the
+    // streaming signal handling work with the `horizontal` instance. Because the `horizontal`
+    // instance is not streaming, but may exist to be used with the recording and replay buffer,
+    // handle this case on its own.
+    if (this.views.isTwitchDualStreaming) {
+      await this.stopTwitchDualStreamOutputs();
+      return;
+    }
+
     // Recording must be stopped before stopping the replay buffer
     // for the correct order of destruction of the context instances
     const keepRecording = this.streamSettingsService.settings.keepRecordingWhenStreamStops;
@@ -1849,6 +1858,33 @@ export class StreamingService
           $t('Error stopping stream: default streams do not exist.'),
         );
       }
+    }
+  }
+
+  /**
+   * Stop a Twitch Dual Stream
+   * @remark Twitch dual stream uses the `enhancedBroadcasting` instance. Because a streaming instance
+   * may exist for recording and replay buffer, handle dual streaming with Twitch on its own.
+   */
+  private async stopTwitchDualStreamOutputs() {
+    // Recording must be stopped before the replay buffer
+    const keepRecording = this.streamSettingsService.settings.keepRecordingWhenStreamStops;
+    if (!keepRecording && this.getIsRecordingStatus(ERecordingState.Recording)) {
+      await this.toggleRecording();
+    }
+
+    // Replay buffer must be stopped after the recording
+    const keepReplaying = this.streamSettingsService.settings.keepReplayBufferStreamStops;
+    if (!keepReplaying && this.getIsReplayBufferStatus(EReplayBufferState.Running)) {
+      this.stopReplayBuffer();
+    }
+
+    // Stop the Twitch dual stream (enhanced broadcasting instance)
+    if (this.contexts.enhancedBroadcasting.streaming) {
+      this.contexts.enhancedBroadcasting.streaming.stop(true);
+    } else {
+      // This should never happen but to ensure that the stream does actually stop, cleanup here
+      this.handleCleanupStreamingInstances({ skipHorizontal: false });
     }
   }
 
@@ -2725,6 +2761,18 @@ export class StreamingService
         if (this.isReplayBufferActive) {
           this.stopReplayBuffer();
         }
+      }
+
+      // Handle Twitch dual streaming separately because it does use the horizontal streaming instance
+      // so we can't rely on the horizontal streaming instance signals
+      if (context === 'enhancedBroadcasting' && this.views.isTwitchDualStreaming) {
+        this.SET_STREAMING_STATUS(EStreamingState.Offline, 'horizontal', new Date().toISOString());
+        this.streamingStatusChange.next(EStreamingState.Offline);
+
+        await this.handleDestroyOutputContexts('enhancedBroadcasting');
+        await this.handleDestroyOutputContexts('horizontal');
+        await this.handleDestroyOutputContexts('vertical');
+        return;
       }
 
       // For the UI, set the streaming status to offline on the `deactivate` signal

--- a/app/styles/antd/day-theme.lazy.less
+++ b/app/styles/antd/day-theme.lazy.less
@@ -189,6 +189,11 @@
   border-left: 0;
 }
 
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}
+
 // make button text not disappear on hover
 .ant-btn:hover,
 .ant-btn:focus {

--- a/app/styles/antd/golive-day-theme.lazy.less
+++ b/app/styles/antd/golive-day-theme.lazy.less
@@ -124,3 +124,16 @@
 
 @border-radius-base: 4px;
 @font-family: 'Roboto', sans-serif;
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner::after {
+  border: 2px solid @light-1;
+  border-top: 0;
+  border-left: 0;
+}
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}

--- a/app/styles/antd/golive-night-theme.lazy.less
+++ b/app/styles/antd/golive-night-theme.lazy.less
@@ -124,3 +124,16 @@
 
 @border-radius-base: 4px;
 @font-family: 'Roboto', sans-serif;
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner::after {
+  border: 2px solid @dark-2;
+  border-top: 0;
+  border-left: 0;
+}
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}

--- a/app/styles/antd/golive-prime-dark.lazy.less
+++ b/app/styles/antd/golive-prime-dark.lazy.less
@@ -126,3 +126,16 @@
 
 @border-radius-base: 4px;
 @font-family: 'Roboto', sans-serif;
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner::after {
+  border: 2px solid @primedark-1;
+  border-top: 0;
+  border-left: 0;
+}
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}

--- a/app/styles/antd/golive-prime-light.lazy.less
+++ b/app/styles/antd/golive-prime-light.lazy.less
@@ -124,3 +124,16 @@
 
 @border-radius-base: 4px;
 @font-family: 'Roboto', sans-serif;
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner::after {
+  border: 2px solid @primelight-1;
+  border-top: 0;
+  border-left: 0;
+}
+
+// Checkbox check icon color
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}

--- a/app/styles/antd/night-theme.lazy.less
+++ b/app/styles/antd/night-theme.lazy.less
@@ -196,6 +196,12 @@
   border-top: 0;
   border-left: 0;
 }
+
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}
+
 .ant-select-item-option-selected:not(.ant-select-item-option-disabled) {
   color: @dark-2;
 }

--- a/app/styles/antd/prime-dark.lazy.less
+++ b/app/styles/antd/prime-dark.lazy.less
@@ -190,6 +190,11 @@
   border-left: 0;
 }
 
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}
+
 // make button text not disappear on hover
 .ant-btn:hover,
 .ant-btn:focus {

--- a/app/styles/antd/prime-light.lazy.less
+++ b/app/styles/antd/prime-light.lazy.less
@@ -189,6 +189,11 @@
   border-left: 0;
 }
 
+.ant-checkbox-checked .ant-checkbox-inner {
+  background-color: var(--secondary-checkbox);
+  border-color: var(--secondary-checkbox);
+}
+
 // make button text not disappear on hover
 .ant-btn:hover,
 .ant-btn:focus {


### PR DESCRIPTION
# Go Live UI 7g: Go Live window UI fixes + Twitch dual stream teardown

Batch of Go Live UI fixes for [7f](https://github.com/streamlabs/desktop/pull/6036), plus a fix for ending a Twitch dual stream when recording/replay buffer are also running.

**Stack:** `master` ← 7a ← 7b ← 7c ← 7d ← 7e ← 7f ← **7g** ← 8

## Changes

- **Twitch dual stream fails to end** (`streaming.ts`) — when streaming Twitch `display: 'both'` + recording and/or replay buffer, the Twitch connection stayed open after End Stream. Added a dedicated teardown path that force-stops the Twitch (`enhancedBroadcasting`) instance and destroys the leftover display contexts in the right order.
- **YouTube "Made for kids" jumps to next line** — the warning text rendered inside the checkbox field widened it and wrapped the row. Moved the warning below the row; the checkbox now stays put.
- **Destination switchers interactive while loading** — disabled the switches while the Go Live window prepopulates/refreshes settings.
- **Vertical display not shown for `vertical`/`both`** — selecting those displays now enables dual output mode and shows the vertical display.
- **Checkbox theming** — added missing checked-checkbox color classes across the antd theme files.
- **Hide recording icons** — recording icons and toggles commented out