### PR TITLE
Tests except stream shift.

### DIFF
--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -114,7 +114,6 @@ class GoLiveSettingsState extends StreamInfoView<IGoLiveSettingsState> {
             ),
           });
 
-          console.log('updating ', otherEnabledTarget, ' to disabled');
           // Update the settings to disable the other enabled platform
           updated = {
             platforms: {

--- a/app/components-react/windows/settings/Stream.tsx
+++ b/app/components-react/windows/settings/Stream.tsx
@@ -586,6 +586,7 @@ function CustomDestinationList() {
 
           {shouldShowPrimeLabel ? (
             <ButtonHighlighted
+              name="customDestUltraBtn"
               onClick={() => addCustomDest(true)}
               filled
               text={$t('Ultra')}

--- a/test/helpers/modules/forms/form.ts
+++ b/test/helpers/modules/forms/form.ts
@@ -282,29 +282,32 @@ export async function readFields(...args: unknown[]): Promise<TFormData> {
 
 /**
  * A shortcut for useForm().assertFormContains()
+ * Pass `indexKey` and `valueKey` to control field lookup (defaults: 'name', 'displayValue')
  */
 export async function assertFormContains(
   formData: TFormData,
-  indexKey?: string,
+  messageOrIndexKey?: string,
+  indexKeyOrValueKey?: string,
   valueKey?: string,
 ): Promise<unknown>;
 export async function assertFormContains(
   formName: string,
   formData: TFormData,
-  indexKey?: string,
+  messageOrIndexKey?: string,
+  indexKeyOrValueKey?: string,
   valueKey?: string,
 ): Promise<unknown>;
 export async function assertFormContains(...args: any[]): Promise<unknown> {
   if (typeof args[0] === 'string') {
-    const [formName, formData, indexKey, valueKey] = args;
+    const [formName, formData, ...rest] = args;
     // TODO: fake hook
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useForm(formName).assertFormContains(formData, indexKey, valueKey);
+    return useForm(formName).assertFormContains(formData, ...rest);
   } else {
-    const [formData, indexKey, valueKey] = args;
+    const [formData, ...rest] = args;
     // TODO: fake hook
     // eslint-disable-next-line react-hooks/rules-of-hooks
-    return useForm().assertFormContains(formData, indexKey, valueKey);
+    return useForm().assertFormContains(formData, ...rest);
   }
 }
 

--- a/test/helpers/modules/streaming.ts
+++ b/test/helpers/modules/streaming.ts
@@ -20,6 +20,12 @@ import { sleep } from '../sleep';
 import { fillForm, TFormData, useForm } from './forms';
 import { setOutputResolution, showSettingsWindow } from './settings/settings';
 import { StreamSettingsService } from '../../../app/services/settings/streaming';
+import {
+  WebsocketService,
+  IStreamShiftRequested,
+  IStreamShiftActionCompleted,
+} from '../../../app/services/websocket';
+import { RestreamService } from '../../../app/services/restream';
 
 /**
  * Go live and wait for stream start
@@ -153,13 +159,14 @@ export async function waitForSettingsWindowLoaded() {
 }
 
 async function waitForStreamShift() {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  await useMainWindow(async () => {
-    const streamShifted = await isDisplayed('span=Another stream detected', { timeout: 5000 });
-    if (streamShifted) {
-      await click('span=Force Start');
-    }
-  });
+  // The "Another stream detected" prompt renders in the child window (GoLive)
+  // via promptAction (Ant Design modal). Check the child window for the prompt
+  // and dismiss it if found so the go live flow can proceed.
+  await focusChild();
+  const streamShifted = await isDisplayed('span=Another stream detected', { timeout: 5000 });
+  if (streamShifted) {
+    await click('span=Force Start');
+  }
 }
 
 export async function switchAdvancedMode() {
@@ -237,4 +244,35 @@ export async function addCustomDestination(name: string, url: string, streamKey:
     streamKey,
   });
   await clickButton('Save');
+}
+
+/**
+ * Mock a Stream Shift socket event
+ *
+ * @param type - 'streamSwitchRequest' (switch to another device) or
+ *               'switchActionComplete' (switch to the current device)
+ * @param identifier - stream id
+ */
+export async function fireStreamShiftSocketEvent(
+  type: IStreamShiftRequested['type'] | IStreamShiftActionCompleted['type'],
+  identifier: string,
+): Promise<void> {
+  const event: IStreamShiftRequested | IStreamShiftActionCompleted = {
+    type,
+    for: '',
+    data: { identifier },
+    event_id: `test_${type}`,
+  };
+  (await getApiClient())
+    .getResource<WebsocketService>('WebsocketService')
+    .sendSocketEventForTest(event);
+}
+
+/**
+ * Emit directly on RestreamService.isLive, triggering the GoLive window's subscription
+ * without going through the real HTTP API. Pass true to show the "Another stream detected"
+ * prompt; pass false to clear it.
+ */
+export async function fireIsLiveEvent(isLive: boolean): Promise<void> {
+  (await getApiClient()).getResource<RestreamService>('RestreamService').emitIsLiveForTest(isLive);
 }

--- a/test/helpers/modules/user.ts
+++ b/test/helpers/modules/user.ts
@@ -1,6 +1,11 @@
 import { getContext, TExecutionContext } from '../webdriver';
 import { TPlatform } from '../../../app/services/platforms';
-import { ITestUserFeatures, reserveUserFromPool, logIn as userLogin } from '../webdriver/user';
+import {
+  ITestUser,
+  ITestUserFeatures,
+  reserveUserFromPool,
+  logIn as userLogin,
+} from '../webdriver/user';
 import { click, clickButton } from './core';
 import { fillForm } from './forms';
 import { showSettingsWindow } from './settings/settings';
@@ -14,9 +19,13 @@ export function logIn(
   return userLogin(getContext(), platform, features, waitForUI, isOnboardingTest);
 }
 
-export async function addCustomDestination(t: TExecutionContext) {
-  const user = await reserveUserFromPool(t, 'twitch');
-  const name = 'MyCustomDest';
+export async function addCustomDestination(
+  t: TExecutionContext,
+  destName?: string,
+  testUser?: ITestUser,
+) {
+  const user = testUser ?? (await reserveUserFromPool(t, 'twitch'));
+  const name = destName ?? 'MyCustomDest';
 
   // add new destination
   await showSettingsWindow('Stream');

--- a/test/regular/highlighter.ts
+++ b/test/regular/highlighter.ts
@@ -1,20 +1,24 @@
 import { test, useWebdriver } from '../helpers/webdriver';
 import { setTemporaryRecordingPath } from '../helpers/modules/settings/settings';
-import { click, clickButton, focusMain, select, waitForDisplayed } from '../helpers/modules/core';
+import { clickButton, focusMain, isDisplayed, waitForDisplayed } from '../helpers/modules/core';
 import { showPage } from '../helpers/modules/navigation';
 import {
+  clickGoLive,
   prepareToGoLive,
   stopStream,
   tryToGoLive,
+  waitForSettingsWindowLoaded,
   waitForStreamStart,
 } from '../helpers/modules/streaming';
 import { logIn } from '../helpers/modules/user';
 import { saveReplayBuffer } from '../helpers/modules/replay-buffer';
-import { assertFormContains, fillForm } from '../helpers/modules/forms';
+import { fillForm } from '../helpers/modules/forms';
 import { withUser } from '../helpers/webdriver/user';
 const path = require('path');
 const fs = require('fs');
 
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
 
 test('Highlighter save and export', async t => {
@@ -45,11 +49,53 @@ test('Highlighter save and export', async t => {
   t.true(fs.existsSync(exportLocation), 'The video file should exist');
 });
 
-test.skip('AI Highlighter', withUser('twitch', { prime: true }), async t => {
-  const recordingDir = await setTemporaryRecordingPath();
-
+test('AI Highlighter', withUser('twitch', { prime: true }), async t => {
+  // AI Highlighter install button shows
   await showPage('Highlighter');
-  await clickButton('Install AI Highlighter App');
+  await waitForDisplayed('[name="installHighlighter"]');
 
+  // Go live with AI Highlighter enabled
   await prepareToGoLive();
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+
+  await fillForm({
+    title: 'Test stream',
+    twitchGame: 'Fortnite',
+  });
+
+  // Highlighter div shows
+  await waitForSettingsWindowLoaded();
+  t.true(
+    await isDisplayed('[name="install-highlighter"]'),
+    'Case 1: Highlighter card should show for supported game',
+  );
+
+  // Highlighter div hides
+  await fillForm({
+    twitchGame: 'DOOM',
+  });
+  await waitForSettingsWindowLoaded();
+  t.false(
+    await isDisplayed('[name="install-highlighter"]'),
+    'Case 2: Highlighter card should hide for not supported game',
+  );
+
+  // Highlighter div shows again
+  await fillForm({
+    twitchGame: 'Fortnite',
+  });
+  await waitForSettingsWindowLoaded();
+  t.true(
+    await isDisplayed('[name="install-highlighter"]'),
+    'Case 3: Highlighter card should show when changing from an unsupported game to a supported game',
+  );
+  await clickButton('Close');
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+  t.true(
+    await isDisplayed('[name="install-highlighter"]'),
+    'Case 5: Highlighter card should show for supported game when opening go live window',
+  );
+  await clickButton('Close');
 });

--- a/test/regular/streaming/dual-output.ts
+++ b/test/regular/streaming/dual-output.ts
@@ -1,21 +1,22 @@
 import {
   clickGoLive,
   prepareToGoLive,
+  stopStream,
   submit,
   waitForSettingsWindowLoaded,
+  waitForStreamStart,
 } from '../../helpers/modules/streaming';
 import {
   click,
   clickButton,
-  clickIfDisplayed,
   clickWhenDisplayed,
-  closeWindow,
+  dismissAlert,
   focusChild,
   focusMain,
   isDisplayed,
   waitForDisplayed,
 } from '../../helpers/modules/core';
-import { logIn } from '../../helpers/modules/user';
+import { addCustomDestination, logIn } from '../../helpers/modules/user';
 import {
   toggleDisplay,
   toggleDualOutputMode,
@@ -27,12 +28,17 @@ import {
   TExecutionContext,
   useWebdriver,
 } from '../../helpers/webdriver';
-import { addDummyAccount, logOut, releaseUserInPool, withUser } from '../../helpers/webdriver/user';
+import {
+  addDummyAccount,
+  logOut,
+  releaseUserInPool,
+  removeDummyAccount,
+  withUser,
+} from '../../helpers/webdriver/user';
 import { SceneBuilder } from '../../helpers/scene-builder';
 import { getApiClient } from '../../helpers/api-client';
-import { fillForm } from '../../helpers/modules/forms';
+import { fillForm, readFields } from '../../helpers/modules/forms';
 import { showSettingsWindow } from '../../helpers/modules/settings/settings';
-import { sleep } from '../../helpers/sleep';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -236,71 +242,130 @@ test(
 /**
  * Dual Output Go Live
  */
-
+// TODO: Add non-ultra accounts with multiple accounts linked to pool, then test cases with
+// multiple merged accounts here and move dual output instagram testing to the instagram test
 test('Dual Output Go Live Non-Ultra', async t => {
   await logIn('twitch', { prime: false });
   await toggleDualOutputMode(true);
   await prepareToGoLive();
 
-  await clickGoLive();
-  await waitForSettingsWindowLoaded();
-  await submit();
-
-  // Cannot go live in dual output mode with only one target linked
-  await waitForDisplayed('div.ant-message-notice-content', {
-    timeout: 10000,
-  });
-  await clickIfDisplayed('div.ant-message-notice-content');
-  await sleep(200);
-
-  await closeWindow('child');
   const dummy = await addDummyAccount('instagram');
 
   try {
     await clickGoLive();
-    await submit();
 
-    // Cannot go live in dual output mode with all targets assigned to one display
-    await waitForDisplayed('div.ant-message-notice-content', {
-      timeout: 5000,
-    });
-    await clickIfDisplayed('div.ant-message-notice-content');
-    await sleep(200);
-
+    await waitForSettingsWindowLoaded();
     await fillForm({
       instagram: true,
-      instagramDisplay: 'vertical',
     });
 
     await waitForSettingsWindowLoaded();
+    await submit();
+
+    // Cannot go live with more than one platform assigned to the same display
+    await dismissAlert('dual-output-info-alert', { timeout: 5000 });
 
     await fillForm({
+      instagramDisplay: 'vertical',
       title: 'Test stream',
       twitchGame: 'Fortnite',
-      streamUrl: dummy.streamUrl,
-      streamKey: dummy.streamKey,
+      instagramStreamUrl: dummy.streamUrl,
+      instagramStreamKey: dummy.streamKey,
     });
 
     await goLiveWithDualOutput('instagram');
+
+    // TODO: Comment in after adding non-ultra user accounts with multiple platforms linked to the pool
+    // Swap displays and go live again
+    // await clickGoLive();
+    // await waitForSettingsWindowLoaded();
+    // await fillForm({
+    //   instagramDisplay: 'horizontal',
+    //   twitchDisplay: 'vertical',
+    // });
+    // await goLiveWithDualOutput('instagram');
   } catch (e: unknown) {
-    console.log('Error during Dual Output Go Live Non-Ultra test:', e);
-    t.fail('Error during Dual Output Go Live Non-Ultra test');
+    console.log('Dual Output Go Live Non-Ultra error with platforms:', e);
+    t.fail('Dual Output Go Live Non-Ultra error with platforms');
   } finally {
     // Clean up the dummy account
     await showSettingsWindow('Stream', async () => {
       await waitForDisplayed('h2=Stream Destinations');
-      await clickWhenDisplayed('[data-name="instagramUnlink"]');
+      await clickWhenDisplayed('[data-name="instagramUnlink"]', { timeout: 3000 });
       await clickButton('Close');
     });
-
-    // Vertical display is hidden after logging out
-    await logOut(t);
-    t.false(await isDisplayed('div#vertical-display'));
-
-    t.pass();
   }
+
+  // Custom destination in non-ultra dual output
+  // TODO: Comment in after adding non-ultra user accounts with multiple platforms linked to the pool
+  // the test will already have an error from attempting to go live with a dummy account
+  // const { user, name } = await addCustomDestination(t);
+
+  // try {
+  //   await clickGoLive();
+  //   await waitForSettingsWindowLoaded();
+  //   await fillForm({ instagram: false });
+  //   await waitForSettingsWindowLoaded();
+
+  //   await fillForm({ [name]: true });
+  //   await waitForSettingsWindowLoaded();
+
+  //   await fillForm({
+  //     twitchDisplay: 'horizontal',
+  //     [`${name}Display`]: 'vertical',
+  //   });
+  //   await goLiveWithDualOutput('twitch');
+
+  //   // Swap displays and go live again
+  //   await clickGoLive();
+  //   await waitForSettingsWindowLoaded();
+  //   await fillForm({
+  //     twitchDisplay: 'vertical',
+  //     [`${name}Display`]: 'horizontal',
+  //   });
+  //   await goLiveWithDualOutput('twitch');
+
+  //   // Clean up custom destination
+  //   await showSettingsWindow('Stream', async () => {
+  //     await click('i.fa-trash');
+  //     await clickButton('Close');
+  //   });
+  //   await releaseUserInPool(user);
+  // } catch (e: unknown) {
+  //   console.log('Dual Output Go Live Non-Ultra error with custom destination:', e);
+  //   t.fail('Dual Output Go Live Non-Ultra error with custom destination');
+  // } finally {
+  //   await releaseUserInPool(user);
+  // }
+
+  // Vertical display is hidden after logging out
+  await logOut(t);
+  t.false(await isDisplayed('div#vertical-display'));
+
+  t.pass();
 });
 
+// TODO: Add test for dual stream with both Twitch and YouTube after adding accounts to pool
+// Currently this test will likely fail due to rate-limiting from YouTube due to the limited number of accounts
+// Note: will need to add `dualStream` ITestUserFeature to the user account(s)
+test.skip(
+  'Dual Stream Non-Ultra',
+  withUser('twitch', { prime: false, dualStream: true }),
+  async t => {
+    await toggleDualOutputMode();
+    await prepareToGoLive();
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+    await fillForm({
+      youtube: true,
+    });
+    // TODO: test Twitch both hides YouTube and satisfies dual output requirement to go live
+    // TODO: test YouTube both hides Twitch and satisfies dual output requirement to go live
+    // TODO: test that the primary chat automatically switches to the platform that is not hidden
+  },
+);
+
+// Note: This test is frequently failing due to rate-limiting from YouTube due to the limited number of accounts in the pool. It is skipped until more accounts are added to the pool.
 test(
   'Dual Output Go Live Ultra',
   withUser('twitch', { prime: true, multistream: true }),
@@ -311,27 +376,58 @@ test(
 
       await clickGoLive();
       await waitForSettingsWindowLoaded();
-      await submit();
-
-      // Cannot go live in dual output mode with all targets assigned to one display
-      await waitForDisplayed('div.ant-message-notice-content', {
-        timeout: 10000,
-      });
-      await clickIfDisplayed('div.ant-message-notice-content');
-      await sleep(500);
-
-      // Dual output with one platform for each display
       await fillForm({
+        youtube: true,
         twitchDisplay: 'vertical',
+        primaryChat: 'Twitch',
+      });
+      await goLiveWithDualOutput('twitch');
+
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        twitchDisplay: 'horizontal',
+        youtubeDisplay: 'vertical',
+        primaryChat: 'YouTube',
       });
       await goLiveWithDualOutput('twitch');
     } catch (e: unknown) {
-      console.log('Error during Dual Output Go Live Ultra test:', e);
-    } finally {
-      // Vertical display is hidden after logging out
-      await logOut(t);
-      t.false(await isDisplayed('div#vertical-display'));
+      t.fail('Error going live with platforms during Dual Output Go Live Ultra test');
+      return;
     }
+
+    // Custom destination in ultra dual output
+    const { user, name } = await addCustomDestination(t);
+
+    try {
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        youtube: false,
+        [name]: true,
+      });
+      await waitForSettingsWindowLoaded();
+      await fillForm({
+        [`${name}Display`]: 'vertical',
+      });
+
+      await goLiveWithDualOutput('twitch');
+    } catch (e: unknown) {
+      t.fail(
+        'Error going live with platform and destination during Dual Output Go Live Ultra test',
+      );
+    } finally {
+      // Clean up custom destination
+      await showSettingsWindow('Stream', async () => {
+        await click('i.fa-trash');
+        await clickButton('Close');
+      });
+      await releaseUserInPool(user);
+    }
+
+    // Vertical display is hidden after logging out
+    await logOut(t);
+    t.false(await isDisplayed('div#vertical-display'));
 
     t.pass();
   },

--- a/test/regular/streaming/go-live-window.ts
+++ b/test/regular/streaming/go-live-window.ts
@@ -1,0 +1,525 @@
+import {
+  clickGoLive,
+  prepareToGoLive,
+  submit,
+  waitForSettingsWindowLoaded,
+} from '../../helpers/modules/streaming';
+import {
+  click,
+  clickButton,
+  dismissAlert,
+  isDisplayed,
+  isTooltipDisplayed,
+  waitForDisplayed,
+} from '../../helpers/modules/core';
+import {
+  skipCheckingErrorsInLog,
+  test,
+  TExecutionContext,
+  useWebdriver,
+} from '../../helpers/webdriver';
+import {
+  addDummyAccount,
+  releaseUserInPool,
+  removeDummyAccount,
+  withUser,
+} from '../../helpers/webdriver/user';
+import { assertFormContains, fillForm } from '../../helpers/modules/forms';
+import { addCustomDestination } from '../../helpers/modules/user';
+import { showSettingsWindow } from '../../helpers/modules/settings/settings';
+
+// not a react hook
+// eslint-disable-next-line react-hooks/rules-of-hooks
+useWebdriver();
+
+/**
+ * Non-prime single platform go live behavior not covered by other cases
+ */
+test('Go Live Non-Ultra', withUser('twitch', { prime: false }), async (t: TExecutionContext) => {
+  await prepareToGoLive();
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+
+  // Case 1: Ultra banner should be visible for non-prime users
+  await isDisplayed('[name="banner-add-destination"]', {
+    timeout: 1000,
+    timeoutMsg: 'Case 1: Ultra banner should be visible for non-prime users but was not found',
+  });
+
+  // Case 2: Add destination button should be below the platform card if there is only one target
+  await isDisplayed('[name="bottom-add-destination"]', {
+    timeout: 1000,
+    timeoutMsg:
+      'Case 2: Add destination button should be below the platform card if there is only one target',
+  });
+
+  // Case 3: Stream shift should be disabled and tooltip should be visible
+  await isDisplayed('[data-name="shift-ultra-icon"]', {
+    timeout: 1000,
+    timeoutMsg: 'Case 3: Shift ultra icon should be visible for non-prime users but was not found',
+  });
+  await isTooltipDisplayed('i.icon-information', '[data-name="non-ultra"]', {
+    timeout: 1000,
+    timeoutMsg: 'Case 3: Non-Ultra stream shift tooltip did not appear',
+  });
+  await assertFormContains({ streamShift: false });
+  await clickButton('Close');
+
+  try {
+    await addDummyAccount('instagram');
+    await addDummyAccount('kick');
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+
+    await fillForm({
+      title: 'Test stream',
+      twitchGame: 'Fortnite',
+    });
+
+    // Case 4: Add destination button should be above the platform card if there are multiple targets
+    await isDisplayed('[name="top-add-destination"]', {
+      timeout: 1000,
+      timeoutMsg:
+        'Case 4: Add destination button should be above the platform card if there are multiple targets',
+    });
+
+    // Case 5: Can toggle a second platform
+    await fillForm({
+      instagram: true,
+    });
+    await waitForSettingsWindowLoaded();
+
+    // Case 6: Can set displays for both targets
+    await fillForm({ instagramDisplay: 'vertical', twitchDisplay: 'horizontal' });
+
+    // Case 7: Cannot toggle a 3rd target
+    await fillForm({
+      kick: true,
+    });
+    await dismissAlert('switcher-info-alert', {
+      timeout: 5000,
+      timeoutMsg: 'Case 7: Non-Ultra limit alert did not appear when toggling a 3rd target',
+    });
+
+    // Case 8: Dual stream disables all other targets
+    await fillForm({ twitchDisplay: 'both' });
+    await dismissAlert('both-display-info-alert', {
+      timeout: 5000,
+      timeoutMsg: 'Case 8: Dual stream info alert did not appear',
+    });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      kick: false,
+    });
+
+    // Case 9: Cannot go live with more than one target per display
+    await fillForm({ twitchDisplay: 'horizontal' });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({
+      twitch: true,
+      instagram: true,
+      kick: false,
+    });
+    await fillForm({ instagramDisplay: 'horizontal' });
+    await submit();
+    await dismissAlert('dual-output-info-alert', {
+      timeout: 5000,
+      timeoutMsg:
+        'Case 9: Non-Ultra limit alert did not appear when going live with 2 targets on the same display',
+    });
+    await fillForm({ instagramDisplay: 'vertical', twitchDisplay: 'vertical' });
+    await submit();
+    await dismissAlert('dual-output-info-alert', {
+      timeout: 5000,
+      timeoutMsg:
+        'Case 9: Non-Ultra limit alert did not appear when going live with 2 targets on the same display',
+    });
+
+    // Case 10: Can toggle off platforms
+    await fillForm({
+      instagram: false,
+    });
+
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      kick: false,
+    });
+
+    // Case 11: Last platform cannot be toggled off
+    await fillForm({
+      twitch: false,
+    });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({ twitch: true });
+  } catch (e: unknown) {
+    await clickButton('Close');
+    await removeDummyAccount('instagram');
+    await removeDummyAccount('kick');
+    console.log('Go Live Non-Ultra Error testing platforms ', e);
+    t.fail('Go Live Non-Ultra Error testing platforms');
+    return;
+  }
+
+  // Custom destinations
+  const { user, name } = await addCustomDestination(t);
+
+  // Case 12: Can only add one custom destination
+  await showSettingsWindow('Stream', async () => {
+    await isDisplayed('name="customDestUltraBtn"', {
+      timeout: 1000,
+      timeoutMsg: 'Case 12: Non-ultra users can only add one custom destination',
+    });
+  });
+
+  try {
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+
+    // Case 13: Custom destination should appear in the go live form
+    await waitForDisplayed(`div=${name}`, {
+      timeout: 3000,
+      timeoutMsg: 'Custom destination should appear in the go live form',
+    });
+
+    // Case 14: Can enable 1 platform + 1 custom destination
+    await fillForm({ [name]: true });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      [name]: true,
+    });
+
+    // Case 15: Cannot enable a 3rd target
+    await fillForm({ instagram: true });
+    await dismissAlert('switcher-info-alert', {
+      timeout: 5000,
+      timeoutMsg: 'Case 15: Non-Ultra limit alert did not appear when enabling a 3rd destination',
+    });
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      [name]: true,
+    });
+
+    // Case 16: Dual stream disables all other targets
+    await fillForm({ twitchDisplay: 'both' });
+    await dismissAlert('both-display-info-alert', {
+      timeout: 5000,
+      timeoutMsg: 'Case 16: Dual stream info alert did not appear',
+    });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      [name]: false,
+    });
+    await fillForm({ twitchDisplay: 'vertical' });
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({
+      twitch: true,
+      instagram: false,
+      [name]: true,
+    });
+
+    // Case 17: Cannot go live with more than one target per display
+    await fillForm({ [`${name}Display`]: 'horizontal', twitchDisplay: 'horizontal' });
+    await submit();
+    await dismissAlert('dual-output-info-alert', {
+      timeout: 5000,
+      timeoutMsg:
+        'Case 17: Non-Ultra limit alert did not appear when going live with 2 targets on the same display',
+    });
+    await fillForm({ [`${name}Display`]: 'vertical', twitchDisplay: 'vertical' });
+    await submit();
+    await dismissAlert('dual-output-info-alert', {
+      timeout: 5000,
+      timeoutMsg:
+        'Case 17: Non-Ultra limit alert did not appear when going live with 2 targets on the same display',
+    });
+
+    // Case 18: Toggle custom destination off
+    await fillForm({ [name]: false });
+    await waitForSettingsWindowLoaded();
+
+    // Case 19: Platform can now be toggled on
+    await fillForm({ instagram: true });
+    await waitForSettingsWindowLoaded();
+    await waitForDisplayed('div[data-name="instagram-settings"]');
+
+    // Case 20: Toggling custom destination with two active targets shows the non-ultra limit alert
+    await fillForm({ [name]: true });
+    await dismissAlert('switcher-info-alert', {
+      timeout: 5000,
+      timeoutMsg:
+        'Case 20: Non-Ultra limit alert did not appear when enabling a custom destination with 2 active targets',
+    });
+
+    await clickButton('Close');
+  } catch (e: unknown) {
+    console.log('Go Live Non-Ultra Error testing custom destinations ', e);
+    t.fail('Go Live Non-Ultra Error testing custom destinations');
+  } finally {
+    // Clean up custom destination
+    await showSettingsWindow('Stream', async () => {
+      await click('i.fa-trash');
+      await clickButton('Close');
+    });
+    await releaseUserInPool(user);
+
+    await removeDummyAccount('instagram');
+    await removeDummyAccount('kick');
+  }
+
+  t.pass();
+});
+
+test(
+  'Go Live Ultra',
+  withUser('twitch', { prime: true, multistream: false }),
+  async (t: TExecutionContext) => {
+    await prepareToGoLive();
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+
+    // Case 1: Does not show ultra banner for prime users
+    t.false(
+      await isDisplayed('[name="banner-add-destination"]'),
+      'Case 1: Ultra banner should not be visible for prime users',
+    );
+
+    // Case 2: Does not show stream shift ultra icon for prime users
+    t.false(
+      await isDisplayed('[data-name="shift-ultra-icon"]'),
+      'Case 2: Ultra icon should not be visible for prime users',
+    );
+
+    // Case 3: Add destination button should be below the platform card if there is only one target
+    await isDisplayed('[name="bottom-add-destination"]', {
+      timeout: 1000,
+      timeoutMsg:
+        'Case 3: Add destination button should be below the platform card if there is only one target',
+    });
+
+    await clickButton('Close');
+    await addDummyAccount('instagram');
+    await addDummyAccount('kick');
+
+    try {
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+
+      // Case 4: Add destination button should be above the platform card if there is only one target
+      await isDisplayed('[name="top-add-destination"]', {
+        timeout: 1000,
+        timeoutMsg:
+          'Case 4: Add destination button should be above the platform card if there is only one target',
+      });
+
+      // Case 5: Can enable more than 2 platforms
+      await fillForm({
+        instagram: true,
+        kick: true,
+      });
+      await waitForSettingsWindowLoaded();
+      await assertFormContains({
+        twitch: true,
+        instagram: true,
+        kick: true,
+      });
+      await fillForm({
+        instagram: false,
+        kick: false,
+      });
+      await waitForSettingsWindowLoaded();
+
+      // Case 6: Stream shift default explanation tooltip shows
+      await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 6: Default stream shift explanation tooltip did not appear',
+      });
+
+      // Case 7: Default tooltip stays the same when multiple platforms are enabled
+      await fillForm({ instagram: true });
+      await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 7: Default stream shift explanation tooltip did not appear',
+      });
+
+      // Case 8: Dual output tooltip
+      await fillForm({ instagramDisplay: 'vertical' });
+      await isTooltipDisplayed('i.icon-information', '[data-name="dual-output"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 8: Dual output tooltip did not appear',
+      });
+      await assertFormContains({ streamShift: false });
+      await fillForm({ instagramDisplay: 'horizontal' });
+      await fillForm({ streamShift: true });
+
+      // Case 9: Stream Shift toggle hides/shows display selectors
+      t.false(
+        await isDisplayed('[data-name="display-selector"]', {
+          timeout: 1000,
+        }),
+        'Case 9: Toggling on Stream Shift hides display selectors',
+      );
+      await fillForm({ streamShift: false });
+      await isDisplayed('[data-name="display-selector"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 9: Toggling off Stream Shift did not show display selectors',
+      });
+      await fillForm({ instagram: false });
+      await waitForSettingsWindowLoaded();
+
+      // Case 10: Toggling stream shift disables enhanced broadcasting and vice versa
+      await fillForm({ isEnhancedBroadcasting: true });
+      await assertFormContains({ streamShift: false, isEnhancedBroadcasting: true });
+      await fillForm({ streamShift: true });
+      await assertFormContains({ streamShift: true, isEnhancedBroadcasting: false });
+      await fillForm({ streamShift: false });
+      await assertFormContains({ streamShift: false, isEnhancedBroadcasting: true });
+      await fillForm({ isEnhancedBroadcasting: false });
+    } catch (e: unknown) {
+      await removeDummyAccount('instagram');
+      console.log('Go Live Ultra Error testing platforms ', e);
+      t.fail('Go Live Ultra Error testing platforms');
+      return;
+    }
+
+    // Custom destinations in Ultra mode
+    const { user, name } = await addCustomDestination(t);
+    const { name: name2 } = await addCustomDestination(t, 'MyCustomDest2', user);
+
+    try {
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+
+      // Case 11: Custom destination should appear in the go live form
+      await waitForDisplayed(`div=${name}`, {
+        timeout: 3000,
+        timeoutMsg: 'Case 11: Custom destination should appear in the go live form',
+      });
+
+      // Case 12: Ultra users can enable more than 2 destinations
+      await fillForm({ [name]: true });
+      await fillForm({ [name2]: true });
+      await waitForSettingsWindowLoaded();
+
+      // Case 13: Ultra users can enable all targets
+      await fillForm({ instagram: true, kick: true });
+      await waitForSettingsWindowLoaded();
+
+      // Case 14: Can set displays for all targets
+      await fillForm({
+        twitchDisplay: 'both',
+        instagramDisplay: 'vertical',
+        kickDisplay: 'vertical',
+        [`${name}Display`]: 'vertical',
+        [`${name2}Display`]: 'vertical',
+      });
+
+      // Case 15: Can toggle custom destination off
+      await fillForm({ [name2]: false });
+      await waitForSettingsWindowLoaded();
+      await assertFormContains({
+        twitch: true,
+        instagram: true,
+        kick: true,
+        [name]: true,
+        [name2]: false,
+      });
+
+      // Case 16: Must always have at least one platform enabled
+      await fillForm({ instagram: false, kick: false });
+      await waitForSettingsWindowLoaded();
+      await assertFormContains({
+        twitch: true,
+        instagram: false,
+        kick: false,
+        [name]: true,
+        [name2]: false,
+      });
+      await fillForm({ twitch: false });
+      await waitForSettingsWindowLoaded();
+      await assertFormContains({
+        twitch: true,
+        instagram: false,
+        kick: false,
+        [name]: true,
+        [name2]: false,
+      });
+
+      await clickButton('Close');
+    } catch (e: unknown) {
+      console.log('Go Live Ultra Error testing custom destinations ', e);
+      t.fail('Go Live Ultra Error testing custom destinations');
+    } finally {
+      // Clean up both custom destinations
+      await showSettingsWindow('Stream', async () => {
+        await click('i.fa-trash');
+        await click('i.fa-trash');
+        await clickButton('Close');
+      });
+      await releaseUserInPool(user);
+
+      await removeDummyAccount('instagram');
+      await removeDummyAccount('kick');
+    }
+
+    // Patreon stream shift tooltip
+    // Note: testing this at the end of the test because it requires adding a dummy Patreon account and toggling
+    // the account throws an error
+    try {
+      // TODO: Remove the skipCheckingErrorsInLog() call after adding test accounts
+      skipCheckingErrorsInLog();
+      await addDummyAccount('patreon');
+
+      // Case 17: Patreon tooltip shown when Patreon is enabled and stream shift toggle is disabled
+      await clickGoLive();
+      await waitForSettingsWindowLoaded();
+      await fillForm({ patreon: true });
+      await isTooltipDisplayed('i.icon-information', '[data-name="patreon"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 17: Patreon tooltip did not appear',
+      });
+      await assertFormContains({ streamShift: false });
+
+      // Case 18: Default tooltip shown when Patreon is disabled
+      await fillForm({ patreon: false });
+      await waitForSettingsWindowLoaded();
+      await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+        timeout: 1000,
+        timeoutMsg: 'Case 18: Default stream shift explanation tooltip did not appear',
+      });
+      await assertFormContains({ streamShift: false });
+
+      // Case 19: Patreon tooltip when stream shift toggle was enabled and then Patreon is enabled
+      // TODO: Uncomment after adding Patreon test accounts because the error loading Patreon account prevents
+      // the form from loading again
+      // await fillForm({ streamShift: true });
+      // await fillForm({ patreon: true });
+      // await isTooltipDisplayed('i.icon-information', '[data-name="patreon"]', {
+      //   timeout: 1000,
+      //   timeoutMsg: 'Case 19: Patreon tooltip did not appear',
+      // });
+      // await assertFormContains({ streamShift: false });
+
+      // Case 20: Toggling off Patreon shows the default tooltip again and re-enables the stream shift toggle
+      // TODO: Uncomment after adding Patreontest accounts because the error loading Patreon account prevents
+      // the form from loading again
+      // await fillForm({ patreon: false });
+      // await waitForSettingsWindowLoaded();
+      // await assertFormContains({ streamShift: true });
+
+      await clickButton('Close');
+    } catch (e: unknown) {
+      console.log('Go Live Ultra Error testing Patreon tooltip ', e);
+      t.fail('Go Live Ultra Error testing Patreon tooltip');
+    } finally {
+      await removeDummyAccount('patreon');
+    }
+  },
+);

--- a/test/regular/streaming/multistream.ts
+++ b/test/regular/streaming/multistream.ts
@@ -1,24 +1,33 @@
 import {
   chatIsVisible,
   clickGoLive,
+  fireIsLiveEvent,
+  fireStreamShiftSocketEvent,
   prepareToGoLive,
   stopStream,
   submit,
   switchAdvancedMode,
   waitForSettingsWindowLoaded,
   waitForStreamStart,
-  waitForStreamStop,
 } from '../../helpers/modules/streaming';
-import { fillForm, useForm } from '../../helpers/modules/forms';
+import { assertFormContains, fillForm, useForm } from '../../helpers/modules/forms';
 import {
   click,
   clickButton,
+  clickWhenDisplayed,
+  focusChild,
   focusMain,
   isDisplayed,
+  isTooltipDisplayed,
   waitForDisplayed,
 } from '../../helpers/modules/core';
 import { logIn } from '../../helpers/modules/user';
-import { releaseUserInPool, reserveUserFromPool, withUser } from '../../helpers/webdriver/user';
+import {
+  addDummyAccount,
+  releaseUserInPool,
+  reserveUserFromPool,
+  withUser,
+} from '../../helpers/webdriver/user';
 import { showSettingsWindow } from '../../helpers/modules/settings/settings';
 import {
   skipCheckingErrorsInLog,
@@ -47,7 +56,7 @@ async function goLiveWithMultistream() {
   // YouTube accounts fail for reasons unrelated to the tests. Check for the bypass prompt, which is
   // shown when setting up a multistream fails, including for errors from YouTube
   // Try toggling off YouTube and going live again
-  const bypassPrompted = await isDisplayed('button=Bypass and Go Live', { timeout: 2000 });
+  const bypassPrompted = await isDisplayed('button=Bypass and Go Live', { timeout: 5000 });
 
   if (bypassPrompted) {
     await clickButton('Close');
@@ -65,36 +74,80 @@ async function goLiveWithMultistream() {
   await chatIsVisible(true);
 }
 
-async function goLiveWithStreamShift(t: TExecutionContext, multistream: boolean) {
+async function goLiveWithStreamShift(
+  t: TExecutionContext,
+  testCase?: { multistream?: boolean; force?: boolean },
+) {
   await clickGoLive();
   await waitForSettingsWindowLoaded();
 
-  if (multistream) {
+  if (testCase?.multistream) {
     await enableAllPlatforms();
     await waitForSettingsWindowLoaded();
     await fillForm({
       title: 'Test stream',
-      description: 'Test stream description',
       twitchGame: 'Fortnite',
       streamShift: true,
     });
-    await goLiveWithMultistream();
+  } else if (testCase?.force) {
+    // Simulate force going live after detecting a stream on another device
+    await fireIsLiveEvent(true);
+    await focusChild();
+    await waitForDisplayed('span=Force Start', {
+      timeout: 10000,
+      timeoutMsg: 'Force Start button did not appear',
+    });
+    await clickButton('Force Start');
+    await waitForSettingsWindowLoaded();
+    await assertFormContains({ streamShift: false });
+
+    // Wait for the 3-second cooldown to expire
+    await sleep(4000);
+
+    // Now go live normally without stream shift
+    console.log('Force going live after detecting a stream on another device');
+    await submit();
+    await waitForStreamStart();
+    await stopStream();
   } else {
     await fillForm({ twitch: true });
     await waitForSettingsWindowLoaded();
     await fillForm({ title: 'Test stream', twitchGame: 'Fortnite', streamShift: true });
-    await waitForSettingsWindowLoaded();
-    await submit();
-    await waitForDisplayed('span=Configure the Multistream service', { timeout: 10000 });
-    await waitForDisplayed("h1=You're live!", { timeout: 60000 });
-    // Confirm chat loads
-    await waitForStreamStart();
-    await focusMain();
-    await chatIsVisible();
   }
 
+  await waitForSettingsWindowLoaded();
+  await submit();
+
+  // Confirm chat loads
+  await waitForStreamStart();
+  await focusMain();
+  await chatIsVisible();
+
+  // Simulate switching stream to another device
+  await fireStreamShiftSocketEvent('streamSwitchRequest', 'testRemoteStreamId');
+  await fireStreamShiftSocketEvent('switchActionComplete', 'testRemoteStreamId');
+  await focusMain();
+  await waitForDisplayed('span=Stream successfully switched', {
+    timeout: 10000,
+    timeoutMsg: 'Stream successfully switched message did not appear',
+  });
+  await clickWhenDisplayed('.ant-modal-close');
+
+  // Simulate switching to the current device
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+  await fireIsLiveEvent(true);
+  await waitForDisplayed('span=Switch to Streamlabs Desktop', {
+    timeout: 10000,
+    timeoutMsg: 'Switch to Streamlabs Desktop button did not appear',
+  });
+  await focusMain();
+  t.true(await isDisplayed('button=Claim Stream'), 'Claim Stream button should be displayed');
+  await focusChild();
+  await click('span=Switch to Streamlabs Desktop');
+
+  await waitForStreamStart();
   await stopStream();
-  await waitForStreamStop();
 }
 
 async function goLiveWithDefaultCodec() {
@@ -137,7 +190,6 @@ async function goLiveWithDefaultCodec() {
   await waitForDisplayed('span=Configure the Multistream service', { timeout: 10000 });
   await waitForDisplayed("h1=You're live!", { timeout: 60000 });
   await stopStream();
-  await waitForStreamStop();
 }
 
 test(
@@ -170,7 +222,9 @@ test(
   },
 );
 
-test(
+// The current iteration of the go live window only has one mode, so this test is skipped unless
+// the advanced mode is reactivated.
+test.skip(
   'Multistream advanced mode',
   withUser('twitch', { prime: true, multistream: true }),
   async t => {
@@ -297,11 +351,214 @@ test('Custom stream destinations', async t => {
 test('Stream Shift', withUser('twitch', { prime: true, multistream: true }), async t => {
   await prepareToGoLive();
 
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+
+  // Default tooltip
+  await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+    timeout: 1000,
+    timeoutMsg: 'Default stream shift explanation tooltip did not appear',
+  });
+
+  // Default tooltip stays the same when multiple platforms are enabled
+  await fillForm({ youtube: true });
+  await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+    timeout: 1000,
+    timeoutMsg: 'Default stream shift explanation tooltip did not appear',
+  });
+
+  // Dual output tooltip
+  await fillForm({ youtubeDisplay: 'vertical' });
+  await isTooltipDisplayed('i.icon-information', '[data-name="dual-output"]', {
+    timeout: 1000,
+    timeoutMsg: 'Dual output tooltip did not appear',
+  });
+  await assertFormContains({ streamShift: false });
+  await fillForm({ youtubeDisplay: 'horizontal' });
+  await fillForm({ streamShift: true });
+
+  // Stream Shift toggle hides/shows display selectors
+  t.false(
+    await isDisplayed('[data-name="display-selector"]', {
+      timeout: 1000,
+      timeoutMsg: 'Toggling on Stream Shift did not hide display selectors',
+    }),
+    'Toggling on Stream Shift hides display selectors',
+  );
+  await fillForm({ streamShift: false });
+  await isDisplayed('[data-name="display-selector"]', {
+    timeout: 1000,
+    timeoutMsg: 'Toggling off Stream Shift did not show display selectors',
+  });
+  await fillForm({ youtube: false });
+  await waitForSettingsWindowLoaded();
+
+  // Stream shift disables Enhanced Broadcasting
+  await fillForm({ isEnhancedBroadcasting: true });
+  await assertFormContains({ streamShift: false, isEnhancedBroadcasting: true });
+  await fillForm({ streamShift: true });
+  await assertFormContains({ streamShift: true, isEnhancedBroadcasting: false });
+  await fillForm({ streamShift: false });
+  await assertFormContains({ streamShift: false, isEnhancedBroadcasting: true });
+  await fillForm({ isEnhancedBroadcasting: false });
+  await clickButton('Close');
+
+  // Claim a stream from another device
+  // await fireIsLiveEvent(true);
+  // await waitForDisplayed('button=Claim Stream', {
+  //   timeout: 10000,
+  //   timeoutMsg: 'Claim Stream button did not appear',
+  // });
+
+  // await clickButton('Claim Stream');
+  // await focusChild();
+  // await waitForDisplayed('span=Switch to Streamlabs Desktop', {
+  //   timeout: 10000,
+  //   timeoutMsg: 'Switch to Streamlabs Desktop button did not appear',
+  // });
+
+  // await clickButton('Switch to Streamlabs Desktop');
+  // await waitForStreamStart();
+  // await stopStream();
+
+  // Single output start streaming with stream shift enabled
+  // await goLiveWithStreamShift(t);
+
+  // Force go live after detecting another stream
+  // await fireIsLiveEvent(true);
+  // TODO: Why is this not working?
+  await goLiveWithStreamShift(t, { force: true });
+  // t.true(await isDisplayed('span=Cancel'), 'Cancel button should be displayed');
+
+  return;
+
+  // Test case 7: "Cancel" button on the stream shift prompt
+  await fillForm({ title: 'Test stream', twitchGame: 'Fortnite', streamShift: true });
+  await waitForSettingsWindowLoaded();
+  await submit();
+  await waitForStreamStart();
+  await focusMain();
+  await chatIsVisible();
+  await fireIsLiveEvent(true);
+  await sleep(50000);
+
+  await focusChild();
+  await waitForDisplayed('span=Cancel', {
+    timeout: 10000,
+    timeoutMsg: 'Cancel button did not appear on stream shift prompt',
+  });
+  await clickButton('Cancel');
+  // After cancel, the go live window should close and stream shift status should be cleared
+  await focusMain();
+  t.false(
+    await isDisplayed('button=Claim Stream', { timeout: 2000 }),
+    'Claim Stream button should not be displayed after canceling stream shift prompt',
+  );
+  await stopStream();
+
+  // Test case 11: Enhanced broadcasting disabled in stream shift mode
+
+  return;
+
+  // Test case 12: "Claim Stream" button on StartStreamingButton
+  // await clickGoLive();
+  // await waitForSettingsWindowLoaded();
+  // await fillForm({ title: 'Test stream', twitchGame: 'Fortnite', streamShift: true });
+  // await waitForSettingsWindowLoaded();
+  // await submit();
+  // await waitForStreamStart();
+  // await focusMain();
+  // await fireIsLiveEvent(true);
+  // await focusMain();
+  // t.true(
+  //   await isDisplayed('button=Claim Stream', { timeout: 10000 }),
+  //   'Claim Stream button should be displayed when streamShiftStatus is pending',
+  // );
+  // await stopStream();
+
   // Single stream shift
-  await goLiveWithStreamShift(t, false);
+  await goLiveWithStreamShift(t);
+
+  // Force go live after detecting another stream
+  await goLiveWithStreamShift(t, { force: true });
 
   // Multistream shift
-  await goLiveWithStreamShift(t, true);
+  // TODO: This test will likely fail due to rate-limiting from YouTube due to the limited number of accounts
+  // Comment the below in when accounts are added
+  // await goLiveWithStreamShift(t, { multistream: true });
+
+  // Patreon tooltip shows/hides when Patreon is toggled on/off
+  // TODO: Remove the skipCheckingErrorsInLog() call after adding test accounts
+  skipCheckingErrorsInLog();
+  await addDummyAccount('patreon');
+
+  // Patreon tooltip shown when Patreon is enabled and stream shift toggle is disabled
+  await clickGoLive();
+  await waitForSettingsWindowLoaded();
+  await fillForm({ patreon: true });
+  await isTooltipDisplayed('i.icon-information', '[data-name="patreon"]', {
+    timeout: 1000,
+    timeoutMsg: 'Patreon tooltip did not appear',
+  });
+  await assertFormContains({ streamShift: false });
+
+  // Default tooltip shown when Patreon is disabled
+  await fillForm({ patreon: false });
+  await isTooltipDisplayed('i.icon-information', '[data-name="explanation"]', {
+    timeout: 1000,
+    timeoutMsg: 'Default stream shift explanation tooltip did not appear',
+  });
+  await assertFormContains({ streamShift: true });
+
+  await clickButton('Close');
+
+  // Patreon tooltip when stream shift toggle was enabled and then Patreon is enabled
+  // TODO: Uncomment after adding test accounts because the error loading Patreon account prevents
+  // the form from loading again
+  // await fillForm({ streamShift: true });
+  // await fillForm({ patreon: true });
+  // await isTooltipDisplayed('i.icon-information', '[data-name="patreon"]', {
+  //   timeout: 1000,
+  //   timeoutMsg: 'Patreon tooltip did not appear',
+  // });
+  // await assertFormContains({ streamShift: false });
+
+  // Toggling off Patreon shows the default tooltip again and re-enables the stream shift toggle
+  // TODO: Uncomment after adding test accounts because the error loading Patreon account prevents
+  // the form from loading again
+  // await fillForm({ patreon: false });
+  // await assertFormContains({ streamShift: true });
+
+  // TODO: Handle other Stream Shift UI cases
+  // 1.  Stream shift toggle hides display selectors — When streamShift: true, hideDisplaySelector becomes true
+  //     (unless Patreon), so DisplaySelector components should disappear. Commented out at lines 346-352.
+  // 2.  Stream shift toggle disabled in dual output mode — When isDualOutputMode is true, the stream shift
+  //     toggle should be disabled. Commented out at lines 340-343.
+  // 3.  Single stream go live with stream shift — goLiveWithStreamShift(t) (no multistream). Goes live with
+  //     stream shift on a single platform, simulates device switch events, tests "Switch to Streamlabs Desktop"
+  //     flow. Commented out at line 357.
+  // 4.  Multistream go live with stream shift — goLiveWithStreamShift(t, { multistream: true }). Same flow but
+  //     with multiple platforms. Commented out at line 360.
+  // 5.  Incompatible codec with stream shift — goLiveWithDefaultCodec(). Tests the "Incompatible Codec
+  //     Detected" modal when using a non-H.264 codec with restream/stream shift. Commented out at line 362.
+  // 6.  "Switch to Streamlabs Desktop" button on the prompt — The prompt has 3 buttons: "Switch to Streamlabs
+  //     Desktop" (starts stream shift go live), "Cancel" (closes window, clears pending status), and "Force Start"
+  //     (only Force Start is tested). The Switch flow calls startStreamShift() + close().
+  // 7.  "Cancel" button on the prompt — Calls clearStreamShiftPending() + close(). Not tested.
+  // 8.  streamShiftStatus triggers prompt automatically — The useEffect at line 230-234 watches
+  //     streamShiftStatus and shows the prompt when it becomes 'pending'. The force test fires
+  //     fireIsLiveEvent(true) which should trigger this, but doesn't explicitly verify the reactive trigger path
+  //     vs mount-time check.
+  // 9.  Incompatible codec on "Switch to Streamlabs Desktop" — If hasIncompatibleCodec is true when clicking
+  //     "Switch to Streamlabs Desktop", it should show the codec prompt instead of going live directly (line
+  //     197-199). Not tested.
+  // 10. Stream shift disabled when forceStreamShiftToggleEnabled is false in dual output — The
+  //     StreamShiftToggle checks isDualOutputMode && !forceStreamShiftToggleEnabled. Not tested.
+  // 11. Enhanced broadcasting disabled in stream shift mode — TwitchEditStreamInfo.tsx line 89: enhanced
+  //     broadcasting checkbox disabled when isStreamShiftMode. Not tested.
+  // 12. "Claim Stream" button on StartStreamingButton — When streamShiftStatus === 'pending', the main window
+  //     button shows "Claim Stream" instead of "Go Live". The goLiveWithStreamShift helper checks for it at line
+  //     117 but that code path is commented out.
 
   t.pass();
 });

--- a/test/regular/streaming/tiktok.ts
+++ b/test/regular/streaming/tiktok.ts
@@ -13,95 +13,110 @@ import {
   waitForStreamStart,
 } from '../../helpers/modules/streaming';
 import { addDummyAccount, withUser } from '../../helpers/webdriver/user';
-import { fillForm, readFields } from '../../helpers/modules/forms';
-import { IDummyTestUser, tikTokUsers } from '../../data/dummy-accounts';
+import { fillForm } from '../../helpers/modules/forms';
+import { IDummyTestUser } from '../../data/dummy-accounts';
 import { TTikTokLiveScopeTypes } from 'services/platforms/tiktok/api';
-import { isDisplayed, waitForDisplayed } from '../../helpers/modules/core';
+import {
+  clickTab,
+  closeWindow,
+  focusChild,
+  focusMain,
+  isDisplayed,
+  isTabActive,
+  waitForDisplayed,
+} from '../../helpers/modules/core';
 
 // not a react hook
 // eslint-disable-next-line react-hooks/rules-of-hooks
 useWebdriver();
 
-test.skip(
-  'Streaming to TikTok',
-  withUser('twitch', { multistream: false, prime: true }),
-  async t => {
-    // test approved status
-    const { tikTokLiveScope, serverUrl, streamKey } = tikTokUsers.approved;
-    await addDummyAccount('tiktok', { tikTokLiveScope, serverUrl, streamKey });
+async function switchToStreamKeyTab(scope: TTikTokLiveScopeTypes) {
+  await clickTab('Stream with TikTok Stream Key', 'tiktokStreamKey');
+  const formName = scope === 'approved' ? 'tiktokStreamForm' : 'tiktokStreamKey';
+  await waitForDisplayed(`[data-name="${formName}"]`, {
+    timeout: 3000,
+    timeoutMsg: `TikTok stream key form not shown for ${scope} scope`,
+  });
+}
 
-    await prepareToGoLive();
-    await clickGoLive();
-    await waitForSettingsWindowLoaded();
+test('Streaming to TikTok', withUser('twitch', { multistream: false, prime: true }), async t => {
+  await prepareToGoLive();
 
-    // enable tiktok
-    await fillForm({
-      twitch: true,
-      tiktok: true,
-    });
-    await waitForSettingsWindowLoaded();
-    await waitForDisplayed('div[data-name="tiktok-settings"]');
+  await testLiveScope(t, 'approved');
+  await testLiveScope(t, 'never-applied');
+  await testLiveScope(t, 'legacy');
+  await testLiveScope(t, 'denied');
 
-    const fields = await readFields();
+  // 'relog' scope throws an error, so skip checking errors in log for this test case
+  skipCheckingErrorsInLog();
+  await testLiveScope(t, 'relog');
 
-    // tiktok always shows regardless of ultra status
-    t.true(fields.hasOwnProperty('tiktok'));
-
-    // accounts approved for live access do not show the server url and stream key fields
-    t.false(fields.hasOwnProperty('serverUrl'));
-    t.false(fields.hasOwnProperty('streamKey'));
-
-    await fillForm({
-      title: 'Test stream',
-      twitchGame: 'Fortnite',
-    });
-    await submit();
-    await waitForDisplayed('span=Update settings for TikTok');
-    await waitForStreamStart();
-    await stopStream();
-
-    // test all other tiktok statuses
-    await testLiveScope(t, 'legacy');
-    await testLiveScope(t, 'denied');
-    await testLiveScope(t, 'relog');
-
-    t.pass();
-  },
-);
+  t.pass('All TikTok scope flows passed');
+});
 
 async function testLiveScope(t: TExecutionContext, scope: TTikTokLiveScopeTypes) {
-  const { serverUrl, streamKey } = tikTokUsers[scope];
-  const user: IDummyTestUser = await addDummyAccount('tiktok', {
+  const { serverUrl, streamKey }: IDummyTestUser = await addDummyAccount('tiktok', {
     tikTokLiveScope: scope,
-    serverUrl,
-    streamKey,
   });
 
   await clickGoLive();
-
-  // denied scope should show prompt to remerge TikTok account
+  // Confirm that the error noty shows in the notifications area for 'relog' scope
+  // Note: the TikTok account merge fails during window load, which can leave the confirm button disabled.
+  // Skip waiting for it to be enabled — just wait for the form, enable TikTok, and check the error.
   if (scope === 'relog') {
-    skipCheckingErrorsInLog();
+    await focusChild();
+    await waitForDisplayed('[data-name="confirmGoLiveBtn"]', { timeout: 15000 });
+    await fillForm({ tiktok: true });
+    await isDisplayed('span=Failed to update TikTok account', {
+      timeout: 3000,
+      timeoutMsg: 'TikTok remerge error not shown for relog scope',
+    });
 
-    t.true(
-      await isDisplayed('div=Failed to update TikTok account', { timeout: 3000 }),
-      'TikTok remerge error shown',
-    );
+    await closeWindow('child');
+    await focusMain();
     return;
   }
 
-  if (scope === 'denied') {
-    await waitForSettingsWindowLoaded();
-    await submit();
+  await waitForSettingsWindowLoaded();
+  await fillForm({
+    tiktok: true,
+  });
 
+  // Confirm that the apply noty shows in the notifications area for 'never-applied' and 'denied' scopes
+  if (scope === 'never-applied' || scope === 'denied') {
+    await focusMain();
+    await isDisplayed('span=You may be eligible for TikTok Live Access. Apply here.', {
+      timeout: 3000,
+      timeoutMsg: `TikTok apply noty not shown for ${scope} scope`,
+    });
+    await focusChild();
+  }
+
+  await waitForDisplayed('div[data-name="tiktok-settings"]', {
+    timeout: 3000,
+    timeoutMsg: `TikTok settings form not shown for ${scope} scope`,
+  });
+  t.true(
+    await isTabActive('Streamlabs Access', 'tiktokLiveAccess'),
+    `TikTok Live Access tab should be active by default for ${scope} scope`,
+  );
+
+  // Confirm that the live access form shows for approved scope
+  if (scope === 'approved') {
     t.true(
-      await isDisplayed(
-        "span=Couldn't confirm TikTok Live Access. Apply for Live Permissions below",
-        { timeout: 3000 },
-      ),
-      'TikTok denied error shown',
+      await isDisplayed('[data-name="tiktokAccessEnabled"]', {
+        timeout: 3000,
+        timeoutMsg: 'TikTok live access form not shown for approved scope',
+      }),
     );
 
+    await switchToStreamKeyTab(scope);
+    await clickTab('Streamlabs Access', 'tiktokLiveAccess');
+    await fillForm({
+      twitchGame: 'Fortnite',
+    });
+
+    await submit();
     await waitForDisplayed('span=Update settings for TikTok');
     await waitForStreamStart();
     await stopStream();
@@ -109,19 +124,28 @@ async function testLiveScope(t: TExecutionContext, scope: TTikTokLiveScopeTypes)
     return;
   }
 
-  // test legacy scope
-  await waitForSettingsWindowLoaded();
-  await waitForDisplayed('div[data-name="tiktok-settings"]');
+  // for all other scopes ('denied', 'legacy', 'never-applied'), the apply form should be shown
+  if (['denied', 'legacy', 'never-applied'].includes(scope)) {
+    await waitForDisplayed('[data-name="tiktokApply"]', {
+      timeout: 3000,
+      timeoutMsg: `TikTok apply form not shown for ${scope} scope`,
+    });
+    await switchToStreamKeyTab(scope);
+  }
 
+  // 'approved, 'denied', 'legacy', 'never-applied' scopes should be able to go live with stream key and server url
   const settings = {
-    serverUrl: user.serverUrl,
-    streamKey: user.streamKey,
+    serverUrl,
+    streamKey,
   };
 
   // show server url and stream key fields for all other account scopes
   await fillForm(settings);
   await submit();
-  await waitForDisplayed('span=Update settings for TikTok');
+  await waitForDisplayed('span=Update settings for TikTok', {
+    timeout: 5000,
+    timeoutMsg: `TikTok ${scope} scope failed to go live with stream key and server URL`,
+  });
   await waitForStreamStart();
   await stopStream();
 }

--- a/test/regular/streaming/twitch.ts
+++ b/test/regular/streaming/twitch.ts
@@ -162,8 +162,10 @@ test('Streaming to Twitch unlisted category', async t => {
   t.pass();
 });
 
-// This test has been skipped because of an error likely caused by Selenium and Chromium version mismatch
-test.skip(
+// TODO: confirm that this test passes in the automated test run
+// This test was previously skipped because of an error likely caused by
+// Selenium and Chromium version mismatch
+test(
   'Twitch Enhanced Broadcasting',
   withUser('twitch', { multistream: true, prime: true }),
   async t => {
@@ -192,16 +194,85 @@ test.skip(
     await stopStream();
 
     // Single Output Multistream
+    // TODO: Add more test accounts with YouTube streaming enabled to the user pool
+    // so that this test doesn't fail due to rate-limiting from YouTube
+    // await clickGoLive();
+    // await waitForSettingsWindowLoaded();
+
+    // await fillForm({
+    //   youtube: true,
+    // });
+
+    // await waitForSettingsWindowLoaded();
+    // await submit();
+    // await waitForStreamStart();
+    // await stopStream();
+    t.pass();
+  },
+);
+
+// TODO: Confirm that this passes in the automated test run
+// Like the enhanced broadcasting test, this may fail because of an error likely caused by
+// Selenium and Chromium version mismatch
+test(
+  'Twitch Dual Format (Dual Stream)',
+  withUser('twitch', { multistream: true, prime: true }),
+  async t => {
+    await prepareToGoLive();
+
+    // Single Output Single Stream
     await clickGoLive();
     await waitForSettingsWindowLoaded();
+
+    // Automatically enables/disables Enhanced Broadcasting when going live with dual stream
+    await assertFormContains({
+      isEnhancedBroadcasting: false,
+    });
+    await fillForm({
+      twitchDisplay: 'both',
+    });
 
     await waitForSettingsWindowLoaded();
     await submit();
     await waitForStreamStart();
     await stopStream();
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+    await fillForm({
+      twitchDisplay: 'vertical',
+    });
+    await assertFormContains({
+      isEnhancedBroadcasting: false,
+    });
 
-    await sleep(4000);
+    await fillForm({
+      isEnhancedBroadcasting: true,
+      twitchDisplay: 'both',
+    });
 
+    await submit();
+    await waitForStreamStart();
+    await stopStream();
+    await clickGoLive();
+    await waitForSettingsWindowLoaded();
+
+    // Also maintains the Enhanced Broadcasting setting when already enabled
+    await fillForm({
+      isEnhancedBroadcasting: true,
+    });
+
+    // Multistream
+    // TODO: Add more test accounts with YouTube streaming enabled to the user pool
+    // so that this test doesn't fail due to rate-limiting from YouTube
+    // await clickGoLive();
+    // await waitForSettingsWindowLoaded();
+    // await fillForm({
+    //   youtube: true,
+    // });
+    // await waitForSettingsWindowLoaded();
+    // await submit();
+    // await waitForStreamStart();
+    // await stopStream();
     t.pass();
   },
 );


### PR DESCRIPTION
# Go Live UI 8: Test Suite Updates

**Stack:** `master` ← 7a ← 7b ← 7c ← 7d ← 7e ← 7f ← 7g ← **8**

## Summary
- Add new `go-live-window.ts` test suite covering non-ultra and ultra go-live flows
- Update multistream, twitch, tiktok, dual-output tests for new UI selectors
- Update highlighter tests for new form/component structure
- Update streaming and form test helpers for new component names/selectors
- Update `addCustomDestination` helper to accept optional destination name and test user
- Remove stray `console.log` from `useGoLiveSettings.ts`
- Add `name` prop to custom destination Ultra button in Stream settings

## Files Changed

| File | Change |
|------|--------|
| `test/regular/streaming/go-live-window.ts` | New — non-ultra and ultra go-live window test flows |
| `test/regular/streaming/multistream.ts` | Updated selectors and flow for new UI |
| `test/regular/streaming/twitch.ts` | Updated for new form field names |
| `test/regular/streaming/tiktok.ts` | Updated for new TikTok form layout |
| `test/regular/streaming/dual-output.ts` | Updated for new dual output UI |
| `test/regular/highlighter.ts` | Updated for new highlighter form structure |
| `test/helpers/modules/streaming.ts` | Updated streaming test helpers |
| `test/helpers/modules/forms/form.ts` | Updated form helpers |
| `test/helpers/modules/user.ts` | `addCustomDestination` now accepts optional `destName` and `testUser` params |
| `app/components-react/windows/go-live/useGoLiveSettings.ts` | Removed stray `console.log` |
| `app/components-react/windows/settings/Stream.tsx` | Added `name="customDestUltraBtn"` to Ultra button for test targeting |

## Performance Implications
None. Predominantly test-only changes; the two app changes are a console.log removal and adding a `name` prop.
