### PR TITLE
[2] Multistream Toggle: Add update runtime targets functions to streaming service and flag.

### DIFF
--- a/app/services/streaming/streaming-view.ts
+++ b/app/services/streaming/streaming-view.ts
@@ -328,15 +328,8 @@ export class StreamInfoView<T extends Object> extends ViewHandler<T> {
     if (this.isStreamShiftMode) return true;
 
     // Live output editing uses the restream service
-    // TODO: Comment in when implemented
-    // if (this.isLiveOutputEditingEnabled) return true;
-
-    // TODO: Swap with the above when implemented
     if (this.isLiveOutputEditingEnabled) {
-      // This log is intentionally left in for development purposes to confirm that live output
-      // editing is being detected correctly. It will be removed when live output editing is implemented.
-      console.log('LIVE OUTPUT EDITING ENABLED');
-      return false;
+      return this.incrementalRolloutView.featureIsEnabled(EAvailableFeatures.liveOutputEditing);
     }
 
     // In dual output mode, if a display has more than one target that display uses the restream service

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -65,7 +65,7 @@ import {
 } from 'services/notifications';
 import { VideoEncodingOptimizationService } from 'services/video-encoding-optimizations';
 import { VideoSettingsService, TDisplayType } from 'services/settings-v2/video';
-import { StreamSettingsService } from '../settings/streaming';
+import { ICustomStreamDestination, StreamSettingsService } from '../settings/streaming';
 import { IStreamShiftTarget, RestreamService } from 'services/restream';
 import Utils from 'services/utils';
 import cloneDeep from 'lodash/cloneDeep';
@@ -189,6 +189,8 @@ export class StreamingService
   streamingStateChange = new Subject<void>();
 
   powerSaveId: number;
+  private isUpdatingStreamTarget: boolean = false;
+  private isUpdatingStreamSecondTarget: boolean = false;
   private numInstances: number = 0;
 
   private resolveStartStreaming: Function = () => {};
@@ -970,42 +972,278 @@ export class StreamingService
   }
 
   /**
-   * Update stream stetting while being live
+   * Update stream settings while being live
+   * @remark Handles adding/removing restream targets and updating platform settings while live   *
+   * @param settings - The go-live settings for updating the enabled platforms and destinations
+   * @param activePlatforms - Updated platforms for the stream
+   * @param activeDestinations - Updated custom destinations for the stream
+   * @returns `true` if all updates succeeded, `false` if a platform settings update failed
    */
-  async updateStreamSettings(settings: IGoLiveSettings): Promise<boolean> {
+  async updateStreamSettings(
+    settings: IGoLiveSettings,
+    activePlatforms: TPlatform[] = [],
+    activeDestinations: ICustomStreamDestination[] = [],
+  ): Promise<boolean> {
     const lifecycle = this.state.info.lifecycle;
 
     // save current settings in store so we can re-use them if something will go wrong
     this.SET_GO_LIVE_SETTINGS(settings);
 
-    // run checklist
-    this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
-
     // call putChannelInfo for each platform
     const platforms = this.views.getEnabledPlatforms(settings.platforms);
+    const updatePlatforms = this.parseUpdatePlatforms(platforms, activePlatforms);
 
-    platforms.forEach(platform => {
-      this.UPDATE_STREAM_INFO({
-        checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+    // Compare active custom destinations by URL+streamKey to uniquely identify them
+    const updateDestinations = this.parseUpdateCustomDestinations(
+      settings.customDestinations.filter(dest => dest.enabled),
+      activeDestinations,
+    );
+
+    // If there is a difference in the active platforms/destinations vs the ones in the go live window,
+    // update the restream targets
+    const shouldUpdateRestream =
+      updatePlatforms.start.length > 0 ||
+      updatePlatforms.stop.length > 0 ||
+      updateDestinations.start.length > 0 ||
+      updateDestinations.stop.length > 0;
+
+    if (this.userService.isPrime && shouldUpdateRestream) {
+      updatePlatforms.stop.forEach(platform => {
+        this.UPDATE_STREAM_INFO({
+          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        });
       });
-    });
 
-    for (const platform of platforms) {
-      const service = getPlatformService(platform);
-      const newSettings = getDefined(settings.platforms[platform]);
-      try {
-        await this.runCheck(platform, () => service.putChannelInfo(newSettings));
-      } catch (e: unknown) {
-        this.handleUpdatePlatformError(e, platform);
-        return false;
+      updatePlatforms.start.forEach(platform => {
+        this.UPDATE_STREAM_INFO({
+          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        });
+      });
+
+      updatePlatforms.continue.forEach(platform => {
+        this.UPDATE_STREAM_INFO({
+          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        });
+      });
+
+      if (shouldUpdateRestream) {
+        this.UPDATE_STREAM_INFO({
+          checklist: { ...this.state.info.checklist, ['setupMultistream']: 'not-started' },
+        });
+      }
+
+      // Run checklist
+      this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
+
+      // Remove targets from restream in a single request
+      if (updatePlatforms.stop.length > 0 || updateDestinations.stop.length > 0) {
+        await this.removeTargetsFromStream(updatePlatforms.stop, updateDestinations.stop);
+      }
+
+      // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms
+      for (const platform of updatePlatforms.start) {
+        await this.setPlatformSettings(platform, settings, false);
+      }
+
+      // Save any settings updated during the `beforeGoLive` process for the platforms.
+      // This is important for dual streaming and multistreaming.
+      this.SET_GO_LIVE_SETTINGS(this.views.savedSettings);
+
+      // Update settings for the persisted targets
+      for (const platform of updatePlatforms.continue) {
+        await this.updatePlatformSettings(platform, settings);
+      }
+
+      // Add targets to restream in a single request
+      if (updatePlatforms.start.length > 0 || updateDestinations.start.length > 0) {
+        await this.addTargetsToStream(updatePlatforms.start, updateDestinations.start);
+      }
+    } else {
+      // If not a prime user or not adding/removing targets, just update settings for enabled platforms
+      platforms.forEach(platform => {
+        this.UPDATE_STREAM_INFO({
+          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        });
+      });
+
+      // Run checklist
+      this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
+
+      // Update settings for all enabled platforms
+      for (const platform of platforms) {
+        await this.updatePlatformSettings(platform, settings);
       }
     }
 
-    // save updated settings locally
+    // Save updated settings locally
     this.streamSettingsService.setSettings({ goLiveSettings: settings });
-    // finish the 'runChecklist' step
+    // Finish the 'runChecklist' step
     this.UPDATE_STREAM_INFO({ lifecycle });
     return true;
+  }
+
+  /**
+   * Adds restream targets while live
+   * @remark Adds targets through the update window checklist
+   * @param platforms - Updated list of platforms for the stream
+   * @param destinations - Updated list of custom destinations for the stream
+   */
+  async addTargetsToStream(platforms: TPlatform[], destinations: ICustomStreamDestination[]) {
+    // Regular multistreaming via restream service
+    try {
+      await this.runCheck('setupMultistream', async () => {
+        await this.restreamService.addTargets(platforms, destinations);
+      });
+    } catch (e: unknown) {
+      const errorType = this.handleTypedStreamError(
+        e,
+        'RESTREAM_UPDATE_FAILED',
+        'Failed to add restream targets while live',
+      );
+      throwStreamError(errorType);
+    }
+  }
+
+  /**
+   * Remove restream targets while live
+   * @remark Removes targets through the update window checklist.
+   * @param platforms - Platforms to stop streaming to
+   * @param destinations - Custom destinations to stop streaming to
+   */
+  async removeTargetsFromStream(platforms: TPlatform[], destinations: ICustomStreamDestination[]) {
+    if (!this.restreamService.state.enabled) {
+      console.error('Restream service is not enabled, cannot remove targets from stream');
+      return;
+    }
+
+    try {
+      await this.restreamService.removeTargets(platforms, destinations);
+
+      // Update checklist for stopped platforms
+      for (const platform of platforms) {
+        await this.runCheck(platform, async () => {
+          // Delay for UI animation
+          await new Promise(resolve => setTimeout(resolve, 300));
+        });
+      }
+    } catch (e: unknown) {
+      const errorType = this.handleTypedStreamError(
+        e,
+        'RESTREAM_UPDATE_FAILED',
+        'Failed to remove restream targets while live',
+      );
+
+      throwStreamError(errorType);
+    }
+  }
+
+  /**
+   * Categorize platforms
+   *
+   * @remark Categorizes platforms for mid-stream updates:
+   * - `continue` — enabled and already active (update settings only)
+   * - `start` — add to restream targets
+   * - `stop` — remove from restream targets
+   * @param enabledPlatforms - Platforms enabled in the Update window
+   * @param activePlatforms - Platforms currently streaming
+   * @returns Platforms grouped `continue`, `stop`, and `start`
+   */
+  parseUpdatePlatforms(
+    enabledPlatforms: TPlatform[],
+    activePlatforms: TPlatform[],
+  ): {
+    continue: TPlatform[];
+    stop: TPlatform[];
+    start: TPlatform[];
+  } {
+    const active = new Set(activePlatforms);
+    const enabled = new Set(enabledPlatforms);
+
+    const platforms = enabledPlatforms.reduce(
+      (acc, platform) => {
+        if (active.has(platform)) {
+          acc.continue.push(platform);
+        } else {
+          acc.start.push(platform);
+        }
+        return acc;
+      },
+      {
+        continue: [] as TPlatform[],
+        stop: [] as TPlatform[],
+        start: [] as TPlatform[],
+      },
+    );
+
+    platforms.stop = activePlatforms.reduce((acc, platform) => {
+      if (!enabled.has(platform)) {
+        acc.push(platform);
+      }
+      return acc;
+    }, [] as TPlatform[]);
+
+    return platforms;
+  }
+
+  /**
+   * Diff enabled custom destinations against currently active custom destinations
+   *
+   * @remark Uses `url + streamKey` as a composite key to uniquely identify destinations.
+   * Categorizes into the same three buckets as {@link parseUpdatePlatforms}.
+   *
+   * @param enabledDestinations - Custom destinations enabled in the Go Live window
+   * @param activeDestinations - Custom destinations currently streaming
+   * @returns Destinations grouped by action: `continue`, `stop`, and `start`
+   */
+  parseUpdateCustomDestinations(
+    enabledDestinations: ICustomStreamDestination[],
+    activeDestinations: ICustomStreamDestination[],
+  ) {
+    const active = new Set(activeDestinations.map(dest => `${dest.url}${dest.streamKey}`));
+    const enabled = new Set(enabledDestinations.map(dest => `${dest.url}${dest.streamKey}`));
+
+    const destinations = enabledDestinations.reduce(
+      (acc, dest) => {
+        const url = `${dest.url}${dest.streamKey}`;
+        if (active.has(url)) {
+          acc.continue.push(dest);
+        } else {
+          acc.start.push(dest);
+        }
+        return acc;
+      },
+      {
+        continue: [] as ICustomStreamDestination[],
+        stop: [] as ICustomStreamDestination[],
+        start: [] as ICustomStreamDestination[],
+      },
+    );
+
+    destinations.stop = activeDestinations.reduce((acc, dest) => {
+      const url = `${dest.url}${dest.streamKey}`;
+      if (!enabled.has(url)) {
+        acc.push(dest);
+      }
+      return acc;
+    }, [] as ICustomStreamDestination[]);
+
+    return destinations;
+  }
+
+  /**
+   * Update channel info for a single platform via `putChannelInfo`
+   * @param platform - The platform to update
+   * @param settings - The update window settings
+   */
+  async updatePlatformSettings(platform: TPlatform, settings: IGoLiveSettings): Promise<boolean> {
+    const service = getPlatformService(platform);
+    const newSettings = getDefined(settings.platforms[platform]);
+    try {
+      await this.runCheck(platform, () => service.putChannelInfo(newSettings));
+    } catch (e: unknown) {
+      this.handleUpdatePlatformError(e, platform);
+      return false;
+    }
   }
 
   handleUpdatePlatformError(e: unknown, platform: TPlatform) {
@@ -2726,6 +2964,9 @@ export class StreamingService
       // Do nothing on the `starting` signal except for updating the streaming status to `starting` for the UI,
       // which happens below
     } else if (info.signal === EOBSOutputSignal.Stopping) {
+      // Ignore stopping signals when updating stream targets mid-stream
+      if (this.isUpdatingStreamTarget || this.isUpdatingStreamSecondTarget) return;
+
       const isEnhancedBroadcastDualOutputStopping =
         this.views.isDualOutputMode &&
         this.state.enhancedBroadcasting &&
@@ -2748,6 +2989,14 @@ export class StreamingService
       // Error handling with a stop signal is handled in the `signalHandler`
     } else if (info.signal === EOBSOutputSignal.Deactivate) {
       // The `deactivate` signal is sent after the `stop` signal
+
+      // Reset mid-stream update flags
+      if (this.isUpdatingStreamTarget && context === 'horizontal') {
+        this.isUpdatingStreamTarget = false;
+      }
+      if (this.isUpdatingStreamSecondTarget && context === 'vertical') {
+        this.isUpdatingStreamSecondTarget = false;
+      }
 
       // Handle stopping recording and replay buffer started by AI Highlighter.
       // handleStopStreaming already stops these for the normal recordWhenStreaming/

--- a/app/services/streaming/streaming.ts
+++ b/app/services/streaming/streaming.ts
@@ -989,89 +989,112 @@ export class StreamingService
     // save current settings in store so we can re-use them if something will go wrong
     this.SET_GO_LIVE_SETTINGS(settings);
 
-    // call putChannelInfo for each platform
-    const platforms = this.views.getEnabledPlatforms(settings.platforms);
-    const updatePlatforms = this.parseUpdatePlatforms(platforms, activePlatforms);
+    if (this.views.isLiveOutputEditingEnabled) {
+      // call putChannelInfo for each platform
+      const platforms = this.views.getEnabledPlatforms(settings.platforms);
+      const updatePlatforms = this.parseUpdatePlatforms(platforms, activePlatforms);
 
-    // Compare active custom destinations by URL+streamKey to uniquely identify them
-    const updateDestinations = this.parseUpdateCustomDestinations(
-      settings.customDestinations.filter(dest => dest.enabled),
-      activeDestinations,
-    );
+      // Compare active custom destinations by URL+streamKey to uniquely identify them
+      const updateDestinations = this.parseUpdateCustomDestinations(
+        settings.customDestinations.filter(dest => dest.enabled),
+        activeDestinations,
+      );
 
-    // If there is a difference in the active platforms/destinations vs the ones in the go live window,
-    // update the restream targets
-    const shouldUpdateRestream =
-      updatePlatforms.start.length > 0 ||
-      updatePlatforms.stop.length > 0 ||
-      updateDestinations.start.length > 0 ||
-      updateDestinations.stop.length > 0;
+      // If there is a difference in the active platforms/destinations vs the ones in the go live window,
+      // update the restream targets
+      const shouldUpdateRestream =
+        updatePlatforms.start.length > 0 ||
+        updatePlatforms.stop.length > 0 ||
+        updateDestinations.start.length > 0 ||
+        updateDestinations.stop.length > 0;
 
-    if (this.userService.isPrime && shouldUpdateRestream) {
-      updatePlatforms.stop.forEach(platform => {
-        this.UPDATE_STREAM_INFO({
-          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+      if (this.userService.isPrime && shouldUpdateRestream) {
+        updatePlatforms.stop.forEach(platform => {
+          this.UPDATE_STREAM_INFO({
+            checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+          });
         });
-      });
 
-      updatePlatforms.start.forEach(platform => {
-        this.UPDATE_STREAM_INFO({
-          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        updatePlatforms.start.forEach(platform => {
+          this.UPDATE_STREAM_INFO({
+            checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+          });
         });
-      });
 
-      updatePlatforms.continue.forEach(platform => {
-        this.UPDATE_STREAM_INFO({
-          checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+        updatePlatforms.continue.forEach(platform => {
+          this.UPDATE_STREAM_INFO({
+            checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+          });
         });
-      });
 
-      if (shouldUpdateRestream) {
-        this.UPDATE_STREAM_INFO({
-          checklist: { ...this.state.info.checklist, ['setupMultistream']: 'not-started' },
+        if (shouldUpdateRestream) {
+          this.UPDATE_STREAM_INFO({
+            checklist: { ...this.state.info.checklist, ['setupMultistream']: 'not-started' },
+          });
+        }
+
+        // Run checklist
+        this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
+
+        // Remove targets from restream in a single request
+        if (updatePlatforms.stop.length > 0 || updateDestinations.stop.length > 0) {
+          await this.removeTargetsFromStream(updatePlatforms.stop, updateDestinations.stop);
+        }
+
+        // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms
+        for (const platform of updatePlatforms.start) {
+          await this.setPlatformSettings(platform, settings, false);
+        }
+
+        // Save any settings updated during the `beforeGoLive` process for the platforms.
+        // This is important for dual streaming and multistreaming.
+        this.SET_GO_LIVE_SETTINGS(this.views.savedSettings);
+
+        // Update settings for the persisted targets
+        for (const platform of updatePlatforms.continue) {
+          await this.updatePlatformSettings(platform, settings);
+        }
+
+        // Add targets to restream in a single request
+        if (updatePlatforms.start.length > 0 || updateDestinations.start.length > 0) {
+          await this.addTargetsToStream(updatePlatforms.start, updateDestinations.start);
+        }
+      } else {
+        // If not a prime user or not adding/removing targets, just update settings for enabled platforms
+        platforms.forEach(platform => {
+          this.UPDATE_STREAM_INFO({
+            checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
+          });
         });
-      }
 
-      // Run checklist
-      this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
+        // Run checklist
+        this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
 
-      // Remove targets from restream in a single request
-      if (updatePlatforms.stop.length > 0 || updateDestinations.stop.length > 0) {
-        await this.removeTargetsFromStream(updatePlatforms.stop, updateDestinations.stop);
-      }
-
-      // Update checklist for added platforms and run `beforeGoLive` to set up the new platforms
-      for (const platform of updatePlatforms.start) {
-        await this.setPlatformSettings(platform, settings, false);
-      }
-
-      // Save any settings updated during the `beforeGoLive` process for the platforms.
-      // This is important for dual streaming and multistreaming.
-      this.SET_GO_LIVE_SETTINGS(this.views.savedSettings);
-
-      // Update settings for the persisted targets
-      for (const platform of updatePlatforms.continue) {
-        await this.updatePlatformSettings(platform, settings);
-      }
-
-      // Add targets to restream in a single request
-      if (updatePlatforms.start.length > 0 || updateDestinations.start.length > 0) {
-        await this.addTargetsToStream(updatePlatforms.start, updateDestinations.start);
+        // Update settings for all enabled platforms
+        for (const platform of platforms) {
+          await this.updatePlatformSettings(platform, settings);
+        }
       }
     } else {
-      // If not a prime user or not adding/removing targets, just update settings for enabled platforms
+      this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
+
+      const platforms = this.views.getEnabledPlatforms(settings.platforms);
+
       platforms.forEach(platform => {
         this.UPDATE_STREAM_INFO({
           checklist: { ...this.state.info.checklist, [platform]: 'not-started' },
         });
       });
 
-      // Run checklist
-      this.UPDATE_STREAM_INFO({ lifecycle: 'runChecklist' });
-
-      // Update settings for all enabled platforms
       for (const platform of platforms) {
-        await this.updatePlatformSettings(platform, settings);
+        const service = getPlatformService(platform);
+        const newSettings = getDefined(settings.platforms[platform]);
+        try {
+          await this.runCheck(platform, () => service.putChannelInfo(newSettings));
+        } catch (e: unknown) {
+          this.handleUpdatePlatformError(e, platform);
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
# Add Mid-Stream Target Management to Streaming Service

**Stack:** `master` ← 1 ← **2** ← 3 ← 4 ← 5

## Summary
Refactored the `updateStreamSettings` method to update runtime targets in addition to updating channel info for already-active platforms. Also added helpers.

## Changes

### Streaming Service (`app/services/streaming/streaming.ts`)

**Expanded `updateStreamSettings`** to accept `activePlatforms` and `activeDestinations` params
1. Removes dropped targets via `removeTargetsFromStream`
2. Runs `beforeGoLive` for newly added platforms via `setPlatformSettings`
3. Updates settings for persisting platforms via `updatePlatformSettings`
4. Adds new targets via `addTargetsToStream`

**New methods:**
- `addTargetsToStream` — delegates to `RestreamService.addTargets` through the `setupMultistream` checklist step
- `removeTargetsFromStream` — delegates to `RestreamService.removeTargets` with checklist updates per removed platform
- `parseUpdatePlatforms` — diffs enabled vs active platforms into `continue`/`stop`/`start` buckets
- `parseUpdateCustomDestinations` — same for custom destinations, using `url + streamKey` as composite key
- `updatePlatformSettings` — extracted single-platform `putChannelInfo` call with error handling

**Signal handling:**
- Added `isUpdatingStreamTarget` / `isUpdatingStreamSecondTarget` flags to suppress `Stopping` signals during mid-stream target removal
- Reset flags on `Deactivate` signal per context

### Streaming View (`app/services/streaming/streaming-view.ts`)

- Replaced the live output editing stub (`console.log` + `return false`) with the actual flag

**Files changed:**
- `app/services/streaming/streaming.ts`
- `app/services/streaming/streaming-view.ts`

## Performance Implications
None. New methods are only invoked during explicit user-initiated mid-stream target changes. The `parseUpdate*` methods are O(n) set-based diffs with negligible overhead.
