### PR TITLE
Fix toggling platforms for grandfathered users in the go live window.

### DIFF
--- a/app/components-react/windows/go-live/DestinationSwitchers.tsx
+++ b/app/components-react/windows/go-live/DestinationSwitchers.tsx
@@ -39,6 +39,8 @@ export const DestinationSwitchers = memo(() => {
     nonPrimeBothDisplayPlatform,
     getUsername,
     isLoading,
+    isFacebookGrandfathered,
+    isTikTokGrandfathered,
   } = useGoLiveSettings().extend(module => ({
     get renderedPlatforms() {
       // Some platforms are always shown, even if not linked so add them to the list of platforms to display
@@ -98,19 +100,46 @@ export const DestinationSwitchers = memo(() => {
       emitSwitch();
       return enabledPlatformsRef.current.includes(platform);
     },
-    [emitSwitch],
+    [emitSwitch, isPrime],
   );
 
   const toggleNonUltraPlatform = useCallback(
     (platform: TPlatform, enabled: boolean) => {
+      // TikTok and Facebook users can always go live with those platforms
+      let maxPlatforms = 2;
+
+      // Expand the maximum allowed platforms for TikTok and Facebook grandfathered users.
+      if (
+        enabled &&
+        isFacebookGrandfathered &&
+        (platform === 'facebook' || enabledPlatformsRef.current.includes('facebook'))
+      ) {
+        maxPlatforms++;
+      }
+
+      if (
+        enabled &&
+        isTikTokGrandfathered &&
+        (platform === 'tiktok' || enabledPlatformsRef.current.includes('tiktok'))
+      ) {
+        maxPlatforms++;
+      }
+
       if (enabled) {
         const total = enabledPlatformsRef.current.length + enabledDestRef.current.length;
-        if (total >= 2) {
+        if (total >= maxPlatforms) {
+          const text =
+            maxPlatforms > 2
+              ? $t(
+                  "You've reached the maximum number of streaming destinations. Upgrade to Ultra to enable multistreaming.",
+                )
+              : $t(
+                  "You've reached the maximum of 2 streaming destinations. Upgrade to Ultra to enable multistreaming.",
+                );
+
           alertInfo({
             name: 'switcher-info-alert',
-            text: $t(
-              "You've reached the maximum of 2 streaming destinations. Upgrade to Ultra to enable multistreaming.",
-            ),
+            text,
           });
           return false;
         }
@@ -127,7 +156,7 @@ export const DestinationSwitchers = memo(() => {
 
       return enabledPlatformsRef.current.includes(platform);
     },
-    [enabledPlatformsRef, emitSwitch],
+    [enabledPlatformsRef, emitSwitch, isFacebookGrandfathered, isTikTokGrandfathered],
   );
 
   const toggleDestination = useCallback(

--- a/app/components-react/windows/go-live/useGoLiveSettings.ts
+++ b/app/components-react/windows/go-live/useGoLiveSettings.ts
@@ -661,6 +661,14 @@ export class GoLiveSettingsModule {
     return Services.RestreamService.views.canEnableRestream;
   }
 
+  get isFacebookGrandfathered() {
+    return Services.RestreamService.views.isFacebookGrandfathered;
+  }
+
+  get isTikTokGrandfathered() {
+    return Services.RestreamService.views.isTikTokGrandfathered;
+  }
+
   get recommendedColorSpaceWarnings() {
     return Services.SettingsService.views.recommendedColorSpaceWarnings;
   }

--- a/app/i18n/en-US/streaming.json
+++ b/app/i18n/en-US/streaming.json
@@ -376,5 +376,6 @@
   "Select a different display for %{platform} to toggle on another destination, or upgrade to Ultra to enable multistreaming.": "Select a different display for %{platform} to toggle on another destination, or upgrade to Ultra to enable multistreaming.",
   "You've reached the maximum of 2 streaming destinations. Upgrade to Ultra to enable multistreaming.": "You've reached the maximum of 2 streaming destinations. Upgrade to Ultra to enable multistreaming.",
   "Automatic (Recommended)": "Automatic (Recommended)",
-  "Preferred Multistream Ingest Server": "Preferred Multistream Ingest Server"
+  "Preferred Multistream Ingest Server": "Preferred Multistream Ingest Server",
+  "You've reached the maximum number of streaming destinations. Upgrade to Ultra to enable multistreaming.": "You've reached the maximum number of streaming destinations. Upgrade to Ultra to enable multistreaming."
 }

--- a/app/services/restream.ts
+++ b/app/services/restream.ts
@@ -965,6 +965,17 @@ class RestreamView extends ViewHandler<IRestreamState> {
   get isGrandfathered() {
     return this.state.grandfathered || this.state.tiktokGrandfathered;
   }
+
+  // includes both multistream and Facebook grandfathered statuses
+  get isFacebookGrandfathered() {
+    return this.state.grandfathered;
+  }
+
+  // includes only the TikTok grandfathered status
+  get isTikTokGrandfathered() {
+    return this.state.tiktokGrandfathered;
+  }
+
   /**
    * This determines whether the user can enable restream
    * Requirements:


### PR DESCRIPTION
# Fix toggling platforms for grandfathered users in the Go Live window

## Summary

Non-Ultra users are normally capped at 2 streaming destinations in the Go Live window. However, some legacy ("grandfathered") users are entitled to stream to Facebook and/or TikTok _in addition to_ the standard 2 destinations. Previously the destination toggle logic applied a hard limit of 2 regardless of grandfathered status, so these users were blocked from enabling a platform they should have access to.

This PR raises the maximum allowed destinations for grandfathered users when Facebook and/or TikTok is involved, and updates the "limit reached" messaging to match.

## Changes

- **`app/services/restream.ts`** — Add two `RestreamView` getters, `isFacebookGrandfathered` (`grandfathered`) and `isTikTokGrandfathered` (`tiktokGrandfathered`), exposing each grandfathered status independently rather than only the combined `isGrandfathered`.
- **`app/components-react/windows/go-live/useGoLiveSettings.ts`** — Surface the two new getters through `GoLiveSettingsModule` so the UI can consume them.
- **`app/components-react/windows/go-live/DestinationSwitchers.tsx`** — In `toggleNonUltraPlatform`, compute `maxPlatforms` dynamically: start at 2 and add one slot for Facebook and/or TikTok when the user is grandfathered for that platform and that platform is being enabled (or is already enabled). Show a generic "maximum number of streaming destinations" message when the limit is above 2, and keep the existing "maximum of 2" message otherwise. Also added `isPrime` to the `togglePlatform` dependency array.
- **`app/i18n/en-US/streaming.json`** — Add the new generic limit-reached string.

## Testing
- Manually verify in the Go Live window that:
  - a standard non-Ultra user is still capped at 2 destinations;
  - a Facebook-grandfathered user can always enable Facebook + 2 other destinations + any other grandfathered platform
  - a TikTok-grandfathered user can always enable TikTok + 2 other destinations + any other grandfathered platform
