### PR TITLE
Kill stale ChromeDriver process

### DIFF
--- a/test/helpers/api-client.ts
+++ b/test/helpers/api-client.ts
@@ -212,7 +212,7 @@ export class ApiClient {
     socket.on('data', (data: Buffer) => {
       chunks.push(data);
       if (data.toString().includes('\x0a')) {
-        socket.destroy();
+        socket.end();
         result = Buffer.concat(chunks as Uint8Array[]);
         done = true;
       }

--- a/test/helpers/webdriver/index.ts
+++ b/test/helpers/webdriver/index.ts
@@ -11,6 +11,7 @@ import fetch from 'node-fetch';
 
 import {
   ITestStats,
+  killChromedriverOnPort,
   killElectronInstances,
   removeFailedTestFromFile,
   saveFailedTestsToFile,
@@ -239,6 +240,7 @@ export function useWebdriver(options: ITestRunnerOptions = {}) {
     if (options.networkLogging) appArgs.push('--network-logging');
     if (options.noSync) appArgs.push('--nosync');
 
+    killChromedriverOnPort(CHROMEDRIVER_PORT);
     await killElectronInstances();
 
     app = t.context.app = new Application({

--- a/test/helpers/webdriver/runner-utils.ts
+++ b/test/helpers/webdriver/runner-utils.ts
@@ -183,6 +183,40 @@ export async function killElectronInstances() {
   tasks.forEach((task: any) => kill(task.pid));
 }
 
+export function killChromedriverOnPort(port: number) {
+  const { execSync } = require('child_process');
+
+  const p = Number(port);
+  if (!Number.isInteger(p) || p <= 0 || p > 65535) return;
+
+  try {
+    if (process.platform === 'win32') {
+      const output = execSync(`netstat -ano -p tcp | findstr LISTENING | findstr :${p}`).toString();
+      const pids = new Set<number>();
+      output.split('\n').forEach((line: string) => {
+        const parts = line.trim().split(/\s+/);
+        // Proto LocalAddress ForeignAddress State PID
+        if (parts.length >= 5 && parts[1].endsWith(`:${p}`) && parts[3] === 'LISTENING') {
+          const pid = parseInt(parts[4], 10);
+          if (Number.isFinite(pid)) pids.add(pid);
+        }
+      });
+      pids.forEach(pid => kill(pid));
+    } else {
+      const output = execSync(`lsof -nP -iTCP:${p} -sTCP:LISTEN -t`).toString().trim();
+      if (output) {
+        output
+          .split('\n')
+          .map((pidStr: string) => parseInt(pidStr, 10))
+          .filter((pid: number) => Number.isFinite(pid))
+          .forEach((pid: number) => kill(pid));
+      }
+    }
+  } catch (e: unknown) {
+    // Nothing is found
+  }
+}
+
 export async function waitForElectronInstancesExist() {
   const interval = 1000;
   const timeout = 10000;


### PR DESCRIPTION
### Issue 1
Fix for issue I encountered when I tried to run a test which failed because a stale chromedriver process blocked the port.

Error spew:
```
  Rejected promise returned by test. Reason:

  Error {
    message: `Failed to create session.␊
    socket hang up`,
  }

  › socket hang up
  › startWebDriverSession (node_modules/webdriver/build/utils.js:73:15)
  › Function.newSession (node_modules/webdriver/build/index.js:46:45)
  › remote (node_modules/webdriverio/build/index.js:77:22)
```
Verified fix by:
Start a fake stale chromedriver in the background: 
`./node_modules/electron-chromedriver/bin/chromedriver --port=4444 &`

On Mac, I run this command to verify the port is occupied:
`lsof -ti :4444`
On Windows:
`netstat -ano | findstr :4444`

Run the test:
`yarn test:file test-dist/test/regular/api/scene-collections.js`

It will now terminate the process that owns the port allowing a new ChromeDriver instance to start listening on the port

### Issue 2
`api-client.js` [MacOS code path] - `use socket.end()` to fix test failure
for `test/regular/api/scene-collections.ts` that I saw on MacOS.

Error spew:
```
  [2026-07-28T21:36:31.135Z] [error] [worker] - Uncaught Error: read ECONNRESET Error: read ECONNRESET
  [2026-07-28T21:36:31.135Z] [error] [worker] -     at __node_internal_captureLargerStackTrace (node:internal/errors:497:5)
  [2026-07-28T21:36:31.135Z] [error] [worker] -     at __node_internal_errnoException (node:internal/errors:624:12)
  [2026-07-28T21:36:31.135Z] [error] [worker] -     at TCP.onStreamRead (node:internal/stream_base_commons:217:20) {
  [2026-07-28T21:36:31.135Z] [error] [worker] -   errno: -54,
  [2026-07-28T21:36:31.135Z] [error] [worker] -   code: 'ECONNRESET',
  [2026-07-28T21:36:31.135Z] [error] [worker] -   syscall: 'read'
  [2026-07-28T21:36:31.135Z] [error] [worker] - }
```

socket.destroy() → socket.end(). end() causes the server to close cleanly rather than seeing a hard reset. Eliminates the error that was logged.

Now running this test will complete with no error:
`yarn test:file test-dist/test/regular/api/scene-collections.js`